### PR TITLE
fix(okta): retry transient fetches + surface callback errors in redirect

### DIFF
--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -24,6 +24,31 @@ interface OktaUserInfo {
   playaname?: string;
 }
 
+// fetch with a longer timeout and one retry on transient network failures.
+// Node's default fetch timeout is 10s; we've seen prod hit it on cold/IPv6
+// connect paths to login.burningman.org, breaking sign-in for users who did
+// nothing wrong.
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  label: string
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(20_000),
+      });
+    } catch (err) {
+      lastErr = err;
+      if (attempt === 2) break;
+    }
+  }
+  const msg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  throw new Error(`${label} failed: ${msg}`);
+}
+
 // helper: exchange authorization code for tokens
 async function exchangeCode(
   code: string,
@@ -44,11 +69,15 @@ async function exchangeCode(
     code_verifier: codeVerifier,
   });
 
-  const resp = await fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-  });
+  const resp = await fetchWithRetry(
+    tokenUrl,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    },
+    "Token exchange"
+  );
 
   if (!resp.ok) {
     const text = await resp.text();
@@ -63,9 +92,11 @@ async function fetchUserInfo(
   accessToken: string
 ): Promise<OktaUserInfo> {
   const issuer = process.env.OKTA_ISSUER!;
-  const resp = await fetch(`${issuer}/v1/userinfo`, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  const resp = await fetchWithRetry(
+    `${issuer}/v1/userinfo`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+    "UserInfo"
+  );
 
   if (!resp.ok) {
     const text = await resp.text();
@@ -159,7 +190,15 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
     const parsed = JSON.parse(decodeURIComponent(oauthCookie));
     storedState = parsed.state;
     codeVerifier = parsed.codeVerifier;
-  } catch {
+  } catch (err) {
+    // Log the raw cookie value (truncated) so we can diagnose the
+    // intermittent "[object Object]" SyntaxError seen in prod.
+    console.error(
+      "OAuth state cookie parse failed:",
+      err,
+      "raw cookie:",
+      oauthCookie.slice(0, 80)
+    );
     return res.redirect("/sign-in?error=invalid_state");
   }
 
@@ -268,7 +307,14 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
     );
   } catch (err) {
     console.error("OAuth callback error:", err);
-    return res.redirect("/sign-in?error=callback_failed");
+    // Surface a short error string in the redirect so the user/admin can
+    // see what failed without having to grep server logs. Truncate hard
+    // to keep the URL short and to avoid leaking long server traces.
+    const detail = err instanceof Error ? err.message : String(err);
+    const safeDetail = detail.replace(/[\r\n]+/g, " ").slice(0, 160);
+    return res.redirect(
+      `/sign-in?error=${encodeURIComponent(`callback_failed: ${safeDetail}`)}`
+    );
   }
 };
 


### PR DESCRIPTION
## Why
Prod logs from this evening show two distinct OAuth callback failure modes that look like opaque errors to the user:

```
SyntaxError: "[object Object]" is not valid JSON
OAuth callback error: TypeError: fetch failed
  [cause]: Error [ConnectTimeoutError]: ... timeout: 10000ms
```

When a user hits either, they currently get redirected to `/sign-in?error=callback_failed` with no detail. Without timestamped log access, we can't tell which step blew up.

## What
1. **Retry transient fetch failures** — wrap the token-exchange and userinfo calls in `fetchWithRetry`: 2 attempts, 20s timeout each (node's default fetch timeout is 10s). The Okta token endpoint occasionally hits IPv6 connect-timeouts that resolve on a retry.
2. **Surface `err.message` in the error redirect** — instead of `?error=callback_failed`, the URL now carries `?error=callback_failed: <truncated, single-line err.message>`. The existing SignIn page already renders the `error` query param in an Alert, so the user sees what went wrong without us having to grep server logs.
3. **Log raw cookie value on state-parse failure** — helps diagnose the `"[object Object]"` SyntaxError next time it happens.

## Test plan
- [ ] Force a token-exchange timeout (block egress) and confirm the user sees `Sign in failed: callback failed: ...` with a meaningful message, not a blank failure
- [ ] Happy-path Okta sign-in still works
- [ ] Test server logs confirm retry behavior (one attempt visible if first succeeds, two if first fails then succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)