### PR TITLE
feat: per-deployment auth mode (NEXT_PUBLIC_PIN_ENABLED)

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -3,3 +3,10 @@ MYSQL_DATABASE = "census"
 MYSQL_HOST = "database"
 MYSQL_PASSWORD = "placeholder"
 MYSQL_USER = "root"
+
+# okta oauth (set these to enable OAuth sign-in)
+# OKTA_CLIENT_ID = ""
+# OKTA_CLIENT_SECRET = ""
+# OKTA_ISSUER = "https://your-org.okta.com/oauth2/default"
+# OKTA_REDIRECT_URI = "https://your-domain.com/api/auth/okta/callback"
+# NEXT_PUBLIC_OKTA_ENABLED = "true"

--- a/client/src/app/auth/complete/AuthComplete.tsx
+++ b/client/src/app/auth/complete/AuthComplete.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSnackbar } from "notistack";
+import { useContext, useEffect, useRef } from "react";
+
+import { Loading } from "@/components/general/Loading";
+import { SnackbarText } from "@/components/general/SnackbarText";
+import { SESSION_SIGN_IN } from "@/constants";
+import { SessionContext } from "@/state/session/context";
+
+export const AuthComplete = () => {
+  // context
+  // ------------------------------------------------------------
+  const { sessionDispatch } = useContext(SessionContext);
+
+  // other hooks
+  // ------------------------------------------------------------
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { enqueueSnackbar } = useSnackbar();
+  const hasProcessed = useRef(false);
+
+  // hydrate session from OAuth callback data
+  // ------------------------------------------------------------
+  useEffect(() => {
+    if (hasProcessed.current) return;
+    hasProcessed.current = true;
+
+    const dataParam = searchParams?.get("data");
+    const returnTo = searchParams?.get("returnTo");
+
+    if (!dataParam) {
+      router.replace("/sign-in?error=missing_data");
+      return;
+    }
+
+    try {
+      const account = JSON.parse(decodeURIComponent(dataParam));
+
+      sessionDispatch({
+        payload: account,
+        type: SESSION_SIGN_IN,
+      });
+
+      enqueueSnackbar(
+        <SnackbarText>
+          <strong>
+            {account.playaName} &quot;{account.worldName}&quot;
+          </strong>{" "}
+          has signed in
+        </SnackbarText>,
+        {
+          variant: "success",
+        }
+      );
+
+      const redirectPath =
+        returnTo && returnTo.startsWith("/")
+          ? returnTo
+          : `/volunteers/${account.shiftboardId}/account`;
+      router.replace(redirectPath);
+    } catch {
+      router.replace("/sign-in?error=invalid_data");
+    }
+  }, [enqueueSnackbar, router, searchParams, sessionDispatch]);
+
+  // render
+  // ------------------------------------------------------------
+  return <Loading />;
+};

--- a/client/src/app/auth/complete/page.tsx
+++ b/client/src/app/auth/complete/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+
+import { AuthComplete } from "@/app/auth/complete/AuthComplete";
+
+export const metadata = {
+  title: "Census | Signing in...",
+};
+const AuthCompletePage = () => {
+  return (
+    <Suspense>
+      <AuthComplete />
+    </Suspense>
+  );
+};
+
+export default AuthCompletePage;

--- a/client/src/app/sign-in/SignIn.tsx
+++ b/client/src/app/sign-in/SignIn.tsx
@@ -5,6 +5,7 @@ import {
   VisibilityOff as VisibilityOffIcon,
 } from "@mui/icons-material";
 import {
+  Alert,
   Autocomplete,
   Button,
   Card,
@@ -12,12 +13,14 @@ import {
   CardContent,
   CircularProgress,
   Container,
+  Divider,
   IconButton,
   Stack,
   TextField,
+  Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 import { useContext, useState } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
@@ -81,7 +84,11 @@ export const SignIn = () => {
   });
   const { enqueueSnackbar } = useSnackbar();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const theme = useTheme();
+
+  const oauthError = searchParams?.get("error");
+  const isOAuthConfigured = Boolean(process.env.NEXT_PUBLIC_OKTA_ENABLED);
 
   // logic
   // ------------------------------------------------------------
@@ -173,6 +180,29 @@ export const SignIn = () => {
             width: theme.spacing(50),
           }}
         >
+          {oauthError && (
+            <Alert severity="error" sx={{ m: 2, mb: 0 }}>
+              Sign in failed: {decodeURIComponent(oauthError).replace(/_/g, " ")}
+            </Alert>
+          )}
+          {isOAuthConfigured && (
+            <CardContent>
+              <Button
+                fullWidth
+                href="/api/auth/okta"
+                size="large"
+                startIcon={<LoginIcon />}
+                variant="contained"
+              >
+                Sign in with Burning Man
+              </Button>
+              <Divider sx={{ mt: 2 }}>
+                <Typography color="text.secondary" variant="body2">
+                  or use passcode
+                </Typography>
+              </Divider>
+            </CardContent>
+          )}
           <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
             <CardContent>
               <Stack spacing={2}>

--- a/client/src/app/sign-in/SignIn.tsx
+++ b/client/src/app/sign-in/SignIn.tsx
@@ -88,7 +88,8 @@ export const SignIn = () => {
   const theme = useTheme();
 
   const oauthError = searchParams?.get("error");
-  const isOAuthConfigured = Boolean(process.env.NEXT_PUBLIC_OKTA_ENABLED);
+  const isOAuthConfigured = process.env.NEXT_PUBLIC_OKTA_ENABLED === "true";
+  const isPinEnabled = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
 
   // logic
   // ------------------------------------------------------------
@@ -185,6 +186,14 @@ export const SignIn = () => {
               Sign in failed: {decodeURIComponent(oauthError).replace(/_/g, " ")}
             </Alert>
           )}
+          {!isOAuthConfigured && !isPinEnabled && (
+            <CardContent>
+              <Alert severity="warning">
+                Sign-in is not configured for this deployment. Please contact
+                an administrator.
+              </Alert>
+            </CardContent>
+          )}
           {isOAuthConfigured && (
             <CardContent>
               <Button
@@ -196,13 +205,16 @@ export const SignIn = () => {
               >
                 Sign in with Burning Man
               </Button>
-              <Divider sx={{ mt: 2 }}>
-                <Typography color="text.secondary" variant="body2">
-                  or use passcode
-                </Typography>
-              </Divider>
+              {isPinEnabled && (
+                <Divider sx={{ mt: 2 }}>
+                  <Typography color="text.secondary" variant="body2">
+                    or use passcode
+                  </Typography>
+                </Divider>
+              )}
             </CardContent>
           )}
+          {isPinEnabled && (
           <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
             <CardContent>
               <Stack spacing={2}>
@@ -302,6 +314,7 @@ export const SignIn = () => {
               </Button>
             </CardActions>
           </form>
+          )}
         </Card>
       </Container>
     </>

--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -1,0 +1,262 @@
+import { RowDataPacket } from "mysql2";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { generateId } from "@/utils/generateId";
+import { pool } from "lib/database";
+
+interface OktaTokenResponse {
+  access_token: string;
+  id_token: string;
+  token_type: string;
+  expires_in: number;
+  scope: string;
+}
+
+interface OktaUserInfo {
+  sub: string; // unique Okta user ID
+  email: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  preferred_username?: string;
+  nickname?: string;
+}
+
+// helper: exchange authorization code for tokens
+async function exchangeCode(
+  code: string,
+  codeVerifier: string
+): Promise<OktaTokenResponse> {
+  const issuer = process.env.OKTA_ISSUER!;
+  const clientId = process.env.OKTA_CLIENT_ID!;
+  const clientSecret = process.env.OKTA_CLIENT_SECRET!;
+  const redirectUri = process.env.OKTA_REDIRECT_URI!;
+
+  const tokenUrl = `${issuer}/v1/token`;
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: clientId,
+    client_secret: clientSecret,
+    code_verifier: codeVerifier,
+  });
+
+  const resp = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Token exchange failed: ${resp.status} ${text}`);
+  }
+
+  return resp.json();
+}
+
+// helper: fetch user profile from Okta
+async function fetchUserInfo(
+  accessToken: string
+): Promise<OktaUserInfo> {
+  const issuer = process.env.OKTA_ISSUER!;
+  const resp = await fetch(`${issuer}/v1/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`UserInfo failed: ${resp.status} ${text}`);
+  }
+
+  return resp.json();
+}
+
+// helper: build the volunteer account response (same shape as sign-in)
+async function buildAccountResponse(shiftboardId: number) {
+  const [dbVolunteerList] = await pool.query<RowDataPacket[]>(
+    `SELECT
+      email,
+      emergency_contact,
+      create_volunteer,
+      location,
+      notes,
+      phone,
+      playa_name,
+      shiftboard_id,
+      world_name
+    FROM op_volunteers
+    WHERE shiftboard_id=?`,
+    [shiftboardId]
+  );
+  const volunteer = dbVolunteerList[0];
+  if (!volunteer) return null;
+
+  const [dbRoleList] = await pool.query<RowDataPacket[]>(
+    `SELECT r.role, r.role_id
+    FROM op_volunteer_roles AS vr
+    JOIN op_roles AS r ON vr.role_id=r.role_id AND vr.remove_role=false
+    WHERE vr.shiftboard_id=?`,
+    [shiftboardId]
+  );
+  const roleList = dbRoleList.map(({ role, role_id }) => ({
+    id: role_id,
+    name: role,
+  }));
+
+  return {
+    email: volunteer.email,
+    emergencyContact: volunteer.emergency_contact ?? "",
+    isCreated: volunteer.create_volunteer,
+    location: volunteer.location ?? "",
+    notes: volunteer.notes ?? "",
+    phone: volunteer.phone ?? "",
+    playaName: volunteer.playa_name,
+    roleList,
+    shiftboardId: volunteer.shiftboard_id,
+    worldName: volunteer.world_name,
+  };
+}
+
+// GET /api/auth/okta/callback — handle Okta OIDC callback
+const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "GET") {
+    return res.status(404).json({ statusCode: 404, message: "Not found" });
+  }
+
+  const { code, state, error, error_description } = req.query;
+
+  // Okta returned an error
+  if (error) {
+    return res.redirect(
+      `/sign-in?error=${encodeURIComponent(String(error_description || error))}`
+    );
+  }
+
+  if (!code || !state) {
+    return res.redirect("/sign-in?error=missing_params");
+  }
+
+  // validate state and retrieve code verifier from cookie
+  const oauthCookie = req.cookies.oauth_state;
+  if (!oauthCookie) {
+    return res.redirect("/sign-in?error=missing_state");
+  }
+
+  let storedState: string;
+  let codeVerifier: string;
+  try {
+    const parsed = JSON.parse(decodeURIComponent(oauthCookie));
+    storedState = parsed.state;
+    codeVerifier = parsed.codeVerifier;
+  } catch {
+    return res.redirect("/sign-in?error=invalid_state");
+  }
+
+  // extract returnTo from state param (format: "randomhex|/path/to/page")
+  const stateStr = String(state);
+  const pipeIndex = stateStr.indexOf("|");
+  const receivedState = pipeIndex >= 0 ? stateStr.substring(0, pipeIndex) : stateStr;
+  const returnTo = pipeIndex >= 0 ? stateStr.substring(pipeIndex + 1) : "";
+
+  if (receivedState !== storedState) {
+    return res.redirect("/sign-in?error=state_mismatch");
+  }
+
+  // clear the oauth cookie
+  res.setHeader("Set-Cookie", [
+    "oauth_state=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+  ]);
+
+  try {
+    // exchange code for tokens
+    const tokens = await exchangeCode(String(code), codeVerifier);
+
+    // fetch user profile
+    const userInfo = await fetchUserInfo(tokens.access_token);
+    const oktaId = userInfo.sub;
+    const email = userInfo.email;
+    const playaName = userInfo.nickname || userInfo.given_name || userInfo.name || email;
+    const worldName = userInfo.name || `${userInfo.given_name || ""} ${userInfo.family_name || ""}`.trim() || email;
+
+    if (!email) {
+      return res.redirect("/sign-in?error=no_email");
+    }
+
+    // try to find existing volunteer by okta_id first, then by email
+    let shiftboardId: number | null = null;
+
+    // 1. check by okta_id
+    const [byOktaId] = await pool.query<RowDataPacket[]>(
+      "SELECT shiftboard_id FROM op_volunteers WHERE okta_id=?",
+      [oktaId]
+    );
+    if (byOktaId.length > 0) {
+      shiftboardId = byOktaId[0].shiftboard_id;
+
+      // sync profile data from Okta
+      await pool.query(
+        `UPDATE op_volunteers
+        SET playa_name=?, world_name=?, email=?
+        WHERE shiftboard_id=?`,
+        [playaName, worldName, email, shiftboardId]
+      );
+    }
+
+    // 2. check by email
+    if (!shiftboardId) {
+      const [byEmail] = await pool.query<RowDataPacket[]>(
+        "SELECT shiftboard_id FROM op_volunteers WHERE email=?",
+        [email]
+      );
+      if (byEmail.length > 0) {
+        shiftboardId = byEmail[0].shiftboard_id;
+
+        // link okta_id and sync profile
+        await pool.query(
+          `UPDATE op_volunteers
+          SET okta_id=?, playa_name=?, world_name=?
+          WHERE shiftboard_id=?`,
+          [oktaId, playaName, worldName, shiftboardId]
+        );
+      }
+    }
+
+    // 3. create new volunteer
+    if (!shiftboardId) {
+      const newId = generateId(`
+        SELECT shiftboard_id
+        FROM op_volunteers
+        WHERE shiftboard_id=?
+      `);
+
+      await pool.query<RowDataPacket[]>(
+        `INSERT INTO op_volunteers (
+          shiftboard_id, playa_name, world_name, email, okta_id, create_volunteer
+        ) VALUES (?, ?, ?, ?, ?, true)`,
+        [newId, playaName, worldName, email, oktaId]
+      );
+      shiftboardId = newId;
+    }
+
+    // build the account response (same shape as passcode sign-in)
+    const account = await buildAccountResponse(shiftboardId);
+    if (!account) {
+      return res.redirect("/sign-in?error=account_error");
+    }
+
+    // encode account data for client-side session hydration
+    const accountData = encodeURIComponent(JSON.stringify(account));
+    const redirectPath = returnTo && returnTo.startsWith("/") ? returnTo : `/volunteers/${shiftboardId}/account`;
+
+    return res.redirect(
+      `/auth/complete?data=${accountData}&returnTo=${encodeURIComponent(redirectPath)}`
+    );
+  } catch (err) {
+    console.error("OAuth callback error:", err);
+    return res.redirect("/sign-in?error=callback_failed");
+  }
+};
+
+export default oktaCallback;

--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -125,6 +125,13 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(404).json({ statusCode: 404, message: "Not found" });
   }
 
+  if (process.env.NEXT_PUBLIC_OKTA_ENABLED !== "true") {
+    return res.status(403).json({
+      statusCode: 403,
+      message: "Okta sign-in is not enabled for this deployment",
+    });
+  }
+
   const { code, state, error, error_description } = req.query;
 
   // Okta returned an error

--- a/client/src/pages/api/auth/okta/index.ts
+++ b/client/src/pages/api/auth/okta/index.ts
@@ -1,0 +1,53 @@
+import crypto from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// GET /api/auth/okta — initiate Okta OIDC authorization code flow
+const oktaAuthorize = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "GET") {
+    return res.status(404).json({ statusCode: 404, message: "Not found" });
+  }
+
+  const clientId = process.env.OKTA_CLIENT_ID;
+  const issuer = process.env.OKTA_ISSUER;
+  const redirectUri = process.env.OKTA_REDIRECT_URI;
+
+  if (!clientId || !issuer || !redirectUri) {
+    return res.status(500).json({
+      statusCode: 500,
+      message: "OAuth not configured",
+    });
+  }
+
+  // generate CSRF state token
+  const state = crypto.randomBytes(32).toString("hex");
+
+  // generate PKCE code verifier and challenge
+  const codeVerifier = crypto.randomBytes(32).toString("base64url");
+  const codeChallenge = crypto
+    .createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+
+  // store state + code verifier in a secure httpOnly cookie
+  const oauthData = JSON.stringify({ state, codeVerifier });
+  res.setHeader("Set-Cookie", [
+    `oauth_state=${encodeURIComponent(oauthData)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600`,
+  ]);
+
+  // preserve returnTo if provided
+  const returnTo = typeof req.query.returnTo === "string" ? req.query.returnTo : "";
+  const stateParam = returnTo ? `${state}|${returnTo}` : state;
+
+  const authUrl = new URL(`${issuer}/v1/authorize`);
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("scope", "openid profile email");
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("state", stateParam);
+  authUrl.searchParams.set("code_challenge", codeChallenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+
+  return res.redirect(302, authUrl.toString());
+};
+
+export default oktaAuthorize;

--- a/client/src/pages/api/auth/okta/index.ts
+++ b/client/src/pages/api/auth/okta/index.ts
@@ -7,6 +7,13 @@ const oktaAuthorize = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(404).json({ statusCode: 404, message: "Not found" });
   }
 
+  if (process.env.NEXT_PUBLIC_OKTA_ENABLED !== "true") {
+    return res.status(403).json({
+      statusCode: 403,
+      message: "Okta sign-in is not enabled for this deployment",
+    });
+  }
+
   const clientId = process.env.OKTA_CLIENT_ID;
   const issuer = process.env.OKTA_ISSUER;
   const redirectUri = process.env.OKTA_REDIRECT_URI;

--- a/client/src/pages/api/sign-in/index.ts
+++ b/client/src/pages/api/sign-in/index.ts
@@ -6,6 +6,13 @@ import type { IResVolunteerAccount } from "@/components/types/volunteers";
 import { pool } from "lib/database";
 
 const signIn = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (process.env.NEXT_PUBLIC_PIN_ENABLED === "false") {
+    return res.status(403).json({
+      statusCode: 403,
+      message: "Passcode sign-in is not enabled for this deployment",
+    });
+  }
+
   switch (req.method) {
     // post
     // ------------------------------------------------------------

--- a/migrations/001_add_okta_id.sql
+++ b/migrations/001_add_okta_id.sql
@@ -1,0 +1,7 @@
+-- Add okta_id column to op_volunteers for Okta OAuth integration
+-- This stores the unique Okta user ID (sub claim) for each volunteer
+-- The unique index allows efficient lookup by okta_id and prevents duplicates
+
+ALTER TABLE op_volunteers
+  ADD COLUMN okta_id VARCHAR(255) DEFAULT NULL AFTER email,
+  ADD UNIQUE INDEX idx_okta_id (okta_id);


### PR DESCRIPTION
## Summary

Adds a `NEXT_PUBLIC_PIN_ENABLED` flag parallel to the existing `NEXT_PUBLIC_OKTA_ENABLED`, so each deployment chooses which sign-in option(s) appear:

| Deployment | OKTA_ENABLED | PIN_ENABLED | Result |
|---|---|---|---|
| Test droplet | `true` | `true` | Both buttons |
| Off-playa prod (`volunteers.census.burningman.org`) | `true` | `false` | Okta only |
| On-playa prod | `false` | `true` | Passcode only |
| (default if unset) | `(false)` | `(true)` | Passcode only — safe fallback |

## Why

Three deployments, three auth pictures:
- **On-playa** is offline — can't reach Okta — must be passcode.
- **Off-playa cloud** is internet-facing — Okta SSO only, less attack surface.
- **Test droplet** wants both so QA can exercise the passcode path without traveling.

## Changes

**UI (`client/src/app/sign-in/SignIn.tsx`):**
- Wraps the passcode form in `isPinEnabled` gate
- "Or use passcode" divider only shown when both are enabled
- Friendly warning Alert when both are disabled (misconfig safeguard)
- Tightens the OKTA gate from `Boolean(...)` to `=== "true"` — the old check returned `true` for the string `"false"`, which would have surprised someone

**API guards (defense in depth so the UI gate isn't the only barrier):**
- `/api/sign-in` → 403 when `PIN_ENABLED=false`
- `/api/auth/okta` → 403 when `OKTA_ENABLED !== "true"`
- `/api/auth/okta/callback` → 403 when `OKTA_ENABLED !== "true"`

## Dependencies

- **Built on `census/okta-oauth` (PR #263).** Diff currently includes those changes; once #263 merges, GitHub auto-shrinks this PR's diff to just the new flag work.

## Operational notes

The Docker compose files don't change — they already `env_file` from `client/.env.production`, which is per-deployment. Operators set the right combination there.

A separate read-only-mode flag (`NEXT_PUBLIC_READ_ONLY`) for the off-playa server during the event is planned as a follow-up PR.

## Test plan

- [ ] With `NEXT_PUBLIC_OKTA_ENABLED=true` + `NEXT_PUBLIC_PIN_ENABLED=true`: both buttons + divider visible, both flows work
- [ ] With `OKTA_ENABLED=true` + `PIN_ENABLED=false`: only Okta button, no divider, passcode form hidden, POST to `/api/sign-in` returns 403
- [ ] With `OKTA_ENABLED=false` + `PIN_ENABLED=true`: only passcode form, GET `/api/auth/okta` returns 403
- [ ] With both disabled: warning message shown, both endpoints return 403
- [ ] Auth flow under each combo doesn't break existing volunteer sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)