### PR TITLE
fix: enable TLS to RDS via MYSQL_SSL flag

### DIFF
--- a/client/lib/database.ts
+++ b/client/lib/database.ts
@@ -1,5 +1,9 @@
 import mysql from "mysql2";
 
+// MYSQL_SSL=true enables TLS for hosted DBs like RDS that require secure
+// transport. Local docker DB on test/playa boxes leaves it unset.
+const sslOption = process.env.MYSQL_SSL ? { ssl: "Amazon RDS" } : {};
+
 export const pool = mysql
   .createPool({
     connectionLimit: 10,
@@ -7,5 +11,6 @@ export const pool = mysql
     host: process.env.MYSQL_HOST,
     password: process.env.MYSQL_PASSWORD,
     user: process.env.MYSQL_USER,
+    ...sslOption,
   })
   .promise();


### PR DESCRIPTION
## Why
Production deploy points the app at AWS RDS, which has `require_secure_transport=ON`. The mysql2 client errored:
```
ER_SECURE_TRANSPORT_REQUIRED: Connections using insecure transport are prohibited while --require_secure_transport=ON.
```

## What
Pass `ssl: "Amazon RDS"` (mysql2's bundled CA profile) when `MYSQL_SSL` is truthy in the env. Test/playa deploys that talk to a sidecar `database` container leave it unset and continue connecting plaintext.

## Test plan
- [ ] Prod (`v2.census.burningman.org`): `/api/shifts` returns 200 with shifts list (after rebuild + restart)
- [ ] Test server: still works (no env change there, same plaintext path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)