### PR TITLE
chore: untrack client/.env.production and broaden env gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,10 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# local env files
-.env*.local
-
-# generated deploy password
-/.env
+# env files (never commit secrets)
+.env
+.env.*
+!.env.example
 
 # vercel
 .vercel

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,5 +1,0 @@
-# database
-MYSQL_DATABASE = "census"
-MYSQL_HOST = "database"
-MYSQL_PASSWORD = "placeholder"
-MYSQL_USER = "root"


### PR DESCRIPTION
## Summary
- `client/.env.production` was tracked in git with placeholder DB values. Per project convention `.env` files should never be in source control. Untracks the file (stays on disk, contents unchanged).
- Replaces the narrow `.env*.local` + `/.env` rules with `.env` / `.env.*` so any current or future env file is excluded by default. Adds `!.env.example` so committed templates are still allowed.

Motivated by upcoming Okta OAuth work — we needed to drop real client secrets into env files and wanted to make sure the file is ignored before any of that lands.

## Test plan
- [x] `git check-ignore -v client/.env.production` → matches `.env.*`
- [x] `git check-ignore -v client/.env.local` → still ignored (matches `.env.*`)
- [x] `git check-ignore -v .env` → still ignored (matches `.env`)
- [x] File still on disk after `git rm --cached`
- [ ] Verify CI still passes (no test runs depend on `.env.production` being in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)