### PR TITLE
docs: add VIP page and training confirmation endpoint specs

### DIFF
--- a/specs/design-vip.md
+++ b/specs/design-vip.md
@@ -1,0 +1,730 @@
+# Volunteer Info Page (VIP) Spec
+
+**Status:** Draft
+**Date:** 2026-04-16
+
+---
+
+## Overview
+
+A new self-service page in CensusScheduler where volunteers can view their SAP (Setup
+Access Pass) eligibility, shift requirements, training status, and update their arrival
+preferences.
+
+This document covers:
+
+1. **Schema changes** — new table, altered tables, seed data
+2. **SAP eligibility rules** — Census Shift Points (CSP) and day-by-day requirements
+3. **VIP page layout** — section-by-section spec with exact UI copy
+4. **Existing page changes** — CSP display on shifts pages, training multi-select
+5. **API routes** — new Next.js Pages Router endpoints
+6. **Implementation order**
+
+**Scope:** Only `op_*` tables.
+
+---
+
+## Database Changes
+
+### New Table: `op_saps`
+
+Stores issued SAP PDF files. Once `shiftboard_id` is set, the volunteer sees a download
+link on their VIP.
+
+```sql
+CREATE TABLE op_saps (
+    sap_id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    filename        VARCHAR(256) NOT NULL,
+    shiftboard_id   BIGINT NULL,
+    date_id         BIGINT NOT NULL,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    KEY idx_sap_volunteer (shiftboard_id),
+    KEY idx_sap_date (date_id),
+    FOREIGN KEY (shiftboard_id) REFERENCES op_volunteers(shiftboard_id),
+    FOREIGN KEY (date_id)       REFERENCES op_dates(date_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `sap_id` | BIGINT AUTO_INCREMENT | PK (let MySQL assign -- do not use `generateId()`) |
+| `filename` | VARCHAR(256) | Hashed filename of the SAP PDF |
+| `shiftboard_id` | BIGINT FK NULL | Volunteer this SAP is assigned to. NULL = unassigned. |
+| `date_id` | BIGINT FK | The playa arrival date this SAP is valid for |
+| `created_at` | TIMESTAMP | Auto-set on insert |
+| `updated_at` | TIMESTAMP | Auto-set on update |
+
+**File storage:** Configurable directory via env var `SAP_FILES_DIR`
+(e.g., `/data/census/saps/`). The `filename` column stores just the hashed filename;
+the API constructs the full path at serve-time.
+
+**How SAPs get into this table:** PDFs are provided by the org, split into individual
+pages, given hashed filenames, and inserted into this table. That ingestion process is
+outside the scope of this document.
+
+**No soft-delete flags:** Unlike most op_* tables, `op_saps` does not have audit/soft-delete
+columns. SAP records are either present (assigned or unassigned) or hard-deleted.
+
+### Alter Table: `op_volunteers`
+
+```sql
+ALTER TABLE op_volunteers
+    ADD COLUMN arrival_date_id BIGINT NULL,
+    ADD KEY idx_vol_arrival (arrival_date_id),
+    ADD FOREIGN KEY (arrival_date_id) REFERENCES op_dates(date_id);
+```
+
+The volunteer picks their expected arrival date on the VIP.
+
+### Alter Table: `op_roles`
+
+```sql
+ALTER TABLE op_roles
+    ADD COLUMN census_shift_points INT NULL DEFAULT NULL
+        COMMENT 'Minimum Census Shift Points required for this role. NULL = no threshold.';
+```
+
+### Alter Table: `op_trainings` (optional)
+
+`op_trainings` already has `training_name`, `role_id`, `code`, and `url`. If you want
+to show explanatory text on the VIP, add:
+
+```sql
+ALTER TABLE op_trainings
+    ADD COLUMN description TEXT NULL;
+```
+
+Skip this if `training_name` + `url` are sufficient for display.
+
+### Seed Data: New Roles
+
+```sql
+INSERT INTO op_roles (role, census_shift_points, display) VALUES
+    ('Staff',                NULL, 1),
+    ('OtherSAP',             NULL, 1),
+    ('CounterCultureCamp',   10,   1),
+    ('CensusLabCamp',        16,   1),
+    ('BurnerProfileUpdated', NULL, 1),
+    ('CensusTicket',         10,   1);
+```
+
+| Role                 | CSP | Purpose                                             |
+|----------------------|----:|-----------------------------------------------------|
+| Staff                |   — | Bypass all SAP requirements                         |
+| OtherSAP             |   — | Has SAP from another group; bypass SAP requirements |
+| CounterCultureCamp   |  10 | Camping with Census (Counter Culture camp)          |
+| CensusLabCamp        |  16 | Census Lab camp                                     |
+| BurnerProfileUpdated |   — | Self-service: volunteer confirmed profile is current|
+| CensusTicket         |  10 | Receiving a ticket through Census                   |
+
+### Relationship to Existing Schema
+
+```
+op_saps.shiftboard_id ──FK──> op_volunteers.shiftboard_id
+op_saps.date_id ──FK──> op_dates.date_id
+op_volunteers.arrival_date_id ──FK──> op_dates.date_id
+op_roles.census_shift_points  (new column, nullable)
+```
+
+---
+
+## SAP Eligibility Rules
+
+All eligibility logic reads from `op_*` tables only.
+
+### Bypass Conditions
+
+A volunteer is **exempt** from SAP requirements if **any** of these are true:
+
+| Condition | How to check | What to show |
+|-----------|-------------|-------------|
+| SAP already issued | `op_saps` row exists with their `shiftboard_id` | Download link + gate message (State 1) |
+| Staff | Has `Staff` role in `op_volunteer_roles` | Staff message (State 2) |
+| OtherSAP | Has `OtherSAP` role in `op_volunteer_roles` | Other-SAP message (State 3) |
+| Post-opening arrival | `arrival_date_id` → datename is after `OpenSun` | "No SAP needed" (State 4) |
+
+Check in the order listed — first match wins.
+
+### Point Requirement
+
+Volunteers must sign up for shifts worth **at least 12 CSP** total.
+
+CSP per position comes from `op_shift_time_position.sap_points` for positions the
+volunteer is signed up for (via `op_volunteer_shifts`). Only count positions where
+`sap_points >= 1`.
+
+### Day-by-Day Shift Requirement
+
+Based on the volunteer's arrival date (`op_volunteers.arrival_date_id` → `op_dates.datename`),
+they need **at least one shift worth ≥1 CSP** on each required day:
+
+| Arrive on | Required shift days |
+|-----------|---------------------|
+| PreSun    | PreMon, PreTue, PreWed, PreThur, **one of** PreFri / PreSat / OpenSun |
+| PreMon    | PreTue, PreWed, PreThur, **one of** PreFri / PreSat / OpenSun |
+| PreTue    | PreWed, PreThur, **one of** PreFri / PreSat / OpenSun |
+| PreWed    | PreThur, PreFri, **one of** PreSat / OpenSun |
+| PreThur   | PreFri, **one of** PreSat / OpenSun |
+| PreFri    | **one of** PreSat / OpenSun |
+| PreSat    | OpenSun |
+
+PreSun is the earliest arrival date in the dropdown. The `op_dates` entries
+EarlyThur, EarlyFri, and EarlyMan are equivalent to PreSun for SAP purposes.
+
+**"One of" logic:** The final group in each row is a single checklist item satisfied if
+the volunteer has a qualifying shift on **any** of the listed days.
+
+### Role-Based Point Thresholds
+
+Each role with `census_shift_points IS NOT NULL` adds an **additional requirement**. The
+volunteer's total CSP must meet or exceed that role's threshold.
+
+The highest threshold subsumes the lower ones — a volunteer with `CensusLabCamp` (16)
+who also needs a base SAP (12) just needs 16 total.
+
+---
+
+## VIP Page Layout
+
+New page at `/volunteers/{shiftboardId}/info`.
+
+<!-- TODO: Confirm this URL fits the existing routing pattern. Alternatives:
+/volunteer-info, /vip/{id}. -->
+
+Text in `{curly braces}` is filled at render time.
+
+### Section 1: Welcome Header
+
+Volunteer's playa name and world name. Link to update Burner Profile.
+
+<!-- TODO: Decide exactly which fields to show. Playa name, world name, email, address?
+Which of these come from op_volunteers vs other sources? -->
+
+### Section 2: On-Playa Information
+
+Three controls, auto-saving on change:
+
+| Control | Type | Saves to | Hidden when |
+|---------|------|----------|-------------|
+| Desired/Expected Arrival Date | `<Select>` from `op_dates` | `op_volunteers.arrival_date_id` | SAP already issued |
+| SAP from another group? | `<Select>` Yes / No | Toggles `OtherSAP` role | SAP already issued |
+| Where will you be camping? | `<TextField>` multiline | `op_volunteers.location` | Never |
+
+### Section 3: SAP Status
+
+First matching state wins:
+
+---
+
+**State 1 — SAP Already Issued** (`op_saps` row exists for this volunteer)
+
+Hide the arrival date and OtherSAP controls. Show:
+
+> Here is your SAP for **{datename}** ({date}). Please download and print it out before
+> reaching the gate. Everyone in your car must have one.
+>
+> [Download SAP PDF]
+
+---
+
+**State 2 — Staff** (has `Staff` role)
+
+> You have been marked as staff. We know you will work your butt off regardless of how
+> much you sign up for.
+
+---
+
+**State 3 — OtherSAP** (has `OtherSAP` role)
+
+> You have indicated you are receiving a SAP from another group. You can disregard the
+> SAP qualifications below.
+
+---
+
+**State 4 — Post-opening arrival** (arrival datename after OpenSun)
+
+> You have told us you are arriving after opening and do not need a SAP.
+
+---
+
+**State 5 — Normal** (needs SAP)
+
+> **Qualifications for Setup Access Pass (SAP) — arriving {datename} ({date}):**
+>
+> - [x] Sign up for at least 12 Census Shift Points — *12 / 12 CSP*
+> - [x] Shift on PreMon (≥1 CSP) — *Requirement Fulfilled*
+> - [ ] Shift on PreTue (≥1 CSP) — *Still needed*
+> - [x] Shift on PreWed (≥1 CSP) — *Requirement Fulfilled*
+> - [x] Shift on PreThur (≥1 CSP) — *Requirement Fulfilled*
+> - [x] Shift on PreFri, PreSat, or OpenSun (≥1 CSP) — *Requirement Fulfilled*
+
+Use green checkmark / red X matching existing CensusScheduler style.
+
+The list of required days is dynamic based on arrival date (see SAP Eligibility Rules).
+
+### Section 4: Role-Based Requirements
+
+For each role the volunteer has where `census_shift_points IS NOT NULL`:
+
+> **{Role Name}**
+> Sign up for at least {N} CSP — *{X} / {N} CSP* | *Requirement Fulfilled*
+
+### Section 5: Training Requirements
+
+Derived from volunteer's shift positions: `op_volunteer_shifts` →
+`op_shift_time_position` → `op_position_trainings` → `op_trainings`.
+
+For each required training:
+
+> - [x] **{training_name}** — [View materials]({url}) — *Completed*
+> - [ ] **{training_name}** — [View materials]({url}) — *Not yet completed*
+
+Training completion is determined by whether the volunteer has the training's `role_id`
+in `op_volunteer_roles` (same mechanism as the training confirmation endpoint).
+
+<!-- TODO: How does behavioral standards fit? Options:
+(a) Create an op_trainings entry for behavioral standards
+(b) Check for a specific role
+(c) Other mechanism
+-->
+
+### Section 6: Burner Profile Confirmation
+
+Self-service checkbox. Toggles the `BurnerProfileUpdated` role.
+
+> [ ] I have updated my [Burner Profile](https://profiles.burningman.org/participate/my-profile/)
+
+Checked → add role. Already set → show as checked.
+
+### Section 7: Shift List
+
+Table of the volunteer's shifts for the current year:
+
+| Day | Date | Time | Position | CSP |
+|-----|------|------|----------|-----|
+
+If total CSP is under 12, show at the bottom:
+
+> **Total CSP: {X}** / 12 required for SAP
+
+---
+
+## Changes to Existing Pages
+
+### Terminology
+
+Rename **"SAP Points"** → **"CSP"** (Census Shift Points) in all display text.
+
+The database column `op_shift_time_position.sap_points` does NOT need to change.
+
+### Shifts List Page
+
+**File:** `client/src/app/shifts/Shifts.tsx`
+
+**New column — CSP:** Show the range of CSP across the shift's positions. Examples:
+"2–4" (range) or "3" (all positions equal). Computed from MIN/MAX of
+`op_shift_time_position.sap_points` for that `shift_times_id`.
+
+**New filter — "After my arrival date":** Toggle that hides shifts before the
+signed-in volunteer's `arrival_date_id`. Default: off (show all).
+
+<!-- TODO: The signed-in volunteer's arrival_date_id needs to be accessible here.
+Either include it in the shifts API response, fetch it separately, or add it to
+SessionContext. Check what volunteer data is already in session state. -->
+
+### Shift Detail / Volunteers Page
+
+**File:** `client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx`
+
+In the **Positions table**, add CSP in bold to each row name:
+
+```
+Name                         | Filled / Total
+Random Sampler — 3 CSP       | 4 / 6
+Lab Host — 2 CSP             | 2 / 4
+```
+
+Value from `op_shift_time_position.sap_points`.
+
+### Shift Position Form — Training Multi-Select
+
+**File:** `client/src/app/shifts/positions/ShiftPositionsForm.tsx`
+
+New field:
+
+- **Label:** "Required Trainings"
+- **Type:** MUI `Autocomplete` with `multiple`
+- **Options:** All rows from `op_trainings` (display `training_name`)
+- **Saves to:** `op_position_trainings` junction table
+
+**API changes:**
+- `GET /api/shifts/positions/defaults` — include `trainings: IResTrainingItem[]`
+- `GET /api/shifts/positions/[positionId]` — include `trainingIds: number[]`
+- `PATCH /api/shifts/positions/[positionId]` — accept `trainingIds: number[]`,
+  sync `op_position_trainings` (delete removed, insert added)
+
+---
+
+## API Endpoints
+
+All routes follow existing CensusScheduler pattern: `pool.query()` with `?` placeholders,
+switch on `req.method`, snake_case DB → camelCase response.
+
+### `GET /api/volunteers/[id]/info` — VIP data
+
+Returns all data needed for the VIP page:
+
+```typescript
+interface IResVolunteerInfo {
+  volunteer: {
+    shiftboardId: number;
+    playaName: string;
+    worldName: string;
+    location: string;
+  };
+  arrivalDate: {
+    dateId: number;
+    datename: string;
+    date: string;           // ISO date
+  } | null;
+  sapStatus: {
+    bypass: boolean;
+    bypassReason: "sap_issued" | "staff" | "other_sap" | "post_opening" | null;
+    bypassMessage: string | null;
+    sapFile: {
+      sapId: number;
+      filename: string;
+      datename: string;
+      date: string;
+    } | null;
+    totalCsp: number;
+    requiredCsp: number;    // always 12
+    cspFulfilled: boolean;
+    requiredDays: {
+      datenames: string[];  // e.g., ["PreFri","PreSat","OpenSun"]
+      label: string;        // e.g., "PreFri, PreSat, or OpenSun"
+      fulfilled: boolean;
+    }[];
+  };
+  roleThresholds: {
+    role: string;
+    requiredCsp: number;
+    fulfilled: boolean;
+  }[];
+  trainings: {
+    trainingId: number;
+    trainingName: string;
+    url: string;
+    description: string | null;
+    completed: boolean;     // has the training's role_id in op_volunteer_roles
+  }[];
+  roles: string[];          // all role names this volunteer has
+  dates: {                  // for arrival date dropdown
+    dateId: number;
+    datename: string;
+    date: string;
+  }[];
+  shifts: {
+    datename: string;
+    date: string;
+    time: string;
+    position: string;
+    csp: number;
+  }[];
+}
+```
+
+**Query flow:**
+
+1. Fetch volunteer: `SELECT * FROM op_volunteers WHERE shiftboard_id = ? AND delete_volunteer = false`
+2. Fetch arrival date: `SELECT * FROM op_dates WHERE date_id = ?` (if `arrival_date_id` set)
+3. Check for SAP file:
+   ```sql
+   SELECT s.sap_id, s.filename, d.datename, d.date
+   FROM op_saps s
+   JOIN op_dates d ON s.date_id = d.date_id
+   WHERE s.shiftboard_id = ?
+   ORDER BY s.created_at DESC LIMIT 1
+   ```
+4. Fetch volunteer roles:
+   ```sql
+   SELECT r.role, r.census_shift_points
+   FROM op_volunteer_roles vr
+   JOIN op_roles r ON vr.role_id = r.role_id
+   WHERE vr.shiftboard_id = ? AND vr.remove_role = false
+   ```
+5. Calculate total CSP:
+   ```sql
+   SELECT COALESCE(SUM(stp.sap_points), 0) AS total_csp
+   FROM op_volunteer_shifts vs
+   JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+   WHERE vs.shiftboard_id = ?
+     AND vs.remove_shift = false
+     AND stp.remove_time_position = false
+   ```
+6. CSP per day:
+   ```sql
+   SELECT d.datename, COALESCE(SUM(stp.sap_points), 0) AS day_csp
+   FROM op_volunteer_shifts vs
+   JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+   JOIN op_shift_times st ON stp.shift_times_id = st.shift_times_id
+   JOIN op_dates d ON st.start_date_id = d.date_id
+   WHERE vs.shiftboard_id = ?
+     AND vs.remove_shift = false
+     AND stp.remove_time_position = false
+     AND st.remove_shift_time = false
+   GROUP BY d.datename
+   ```
+7. Required trainings:
+   ```sql
+   SELECT DISTINCT t.training_id, t.training_name, t.url, t.description
+   FROM op_volunteer_shifts vs
+   JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+   JOIN op_position_trainings pt ON stp.position_type_id = pt.position_type_id
+   JOIN op_trainings t ON pt.training_id = t.training_id
+   WHERE vs.shiftboard_id = ?
+     AND vs.remove_shift = false
+     AND stp.remove_time_position = false
+     AND pt.delete_position_training = false
+     AND t.delete_training = false
+   ```
+8. Volunteer shifts:
+   ```sql
+   SELECT d.datename, d.date, st.start_time, st.end_time,
+          pt.position, stp.sap_points
+   FROM op_volunteer_shifts vs
+   JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+   JOIN op_shift_times st ON stp.shift_times_id = st.shift_times_id
+   JOIN op_dates d ON st.start_date_id = d.date_id
+   JOIN op_position_type pt ON stp.position_type_id = pt.position_type_id
+   WHERE vs.shiftboard_id = ?
+     AND vs.remove_shift = false
+     AND stp.remove_time_position = false
+     AND st.remove_shift_time = false
+     AND pt.delete_position = false
+   ORDER BY d.date, st.start_time
+   ```
+9. All dates (for dropdown):
+   ```sql
+   SELECT date_id, datename, date FROM op_dates ORDER BY date
+   ```
+10. Compute SAP status from the results of steps 2–6 (see SAP Eligibility Rules).
+
+### `PATCH /api/volunteers/[id]/info` — Update arrival date and/or location
+
+```typescript
+// Request body (all fields optional)
+interface IReqVolunteerInfoUpdate {
+  arrivalDateId?: number | null;
+  location?: string;
+}
+```
+
+**arrivalDateId:**
+```sql
+UPDATE op_volunteers
+SET arrival_date_id = ?, update_volunteer = true
+WHERE shiftboard_id = ?
+```
+
+**location:**
+```sql
+UPDATE op_volunteers
+SET location = ?, update_volunteer = true
+WHERE shiftboard_id = ?
+```
+
+Returns the refreshed `sapStatus` block (re-run steps 2–6 from the GET endpoint) so the
+UI can update the checklist without a full page reload.
+
+### `POST /api/volunteers/[id]/info/other-sap` — Toggle OtherSAP role
+
+```typescript
+// Request body
+interface IReqToggleOtherSap {
+  hasOtherSap: boolean;
+}
+```
+
+`true` → add `OtherSAP` role (SELECT-then-INSERT/UPDATE pattern, same as
+`/api/confirm/[code]` POST). `false` → soft-remove (`remove_role = true`).
+
+Returns refreshed `sapStatus`.
+
+### `POST /api/volunteers/[id]/info/profile-updated` — Toggle BurnerProfileUpdated
+
+```typescript
+// Request body
+interface IReqToggleProfileUpdated {
+  updated: boolean;
+}
+```
+
+Same SELECT-then-INSERT/UPDATE pattern.
+
+### `GET /api/volunteers/[id]/sap/[sapId]` — Download SAP PDF
+
+Stream the file from `SAP_FILES_DIR + filename`. Verify `op_saps.shiftboard_id` matches
+the path parameter `id` (or requester is admin).
+
+Return with headers:
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="sap-{datename}.pdf"
+```
+
+---
+
+## Gotchas & Implementation Notes
+
+1. **Do NOT use `generateId()`** for `sap_id`. Use `AUTO_INCREMENT` and omit the ID from
+   INSERT statements.
+
+2. **Soft-delete filters**: All queries against op_* tables must respect soft-delete flags.
+   Missing any of these will return deleted/removed data.
+   - `op_volunteer_shifts`: `remove_shift = false`
+   - `op_volunteer_roles`: `remove_role = false`
+   - `op_shift_time_position`: `remove_time_position = false`
+   - `op_shift_times`: `remove_shift_time = false`
+   - `op_position_type`: `delete_position = false`
+   - `op_position_trainings`: `delete_position_training = false`
+   - `op_trainings`: `delete_training = false`
+   - `op_volunteers`: `delete_volunteer = false`
+
+3. **Role toggle pattern**: Use SELECT-then-branch (check if row exists, then INSERT or
+   UPDATE). This matches the existing pattern in `/pages/api/roles/[roleId]/volunteers/`.
+   Do NOT use `ON DUPLICATE KEY UPDATE`.
+
+4. **Auth is client-side only**: `shiftboardId` comes from `SessionContext` on the client.
+   The `[id]` path parameter is the volunteer ID. Verify the signed-in user matches `[id]`
+   (or is admin) to prevent a volunteer from viewing/modifying another volunteer's VIP.
+
+5. **Day-by-day "one of" group**: The last requirement in each arrival-date row is a group
+   (e.g., `["PreFri", "PreSat", "OpenSun"]`). The API returns this as
+   `{ datenames: [...], label: "PreFri, PreSat, or OpenSun", fulfilled: boolean }`.
+   Fulfilled = any datename in the group has ≥1 CSP.
+
+6. **CSP column on shifts list**: The shifts API already returns position data. The CSP
+   range can be computed server-side (MIN/MAX sap_points per shift_times_id) or
+   client-side from existing data. Pick whichever is simpler.
+
+7. **Arrival date dropdown options**: Query all dates from `op_dates` sorted by `date`.
+   The UI should only offer dates from PreSun through OpenSun (filter out dates outside
+   this range, or flag which dates are valid arrival options).
+
+8. **Route file placement**: API routes go in `client/src/pages/api/` (Pages Router).
+   Frontend page goes in `client/src/app/` (App Router). This matches the existing split.
+
+9. **Schema location**: Add the `CREATE TABLE op_saps` statement and `ALTER TABLE`
+   statements to `database/scheduler_schema.sql`. The `op_saps` table must come after
+   `op_volunteers` and `op_dates` due to FK dependencies.
+
+10. **On-playa SQL dumps**: `update_server.sh` dumps all `op_*` tables. Since `op_saps`
+    follows the prefix convention, it will be included automatically.
+
+11. **Audit flags on UPDATE**: When updating `op_volunteers` columns, also set
+    `update_volunteer = true`. This matches the convention for other op_* tables where
+    `update_*` flags indicate the record was modified.
+
+12. **Navigation to VIP**: Add a link to the VIP from the volunteer's account page
+    (e.g., `/volunteers/{id}/account`). Also consider adding it to the main nav for
+    authenticated volunteers.
+
+---
+
+## Files to Create/Modify
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `client/src/pages/api/volunteers/[id]/info/index.ts` | VIP data GET + PATCH |
+| Create | `client/src/pages/api/volunteers/[id]/info/other-sap/index.ts` | Toggle OtherSAP role |
+| Create | `client/src/pages/api/volunteers/[id]/info/profile-updated/index.ts` | Toggle BurnerProfileUpdated |
+| Create | `client/src/pages/api/volunteers/[id]/sap/[sapId]/index.ts` | SAP PDF download |
+| Create | `client/src/app/volunteers/[id]/info/page.tsx` | VIP page entry |
+| Create | `client/src/app/volunteers/[id]/info/VolunteerInfo.tsx` | VIP main component |
+| Create | `client/src/components/types/volunteer-info.ts` | TypeScript interfaces |
+| Modify | `client/src/app/shifts/Shifts.tsx` | Add CSP column + arrival date filter |
+| Modify | `client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx` | Bold CSP in positions table |
+| Modify | `client/src/app/shifts/positions/ShiftPositionsForm.tsx` | Training multi-select |
+| Modify | `client/src/pages/api/shifts/positions/defaults/index.ts` | Include trainings list |
+| Modify | `client/src/pages/api/shifts/positions/[positionId]/index.ts` | Include/save training associations |
+| Modify | `database/scheduler_schema.sql` | Add `op_saps`, alter `op_volunteers`, alter `op_roles` |
+
+---
+
+## Implementation Order
+
+### Phase 1: Schema & Seed Data
+1. Add `census_shift_points` column to `op_roles`
+2. Add `arrival_date_id` column to `op_volunteers`
+3. Create `op_saps` table
+4. Insert 6 new roles
+5. (Optional) Add `description` column to `op_trainings`
+6. Update `database/scheduler_schema.sql`
+
+### Phase 2: API Routes
+1. `GET /api/volunteers/[id]/info` — VIP data
+2. `PATCH /api/volunteers/[id]/info` — update arrival date + location
+3. `POST /api/volunteers/[id]/info/other-sap` — toggle OtherSAP
+4. `POST /api/volunteers/[id]/info/profile-updated` — toggle BurnerProfileUpdated
+5. `GET /api/volunteers/[id]/sap/[sapId]` — SAP file download
+6. Modify shifts/positions API for training associations
+
+### Phase 3: VIP Page
+1. Create page component and route
+2. Welcome header
+3. On-playa info (arrival date + OtherSAP + location)
+4. SAP status display (all 5 states)
+5. SAP eligibility checklist (points + day-by-day)
+6. Role-based CSP threshold display
+7. Training requirements display
+8. Burner Profile confirmation checkbox
+9. Shift list table with CSP column
+
+### Phase 4: Existing Page Updates
+1. Rename "SAP Points" → "CSP" throughout
+2. CSP column on shifts list (`Shifts.tsx`)
+3. "After my arrival date" filter on shifts list
+4. Bold CSP in positions table (`ShiftVolunteers.tsx`)
+5. Training multi-select on position form (`ShiftPositionsForm.tsx`)
+
+---
+
+## Testing Checklist
+
+- [ ] VIP page loads for authenticated volunteer
+- [ ] VIP page blocks access for wrong volunteer (can't view other's VIP)
+- [ ] Arrival date dropdown populated from `op_dates`
+- [ ] Changing arrival date updates SAP checklist without full reload
+- [ ] OtherSAP toggle adds/removes role correctly
+- [ ] OtherSAP toggle hides/shows SAP checklist
+- [ ] Staff volunteer sees staff bypass message
+- [ ] SAP-issued volunteer sees download link, arrival/OtherSAP hidden
+- [ ] SAP PDF downloads correctly
+- [ ] Post-opening arrival shows "no SAP needed"
+- [ ] Day-by-day checklist matches the rules for each arrival date
+- [ ] "One of" group shows fulfilled if any day in group is covered
+- [ ] CSP total correctly sums from volunteer's shift positions
+- [ ] Role-based thresholds display for CounterCultureCamp, CensusLabCamp, CensusTicket
+- [ ] Training requirements derived from volunteer's shift positions
+- [ ] BurnerProfileUpdated checkbox toggles role
+- [ ] Shift list shows correct CSP per shift
+- [ ] CSP column appears on shifts list page
+- [ ] CSP range shows min–max correctly
+- [ ] "After my arrival date" filter hides earlier shifts
+- [ ] Bold CSP shows in positions table on shift detail
+- [ ] Training multi-select on position form saves to `op_position_trainings`
+- [ ] Soft-deleted roles, positions, trainings are excluded from all queries
+
+---
+
+## Resolved Questions
+
+1. **EarlyThur / EarlyFri / EarlyMan** (`op_dates` entries) — Equivalent to PreSun
+   for SAP purposes. PreSun is the earliest arrival date in the dropdown.
+2. **SAP file format** — PDFs from the org, split, hashed. Ingestion out of scope.
+3. **Camping location** — Already `op_volunteers.location`. Use directly.
+4. **Scope** — Only `op_*` tables.
+5. **App** — VIP is built in CensusScheduler (Next.js).

--- a/specs/training-confirmation-endpoint.md
+++ b/specs/training-confirmation-endpoint.md
@@ -1,0 +1,498 @@
+# Training Confirmation Endpoint Spec
+
+## Overview
+
+A new endpoint `/api/confirm/[code]` allows volunteers to confirm training completion via a unique link. The flow:
+1. Volunteer visits `/confirm/{code}` in the app (must be signed in)
+2. Page shows training details and a "Confirm" button
+3. On confirm, the training's completion role is assigned to the volunteer
+4. Page displays a thank-you message and lists available shifts requiring that training
+
+---
+
+## Database Changes
+
+### New Table: `op_trainings`
+
+Defines available trainings and their confirmation codes.
+
+```sql
+DROP TABLE IF EXISTS `op_trainings`;
+CREATE TABLE `op_trainings` (
+  `training_id` bigint NOT NULL AUTO_INCREMENT,
+  `training_name` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `role_id` bigint DEFAULT NULL,
+  `code` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `url` varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `create_training` tinyint(1) DEFAULT '0',
+  `update_training` tinyint(1) DEFAULT '0',
+  `delete_training` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`training_id`),
+  UNIQUE KEY `training_name` (`training_name`),
+  UNIQUE KEY `code` (`code`),
+  KEY `fk_training_role` (`role_id`),
+  CONSTRAINT `fk_training_role` FOREIGN KEY (`role_id`) REFERENCES `op_roles` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+```
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `training_id` | BIGINT AUTO_INCREMENT | PK (let MySQL assign -- do not use `generateId()`) |
+| `training_name` | VARCHAR(128) UNIQUE | Display name (e.g., "Gate Training") |
+| `role_id` | BIGINT FK | The role granted on completion (FK to `op_roles`) |
+| `code` | VARCHAR(64) UNIQUE | URL-safe confirmation code (see Code Format below) |
+| `url` | VARCHAR(512) | Link to the training course material |
+| `create_training` | tinyint(1) | Audit: record was created |
+| `update_training` | tinyint(1) | Audit: record was modified |
+| `delete_training` | tinyint(1) | Audit: soft delete flag |
+
+### New Table: `op_position_trainings`
+
+Links positions to required trainings. A position may require multiple trainings.
+
+```sql
+DROP TABLE IF EXISTS `op_position_trainings`;
+CREATE TABLE `op_position_trainings` (
+  `position_training_id` bigint NOT NULL AUTO_INCREMENT,
+  `position_type_id` bigint DEFAULT NULL,
+  `training_id` bigint DEFAULT NULL,
+  `create_position_training` tinyint(1) DEFAULT '0',
+  `update_position_training` tinyint(1) DEFAULT '0',
+  `delete_position_training` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`position_training_id`),
+  UNIQUE KEY `uk_position_training` (`position_type_id`,`training_id`),
+  KEY `fk_pt_training` (`training_id`),
+  CONSTRAINT `fk_pt_position` FOREIGN KEY (`position_type_id`) REFERENCES `op_position_type` (`position_type_id`),
+  CONSTRAINT `fk_pt_training` FOREIGN KEY (`training_id`) REFERENCES `op_trainings` (`training_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+```
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `position_training_id` | BIGINT AUTO_INCREMENT | PK (let MySQL assign) |
+| `position_type_id` | BIGINT FK | Which position requires this training |
+| `training_id` | BIGINT FK | Which training is required |
+| `create/update/delete_position_training` | tinyint(1) | Audit flags |
+
+### Code Format
+
+The `code` column must be URL-safe and not guessable. Use format: `{type}-{year}-{16-char-random}`.
+
+Example: `gate-2026-a1b2c3d4e5f6g7h8`
+
+Generate the random portion with: `crypto.randomBytes(12).toString('base64url').slice(0, 16)`
+
+This gives ~96 bits of entropy -- brute-force infeasible even without rate limiting.
+
+### Relationship to Existing Schema
+
+```
+op_trainings.role_id ──FK──> op_roles.role_id
+op_position_trainings.position_type_id ──FK──> op_position_type.position_type_id
+op_position_trainings.training_id ──FK──> op_trainings.training_id
+```
+
+### Interaction with `op_position_type.prerequisite_id`
+
+The existing `op_position_type.prerequisite_id` (FK to `op_shift_category`) represents "experience in a shift category" as a prerequisite. The new `op_position_trainings` table represents "formal training completion" prerequisites.
+
+**These are independent systems.** A position can have:
+- A `prerequisite_id` only (experience-based)
+- `op_position_trainings` entries only (training-based)
+- Both (volunteer must satisfy all)
+- Neither
+
+The shift volunteer add dialog (`ShiftVolunteersDialogAdd.tsx`) currently checks `prerequisiteId` and `roleRequiredId`. When `op_position_trainings` is implemented, this dialog should also check whether the volunteer holds the training role(s). This is a **follow-up change** -- the confirmation endpoint works independently of the dialog filtering.
+
+---
+
+## API Endpoints
+
+### `GET /api/confirm/[code]` -- Read-only lookup
+
+Returns training info, whether the volunteer has already confirmed, and available shifts. **No side effects.**
+
+**Query parameter**: `shiftboardId` (required) -- the signed-in volunteer's ID, passed from client-side session state.
+
+**Path parameter**: `code` -- the unique confirmation code from `op_trainings`.
+
+**Flow**:
+
+1. Parse `shiftboardId` from query: `const { shiftboardId } = req.query`
+2. Look up the training by code:
+   ```sql
+   SELECT t.training_id, t.training_name, t.role_id, t.url, r.role AS role_name
+   FROM op_trainings AS t
+   JOIN op_roles AS r ON r.role_id = t.role_id
+   WHERE t.code = ? AND t.delete_training = false
+   ```
+3. If not found, return 404: `{ statusCode: 404, message: "Not found" }`
+4. Get the volunteer's playa name:
+   ```sql
+   SELECT playa_name FROM op_volunteers
+   WHERE shiftboard_id = ? AND delete_volunteer = false
+   ```
+5. Check if the role is already assigned:
+   ```sql
+   SELECT role_id FROM op_volunteer_roles
+   WHERE shiftboard_id = ? AND role_id = ? AND remove_role = false
+   ```
+6. Query positions that require this training, and their shifts:
+   ```sql
+   SELECT DISTINCT
+     sn.shift_name, sn.shift_name_id,
+     sc.department,
+     pt.position, pt.position_type_id,
+     st.shift_instance, st.start_time, st.end_time, st.shift_times_id,
+     d.datename
+   FROM op_position_trainings AS ptr
+   JOIN op_position_type AS pt ON ptr.position_type_id = pt.position_type_id
+   JOIN op_shift_time_position AS stp ON pt.position_type_id = stp.position_type_id
+   JOIN op_shift_times AS st ON stp.shift_times_id = st.shift_times_id
+   JOIN op_shift_name AS sn ON st.shift_name_id = sn.shift_name_id
+   JOIN op_shift_category AS sc ON sn.shift_category_id = sc.shift_category_id
+   JOIN op_dates AS d ON st.start_date_id = d.date_id
+   WHERE ptr.training_id = ?
+     AND ptr.delete_position_training = false
+     AND pt.delete_position = false
+     AND stp.remove_time_position = false
+     AND st.remove_shift_time = false
+     AND sn.delete_shift_name = false
+     AND sc.delete_category = false
+   ORDER BY d.date, st.start_time
+   ```
+7. Return response (map DB snake_case to camelCase as per codebase convention):
+
+```typescript
+interface IResTrainingConfirmation {
+  training: {
+    name: string;       // training_name
+    roleName: string;   // role (from op_roles join)
+    url: string;        // link to training course material
+  };
+  volunteer: {
+    playaName: string;  // playa_name
+  };
+  alreadyConfirmed: boolean;
+  availableShifts: IResTrainingShiftItem[];
+}
+
+interface IResTrainingShiftItem {
+  dateName: string;
+  department: string;
+  endTime: string;
+  position: string;
+  positionId: number;
+  shiftName: string;
+  shiftTimesId: number;
+  startTime: string;
+}
+```
+
+**Error responses**:
+- `404` - Invalid or deleted confirmation code
+
+### `POST /api/confirm/[code]` -- Assign role
+
+Performs the actual role assignment. Called once by the frontend on user action.
+
+**Request body**:
+```typescript
+interface IReqTrainingConfirm {
+  shiftboardId: number;
+}
+```
+
+**Flow**:
+
+1. Parse body: `const { shiftboardId }: IReqTrainingConfirm = JSON.parse(req.body)`
+2. Look up training by code (same query as GET step 2). Return 404 if not found.
+3. Check if role already assigned (SELECT first, then branch -- matches codebase pattern):
+   ```sql
+   SELECT role_id FROM op_volunteer_roles
+   WHERE role_id = ? AND shiftboard_id = ?
+   ```
+4. If row exists (even if soft-deleted), UPDATE:
+   ```sql
+   UPDATE op_volunteer_roles
+   SET add_role = true, remove_role = false
+   WHERE role_id = ? AND shiftboard_id = ?
+   ```
+5. If no row exists, INSERT:
+   ```sql
+   INSERT INTO op_volunteer_roles (shiftboard_id, role_id, add_role, remove_role)
+   VALUES (?, ?, true, false)
+   ```
+6. Return: `{ statusCode: 201, message: "Created" }`
+   Or if already confirmed: `{ statusCode: 200, message: "OK" }`
+
+---
+
+## Frontend
+
+### New Page: `/confirm/[code]/page.tsx`
+
+**Location**: `client/src/app/confirm/[code]/page.tsx`
+
+**Component**: `TrainingConfirmation`
+
+**Auth**: Check `sessionState.settings.isAuthenticated` from session context. If not signed in:
+1. Store the current URL (`/confirm/{code}`) in `sessionStorage` under a key like `redirectAfterSignIn`
+2. Redirect to `/sign-in`
+
+This requires a small change to the sign-in success handler (in `SignIn.tsx`): after successful sign-in, check `sessionStorage.getItem("redirectAfterSignIn")`. If present, navigate there and clear the key. Otherwise navigate to the default landing page.
+
+This redirect mechanism is auth-method-agnostic -- it works the same whether sign-in uses passcode or OAuth.
+
+**Data fetching**:
+
+1. Use `useSWR` for the GET (read-only lookup):
+   ```typescript
+   const { data, error } = useSWR(
+     `/api/confirm/${code}?shiftboardId=${sessionState.user.shiftboardId}`,
+     fetcherGet
+   );
+   ```
+
+2. Use `useSWRMutation` with `fetcherTrigger` for the POST (role assignment):
+   ```typescript
+   const { trigger } = useSWRMutation(`/api/confirm/${code}`, fetcherTrigger);
+
+   const handleConfirm = async () => {
+     await trigger({
+       method: "POST",
+       body: { shiftboardId: sessionState.user.shiftboardId },
+     });
+     // Update client-side session state with new role
+     sessionDispatch({
+       type: SESSION_ROLE_ITEM_ADD,
+       payload: { id: data.training.roleId, name: data.training.roleName },
+     });
+     // Revalidate the GET to show updated state
+     mutate(`/api/confirm/${code}?shiftboardId=${sessionState.user.shiftboardId}`);
+   };
+   ```
+
+**Display states**:
+
+1. **Loading**: Show `<Loading />` component
+2. **Error / 404**: Show `<ErrorPage />`
+3. **Not yet confirmed** (`alreadyConfirmed: false`):
+   ```
+   {trainingName}
+
+   Hi {playaName}! Confirm your completion of {trainingName} to unlock
+   shifts that require this training.
+
+   [Confirm] button
+
+   Available shifts requiring {trainingName}:
+   - [shift list with links to /shifts/{shiftTimesId}/volunteers]
+   ```
+4. **After confirmation / already confirmed** (`alreadyConfirmed: true`):
+   ```
+   Thank you, {playaName}, for confirming completion of {trainingName}!
+
+   Your {roleName} role has been added to your account.
+
+   Sign up for shifts that need this training:
+   - [shift list with links to /shifts/{shiftTimesId}/volunteers]
+   ```
+5. **No available shifts**: Replace shift list with:
+   ```
+   There are no open shifts requiring {trainingName} at this time.
+   ```
+
+**UI Components** (follow existing patterns):
+- `<Hero text="Training Confirmation" />`
+- `<Container component="main">` wrapper
+- Shift list as MUI `<List>` with clickable items linking to `/shifts/{shiftTimesId}/volunteers`
+- Use `useSnackbar()` from notistack for success/error feedback after POST
+- Use `<Button>` from MUI for the confirm action
+
+---
+
+## Admin Management (Future / Optional)
+
+For managing trainings via the admin UI, add CRUD endpoints following the same pattern as `/api/roles`:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/trainings` | GET | List all trainings |
+| `/api/trainings` | POST | Create training (let MySQL auto-generate ID) |
+| `/api/trainings/[trainingId]` | PATCH | Update training |
+| `/api/trainings/[trainingId]` | DELETE | Soft delete (`delete_training = true`) |
+| `/api/trainings/[trainingId]/positions` | GET | List positions linked to training |
+| `/api/trainings/[trainingId]/positions` | POST | Link position to training |
+| `/api/trainings/[trainingId]/positions/[positionTrainingId]` | DELETE | Unlink position |
+
+---
+
+## Gotchas & Implementation Notes
+
+1. **Do NOT use `generateId()`** for `training_id` or `position_training_id`. The existing `generateId()` has an async race condition (returns before the duplicate check completes). These tables use `AUTO_INCREMENT` -- omit the ID from INSERT statements and let MySQL assign it.
+
+2. **Code generation**: For the `code` column on `op_trainings`, generate codes server-side when creating a training via the admin endpoint. Use `crypto.randomBytes(12).toString('base64url').slice(0, 16)` for the random portion. Format: `{type}-{year}-{random16}`.
+
+3. **Role assignment pattern**: Use the SELECT-then-branch pattern (check if row exists, then INSERT or UPDATE). This matches the existing pattern in `/pages/api/roles/[roleId]/volunteers/index.ts`. Do NOT use `ON DUPLICATE KEY UPDATE` -- no endpoint in the codebase uses it.
+
+4. **Soft deletes**: Never hard-delete. Use `delete_*` flags and always filter with `WHERE delete_* = false` in queries.
+
+5. **Route file placement**: API route: `client/src/pages/api/confirm/[code]/index.ts` (pages router). Frontend page: `client/src/app/confirm/[code]/page.tsx` (app router). All API routes use pages router; all UI pages use app router.
+
+6. **Auth is client-side only**: There is no server-side auth middleware. The `shiftboardId` is passed as a query param (GET) or body field (POST) from client-side session state. The `AuthGate` component prevents unauthenticated users from reaching the page. This matches every other endpoint in the codebase.
+
+7. **Session state update**: After assigning the role via POST, dispatch `SESSION_ROLE_ITEM_ADD` to the session reducer to update the client-side role list. Do NOT use `mutate("/api/volunteers/...")` -- the role list lives in React context, not SWR cache.
+
+8. **`prerequisite_id` coexistence**: The existing `op_position_type.prerequisite_id` (FK to `op_shift_category`) is a separate prerequisite system. Both coexist. The `op_position_trainings` table is for formal training completion; `prerequisite_id` is for shift category experience. The volunteer add dialog will need a follow-up update to check training roles too.
+
+9. **`op_roles.display`**: Set `display = 0` for training completion roles so they don't clutter the main roles admin list. They'll still appear in the volunteer's role list.
+
+10. **Collation**: `utf8mb4_bin` means `code` lookups are case-sensitive. Codes should be lowercase for consistency.
+
+11. **Schema location**: Add the new `CREATE TABLE` statements to `database/scheduler_schema.sql`. Use `DROP TABLE IF EXISTS` before each (matching existing convention). The tables must be created after `op_roles` and `op_position_type` due to FK dependencies.
+
+12. **On-playa SQL dumps**: The `update_server.sh` script dumps all `op_*` tables. Since the new tables follow the `op_` prefix, they'll be included automatically.
+
+13. **Soft-delete filters in shift query**: The shifts query MUST filter on ALL soft-delete columns: `delete_position_training`, `delete_position`, `remove_time_position`, `remove_shift_time`, `delete_shift_name`, `delete_category`. Missing any of these will return deleted/removed data.
+
+---
+
+## Seed Data
+
+Role IDs start at 2000001 (above current max of 1001321).
+
+Codes use 5 unambiguous characters (no 0/O, 1/I/l): `ABCDEFGHJKMNPQRSTUVWXYZ23456789`
+
+```sql
+-- ============================================================
+-- Training completion roles
+-- ============================================================
+INSERT INTO op_roles (`role_id`, `role`, `display`, `create_role`, `delete_role`, `role_src`) VALUES
+  (2000001, 'TrainingCensusBasicsComplete',      0, 1, 0, 'tablet'),
+  (2000002, 'TrainingRandomSamplingComplete',     0, 1, 0, 'tablet'),
+  (2000003, 'TrainingOutReachComplete',           0, 1, 0, 'tablet'),
+  (2000004, 'TrainingDataEntryWizComplete',       0, 1, 0, 'tablet'),
+  (2000005, 'TrainingDataBeastDriverComplete',    0, 1, 0, 'tablet');
+
+-- ============================================================
+-- Training definitions
+-- ============================================================
+INSERT INTO op_trainings (`training_name`, `role_id`, `code`, `url`, `create_training`) VALUES
+  ('Census Basics', 2000001, 'XQDDG',
+   'https://hive.burningman.org/posts/census-course-basics-start-here-course-overview-84578159', 1),
+  ('Random Sampling', 2000002, 'AH73H',
+   'https://hive.burningman.org/posts/census-course-random-sampling-start-here-random-sampling-course-overview', 1),
+  ('OutReach', 2000003, 'XQ9VD',
+   'https://hive.burningman.org/posts/census-course-outreach-course-overview-start-here-84578181', 1),
+  ('DataEntry Wiz', 2000004, 'TMBSW',
+   'https://drive.google.com/file/d/1rhB75gEhYQ7gctzHZEHG7xLrRWiejyth/view?usp=drivesdk', 1),
+  ('DataBeast Driver', 2000005, 'PZBWG',
+   'https://hive.burningman.org/posts/census-course-databeast-drive-start-here-databeast-driver-course-overview', 1);
+
+-- ============================================================
+-- Position-training links
+-- training_id references: 1=Census Basics, 2=Random Sampling, 3=OutReach, 4=DataEntry Wiz, 5=DataBeast Driver
+-- ============================================================
+
+-- Census Basics (all positions)
+INSERT INTO op_position_trainings (`position_type_id`, `training_id`, `create_position_training`) VALUES
+  (1, 1, 1),       -- Airport Sampler
+  (9, 1, 1),       -- Airport Sampling Lead
+  (18, 1, 1),      -- Art Tour Lead
+  (28, 1, 1),      -- Artist
+  (17, 1, 1),      -- Census Art Tour
+  (15, 1, 1),      -- Census Lab Host
+  (36, 1, 1),      -- Census PopUp Lab Host
+  (27, 1, 1),      -- Data Disseminator
+  (19, 1, 1),      -- Data Entry Shift Lead
+  (20, 1, 1),      -- Data Entry Wiz
+  (40, 1, 1),      -- DataBash Presenter
+  (10, 1, 1),      -- DataBeast Driver
+  (3, 1, 1),       -- Gate Sampler
+  (8, 1, 1),       -- Gate Sampling Lead
+  (30, 1, 1),      -- Infoboard creator
+  (16, 1, 1),      -- Lab Host Lead
+  (13, 1, 1),      -- Lab Host Lead Trainee
+  (14, 1, 1),      -- Lab Host Lead Trainer
+  (35, 1, 1),      -- Lab Host Trainer
+  (34, 1, 1),      -- Lab Host Training
+  (41, 1, 1),      -- Party Host
+  (21, 1, 1),      -- Party Support
+  (33, 1, 1),      -- Random Sampling Trainer
+  (32, 1, 1),      -- Random Sampling Training
+  (11, 1, 1),      -- Sampling Lead Trainee
+  (12, 1, 1),      -- Sampling Lead Trainer
+  (23, 1, 1),      -- Setup Crew
+  (26, 1, 1),      -- Setup Lead
+  (29, 1, 1),      -- Statistician
+  (24, 1, 1),      -- Strike
+  (25, 1, 1),      -- Strike Lead
+  (31, 1, 1),      -- Tech Support
+  (2, 1, 1),       -- Traffic Tamer
+  (955994, 1, 1),  -- Trainee
+  (685401, 1, 1);  -- Welcome Party
+
+-- Random Sampling
+INSERT INTO op_position_trainings (`position_type_id`, `training_id`, `create_position_training`) VALUES
+  (1, 2, 1),       -- Airport Sampler
+  (9, 2, 1),       -- Airport Sampling Lead
+  (3, 2, 1),       -- Gate Sampler
+  (8, 2, 1),       -- Gate Sampling Lead
+  (33, 2, 1),      -- Random Sampling Trainer
+  (32, 2, 1),      -- Random Sampling Training
+  (11, 2, 1),      -- Sampling Lead Trainee
+  (12, 2, 1),      -- Sampling Lead Trainer
+  (2, 2, 1);       -- Traffic Tamer
+
+-- OutReach
+INSERT INTO op_position_trainings (`position_type_id`, `training_id`, `create_position_training`) VALUES
+  (15, 3, 1),      -- Census Lab Host
+  (36, 3, 1),      -- Census PopUp Lab Host
+  (27, 3, 1),      -- Data Disseminator
+  (16, 3, 1),      -- Lab Host Lead
+  (13, 3, 1),      -- Lab Host Lead Trainee
+  (14, 3, 1),      -- Lab Host Lead Trainer
+  (35, 3, 1),      -- Lab Host Trainer
+  (34, 3, 1);      -- Lab Host Training
+
+-- DataEntry Wiz
+INSERT INTO op_position_trainings (`position_type_id`, `training_id`, `create_position_training`) VALUES
+  (19, 4, 1),      -- Data Entry Shift Lead
+  (20, 4, 1);      -- Data Entry Wiz
+
+-- DataBeast Driver
+INSERT INTO op_position_trainings (`position_type_id`, `training_id`, `create_position_training`) VALUES
+  (10, 5, 1);      -- DataBeast Driver
+```
+
+---
+
+## Files to Create/Modify
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `client/src/pages/api/confirm/[code]/index.ts` | API endpoint (GET + POST) |
+| Create | `client/src/app/confirm/[code]/page.tsx` | Frontend page entry |
+| Create | `client/src/app/confirm/[code]/TrainingConfirmation.tsx` | Page component |
+| Create | `client/src/components/types/confirm.ts` | TypeScript interfaces |
+| Modify | `database/scheduler_schema.sql` | Add `op_trainings` and `op_position_trainings` tables |
+| Modify | `client/src/app/sign-in/SignIn.tsx` | Add sessionStorage redirect-after-sign-in check |
+
+---
+
+## Testing Checklist
+
+- [ ] GET with valid code: returns training info + shift list
+- [ ] GET with invalid/deleted code: returns 404
+- [ ] POST with valid code: assigns role, returns 201
+- [ ] POST with already-confirmed code: re-enables role (idempotent), returns 200
+- [ ] GET after POST: `alreadyConfirmed` is true
+- [ ] Visiting page while not signed in: redirects to sign-in, then back to confirm page after sign-in
+- [ ] Shifts query excludes soft-deleted positions, shift times, categories
+- [ ] Shifts query excludes soft-deleted position_trainings
+- [ ] New tables created correctly in Docker init (scheduler_schema.sql)
+- [ ] New tables included in on-playa SQL dumps (op_ prefix auto-includes)
+- [ ] Session state updated after confirmation (role appears in UI)
+- [ ] Multiple volunteers can confirm the same training code
+- [ ] Code is case-sensitive (lowercase enforced)


### PR DESCRIPTION
## Summary
Imports two design docs that have been living locally untracked. Goal is preservation — the docs were one stray `git clean` away from being lost.

- **`specs/design-vip.md`** (730 lines, status: Draft, dated 2026-04-16) — Volunteer Information Page spec: `op_saps` table + `op_volunteers`/`op_roles` alters, SAP eligibility rules (CSP thresholds, day-by-day shift requirements, role-based bypasses), section-by-section UI copy with exact text, five new API endpoints, phased implementation order.
- **`specs/training-confirmation-endpoint.md`** (498 lines) — `/api/confirm/[code]` flow for volunteers to confirm training completion via unique link, plus the new `op_trainings` table.

Both docs predate some of the implementation already on `census/vip-page`. A follow-up will reconcile the docs with shipped code (collapse-by-default checklist, redirect-loop handling for wrong roles, banner title, etc.).

No code changes — pure docs commit. Safe to merge.

## Test plan
- [x] `git diff main...docs/vip-and-training-specs` is two new markdown files, nothing else
- [ ] Verify CI passes (lint shouldn't touch markdown, build shouldn't run on docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)