### PR TITLE
feat: auth redirect with returnTo URL

### DIFF
--- a/client/src/app/sign-in/SignInAuthGate.tsx
+++ b/client/src/app/sign-in/SignInAuthGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useContext, useEffect } from "react";
 
 import { SignIn } from "@/app/sign-in/SignIn";
@@ -25,6 +25,7 @@ export const SignInAuthGate = () => {
   // other hooks
   // ------------------------------------------------------------
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // side effects
   // ------------------------------------------------------------
@@ -35,9 +36,14 @@ export const SignInAuthGate = () => {
 
   useEffect(() => {
     if (isAuthenticated) {
-      router.push(`/volunteers/${shiftboardId}/account`);
+      const returnTo = searchParams?.get("returnTo");
+      if (returnTo && returnTo.startsWith("/")) {
+        router.push(returnTo);
+      } else {
+        router.push(`/volunteers/${shiftboardId}/account`);
+      }
     }
-  }, [isAuthenticated, router, shiftboardId]);
+  }, [isAuthenticated, router, searchParams, shiftboardId]);
 
   // render
   // ------------------------------------------------------------

--- a/client/src/components/general/AuthGate.tsx
+++ b/client/src/components/general/AuthGate.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useContext } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useContext, useEffect } from "react";
 
 import { Loading } from "@/components/general/Loading";
 import {
@@ -34,6 +35,11 @@ export const AuthGate = ({ accountTypeToCheck, children }: IAuthGateProps) => {
     },
   } = useContext(SessionContext);
 
+  // other hooks
+  // ------------------------------------------------------------
+  const pathname = usePathname();
+  const router = useRouter();
+
   // logic
   // ------------------------------------------------------------
   let isAuthorized = false;
@@ -50,6 +56,19 @@ export const AuthGate = ({ accountTypeToCheck, children }: IAuthGateProps) => {
       break;
     default:
   }
+
+  // redirect unauthenticated users to sign-in with a return URL
+  // ------------------------------------------------------------
+  useEffect(() => {
+    if (!isAuthorized) {
+      if (pathname) {
+        const returnTo = encodeURIComponent(pathname);
+        router.replace(`/sign-in?returnTo=${returnTo}`);
+      } else {
+        router.replace("/sign-in");
+      }
+    }
+  }, [isAuthorized, pathname, router]);
 
   // render
   // ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **AuthGate** now redirects unauthenticated users to `/sign-in?returnTo=<path>` instead of showing an infinite loading spinner
- **SignInAuthGate** reads the `returnTo` query param after login and redirects back to the originally requested page
- Falls back to the default account page when no `returnTo` param is present
- `returnTo` is validated to start with `/` to prevent open redirect attacks

## Test plan
- [ ] Visit a protected page while logged out → should redirect to `/sign-in?returnTo=<that-page>`
- [ ] Log in → should redirect back to the originally requested page
- [ ] Log in without `returnTo` param → should redirect to account page (existing behavior)
- [ ] Verify `returnTo` with external URL (e.g., `?returnTo=https://evil.com`) is rejected
- [ ] E2E tests to be added after test suite PR #261 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)