### PR TITLE
fix(security): hotfix prod PII leak — server-side session + auth gate

### DIFF
--- a/client/src/lib/session.ts
+++ b/client/src/lib/session.ts
@@ -1,0 +1,91 @@
+import crypto from "crypto";
+
+const COOKIE_NAME = "census-session";
+const SESSION_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+interface SessionPayload {
+  shiftboardId: number;
+  expires: number;
+}
+
+function getSecret(): string {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error(
+      "SESSION_SECRET env var is not set. Sign-in cannot proceed safely."
+    );
+  }
+  return secret;
+}
+
+function sign(payload: SessionPayload): string {
+  const json = JSON.stringify(payload);
+  const b64 = Buffer.from(json, "utf8").toString("base64url");
+  const hmac = crypto
+    .createHmac("sha256", getSecret())
+    .update(b64)
+    .digest("base64url");
+  return `${b64}.${hmac}`;
+}
+
+function verify(value: string): SessionPayload | null {
+  const [b64, hmac] = value.split(".");
+  if (!b64 || !hmac) return null;
+
+  const expected = crypto
+    .createHmac("sha256", getSecret())
+    .update(b64)
+    .digest("base64url");
+
+  const a = Buffer.from(hmac, "base64url");
+  const b = Buffer.from(expected, "base64url");
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+  let payload: SessionPayload;
+  try {
+    payload = JSON.parse(Buffer.from(b64, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof payload.shiftboardId !== "number") return null;
+  if (typeof payload.expires !== "number") return null;
+  if (payload.expires < Date.now()) return null;
+
+  return payload;
+}
+
+export function buildSessionCookie(shiftboardId: number): string {
+  const value = sign({
+    shiftboardId,
+    expires: Date.now() + SESSION_DURATION_MS,
+  });
+  const maxAgeSeconds = Math.floor(SESSION_DURATION_MS / 1000);
+  return `${COOKIE_NAME}=${value}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAgeSeconds}; Secure`;
+}
+
+export function buildClearSessionCookie(): string {
+  return `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure`;
+}
+
+export function readSessionFromHeader(
+  cookieHeader: string | undefined
+): SessionPayload | null {
+  if (!cookieHeader) return null;
+  for (const raw of cookieHeader.split(";")) {
+    const [name, ...rest] = raw.trim().split("=");
+    if (name === COOKIE_NAME) {
+      return verify(rest.join("="));
+    }
+  }
+  return null;
+}
+
+export function readSessionFromCookies(
+  cookies: Partial<Record<string, string>>
+): SessionPayload | null {
+  const value = cookies[COOKIE_NAME];
+  if (!value) return null;
+  return verify(value);
+}
+
+export const SESSION_COOKIE_NAME = COOKIE_NAME;

--- a/client/src/lib/withAuth.ts
+++ b/client/src/lib/withAuth.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { readSessionFromCookies } from "@/lib/session";
+
+// Wrap an API handler so it requires a valid (HMAC-verified) session cookie.
+// Belt-and-suspenders for the middleware, which only checks cookie presence
+// in the Edge runtime. This catches forged cookies.
+//
+// Usage:
+//
+//   export default withAuth(async (req, res, session) => {
+//     // session.shiftboardId is the authenticated user
+//   });
+
+export interface ApiHandlerWithSession {
+  (
+    req: NextApiRequest,
+    res: NextApiResponse,
+    session: { shiftboardId: number }
+  ): Promise<void> | void;
+}
+
+export function withAuth(handler: ApiHandlerWithSession) {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const session = readSessionFromCookies(req.cookies);
+    if (!session) {
+      return res.status(401).json({
+        statusCode: 401,
+        message: "Authentication required",
+      });
+    }
+    return handler(req, res, session);
+  };
+}

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Inlined deliberately — Next.js middleware runs in the Edge runtime which
+// does not have access to Node's `crypto` module. The session module uses
+// `import crypto from "crypto"` so importing from it would break the build.
+// Cryptographic verification happens at the API layer (Node runtime).
+const SESSION_COOKIE_NAME = "census-session";
+
+// HOTFIX 2026-05-06: gate everything-except-allowlist on the census-session
+// cookie. Public routes that volunteers (or new prospective volunteers) must
+// be able to reach without a session go through the allowlist below.
+//
+// Cookie validity is verified server-side at the API layer (where we have
+// access to crypto / Node APIs). The middleware only checks for cookie
+// presence — a forged cookie passes here but fails at the API layer.
+//
+// This is a stopgap. The proper fix is per-route role-based authorization
+// (issue #237). For now: block the obvious enumeration paths.
+
+const ALLOWLIST = [
+  // Sign-in surface (must be reachable while unauthenticated)
+  "/sign-in",
+  "/api/sign-in",
+  "/api/auth/okta",
+  "/api/auth/okta/callback",
+  "/api/auth/sign-out",
+  "/auth/complete",
+
+  // Public information pages (per Mew, 2026-05-06)
+  "/contact",
+  "/help",
+  "/reports",
+
+  // Account creation (lets new volunteers self-register)
+  "/volunteers/account/create",
+  "/api/volunteers/account/create",
+
+  // Volunteer dropdown for sign-in autocomplete — needed for on-playa
+  // passcode UI. Off-playa Okta-only mode will gate this via PR #275.
+  "/api/volunteers/dropdown",
+
+  // Health / static
+  "/_next",
+  "/favicon.ico",
+  "/banners",
+  "/general",
+  "/help/",
+  "/reports/",
+];
+
+const PUBLIC_PATHS = new Set(["/"]);
+
+function isAllowlisted(pathname: string): boolean {
+  if (PUBLIC_PATHS.has(pathname)) return true;
+  for (const prefix of ALLOWLIST) {
+    if (pathname === prefix || pathname.startsWith(prefix + "/")) return true;
+  }
+  return false;
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl;
+
+  if (isAllowlisted(pathname)) {
+    return NextResponse.next();
+  }
+
+  const cookie = req.cookies.get(SESSION_COOKIE_NAME);
+  if (cookie?.value) {
+    return NextResponse.next();
+  }
+
+  // API requests get a 401 instead of a redirect so callers see the error
+  if (pathname.startsWith("/api/")) {
+    return new NextResponse(
+      JSON.stringify({
+        statusCode: 401,
+        message: "Authentication required",
+      }),
+      { status: 401, headers: { "content-type": "application/json" } }
+    );
+  }
+
+  // Page requests redirect to /sign-in with a returnTo so the user lands
+  // back where they tried to go after authenticating.
+  const url = req.nextUrl.clone();
+  url.pathname = "/sign-in";
+  url.search = "";
+  url.searchParams.set("returnTo", pathname + search);
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: [
+    // Run on every path except Next.js internals + static files. The
+    // allowlist above filters within these paths.
+    "/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:png|jpg|jpeg|svg|webp|ico|gif|css|js|woff|woff2|ttf)$).*)",
+  ],
+};

--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -1,6 +1,7 @@
 import { RowDataPacket } from "mysql2";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { buildSessionCookie } from "@/lib/session";
 import { generateId } from "@/utils/generateId";
 import { pool } from "lib/database";
 
@@ -297,6 +298,10 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!account) {
       return res.redirect("/sign-in?error=account_error");
     }
+
+    // hotfix 2026-05-06: set the server-side session cookie so the
+    // middleware (and API guards) recognize this user as authenticated.
+    res.setHeader("Set-Cookie", buildSessionCookie(shiftboardId));
 
     // encode account data for client-side session hydration
     const accountData = encodeURIComponent(JSON.stringify(account));

--- a/client/src/pages/api/auth/sign-out.ts
+++ b/client/src/pages/api/auth/sign-out.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { buildClearSessionCookie } from "@/lib/session";
+
+// Clears the server-side session cookie. Client-side code (signOut.tsx)
+// also clears its sessionStorage state and redirects to /sign-in.
+const signOut = async (req: NextApiRequest, res: NextApiResponse) => {
+  res.setHeader("Set-Cookie", buildClearSessionCookie());
+  return res.status(200).json({ statusCode: 200, message: "Signed out" });
+};
+
+export default signOut;

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -7,6 +7,7 @@ import type {
   IResShiftVolunteerInformation,
   IResShiftVolunteerRowItem,
 } from "@/components/types/shifts";
+import { withAuth } from "@/lib/withAuth";
 import { pool } from "lib/database";
 import {
   shiftVolunteerRemove,
@@ -236,4 +237,7 @@ const shiftVolunteers = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default shiftVolunteers;
+// Hotfix 2026-05-06: this endpoint exposes volunteer playa + world names
+// per shift. Wrapped in withAuth so unauth requests get 401 and forged
+// cookies are rejected by HMAC verification.
+export default withAuth(shiftVolunteers);

--- a/client/src/pages/api/sign-in/index.ts
+++ b/client/src/pages/api/sign-in/index.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IReqSignIn } from "@/components/types/sign-in";
 import type { IResVolunteerAccount } from "@/components/types/volunteers";
+import { buildSessionCookie } from "@/lib/session";
 import { pool } from "lib/database";
 
 const signIn = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -71,6 +72,10 @@ const signIn = async (req: NextApiRequest, res: NextApiResponse) => {
         shiftboardId: volunteerFirst.shiftboard_id,
         worldName: volunteerFirst.world_name,
       };
+
+      // hotfix 2026-05-06: set the server-side session cookie so the
+      // middleware (and API guards) recognize this user as authenticated.
+      res.setHeader("Set-Cookie", buildSessionCookie(resAccount.shiftboardId));
 
       return res.status(200).json(resAccount);
     }

--- a/client/src/pages/api/volunteers/[shiftboardId]/account/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/account/index.ts
@@ -6,6 +6,7 @@ import type {
   IResVolunteerAccount,
 } from "@/components/types/volunteers";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 
 const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
   const { shiftboardId } = req.query;
@@ -122,4 +123,4 @@ const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default volunteers;
+export default withAuth(volunteers);

--- a/client/src/pages/api/volunteers/[shiftboardId]/account/passcode/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/account/passcode/index.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IReqPasscode } from "@/components/types/volunteers";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 
 const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
   const { shiftboardId } = req.query;
@@ -41,4 +42,4 @@ const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default volunteers;
+export default withAuth(volunteers);

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -6,6 +6,7 @@ import type {
   IResVolunteerInfo,
 } from "@/components/types/volunteer-info";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 
 // SAP day-by-day requirements keyed by arrival datename.
 // Each entry is either a single datename string, or an array meaning "any of these."
@@ -387,4 +388,4 @@ const volunteerInfo = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default volunteerInfo;
+export default withAuth(volunteerInfo);

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/other-sap/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/other-sap/index.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IReqToggleOtherSap } from "@/components/types/volunteer-info";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 
 const ROLE_OTHER_SAP_ID = 2000007;
 
@@ -69,4 +70,4 @@ const otherSap = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default otherSap;
+export default withAuth(otherSap);

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/profile-updated/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/profile-updated/index.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IReqToggleProfileUpdated } from "@/components/types/volunteer-info";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 
 const ROLE_BURNER_PROFILE_UPDATED_ID = 2000010;
 
@@ -66,4 +67,4 @@ const profileUpdated = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default profileUpdated;
+export default withAuth(profileUpdated);

--- a/client/src/pages/api/volunteers/[shiftboardId]/sap/[sapId]/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/sap/[sapId]/index.ts
@@ -5,6 +5,7 @@ import { RowDataPacket } from "mysql2";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 
 const SAP_FILES_DIR = process.env.SAP_FILES_DIR ?? "/data/census/saps/";
 
@@ -62,4 +63,4 @@ const sapDownload = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default sapDownload;
+export default withAuth(sapDownload);

--- a/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IResVolunteerShiftItem } from "@/components/types/volunteers";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
 import {
   shiftVolunteerRemove,
   shiftVolunteerUpdate,
@@ -117,4 +118,4 @@ const volunteerShifts = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default volunteerShifts;
+export default withAuth(volunteerShifts);

--- a/client/src/utils/signOut.tsx
+++ b/client/src/utils/signOut.tsx
@@ -21,6 +21,14 @@ export const signOut = (
   worldName: string
 ) => {
   if (isAuthenticated) {
+    // Clear the server-side session cookie. Fire-and-forget — even if the
+    // request fails (offline, etc.) we still proceed with the client-side
+    // teardown so the user feels signed out.
+    fetch("/api/auth/sign-out", {
+      method: "POST",
+      credentials: "same-origin",
+    }).catch(() => {});
+
     developerModeDispatch({
       type: DEVELOPER_MODE_RESET,
     });


### PR DESCRIPTION
## ⚠️ Production hotfix

Filed in response to Chipper finding **unauthenticated PII exposure on prod** (https://volunteers.census.burningman.org/shifts/78/volunteers shows real playa + world names without login).

**Do NOT auto-merge.** This changes prod authentication behavior. CaptainMew gates the merge per usual.

## What's wrong on prod today

Auth is entirely **client-side** — `AuthGate` reads `sessionStorage` in React, server happily serves anyone. Result: **anyone with a URL can browse `/shifts/[id]/volunteers`, `/volunteers/[id]/account`, `/volunteers/[id]/info`, and the underlying `/api/*` endpoints, with no auth check.** Real names visible.

## What this PR does

Flips to **server-validated sessions** with belt-and-suspenders gating.

**New infrastructure:**
- `SESSION_SECRET` env var — HMAC key. **Must be set on every deployment.** Generate with `openssl rand -hex 32`. Different value per env.
- `client/src/lib/session.ts` — HMAC-signed cookie `census-session`, 1 hr expiry, `crypto.timingSafeEqual` for verify.
- `client/src/lib/withAuth.ts` — API handler wrapper, returns 401 on missing/invalid cookie.
- `client/src/middleware.ts` — Edge-runtime middleware gating everything except an explicit allowlist (sign-in, OAuth, contact, help, account creation, volunteer-dropdown, static). Unauth API → 401, unauth page → redirect to `/sign-in?returnTo=`. Edge runtime can't import Node crypto, so middleware does presence-only check; API layer does crypto verify.
- `client/src/pages/api/auth/sign-out.ts` — clears the cookie on logout.

**Cookie-setting:**
- `/api/sign-in` (passcode) sets the cookie on successful credential check.
- `/api/auth/okta/callback` (OAuth) sets the cookie on successful auth, after volunteer record is created/found.
- `signOut.tsx` calls `/api/auth/sign-out` before clearing client-side state.

**`withAuth` applied to high-risk endpoints:**
- `/api/shifts/[timeId]/volunteers` — the leak Chipper found.
- `/api/volunteers/[shiftboardId]/*` — IDOR risk (account, info, shifts, sap, passcode, other-sap, profile-updated).

## What's NOT in scope

- **Role-based authorization.** This is a "logged in or not" gate. Admin endpoints (notes update, role toggle, etc.) still need admin-role checks — that's the bigger work tracked in #237.
- **Reports stay public** per Mew's call.
- **Other `/api/*` endpoints** are protected by the middleware presence-check but not the API-layer crypto verify. A forged cookie value would pass middleware but be caught at the API layer once `withAuth` wraps every endpoint. Followup PRs to wrap the rest.
- **`/api/volunteers/dropdown` stays open** because passcode sign-in (test droplet, on-playa) needs it for autocomplete. PR #275 closes that vector for off-playa prod by hiding the dropdown when `PIN_ENABLED=false` — merge #275 alongside this hotfix to fully close the dropdown PII vector on prod.

## Deploy steps (when CaptainMew authorizes merge)

1. Set `SESSION_SECRET` on prod's `.env.production` (and the test droplet's), via `openssl rand -hex 32`. Different value per env.
2. Rebuild + restart container so the middleware is registered.
3. All existing sessions invalidate (sessionStorage-only sessions don't satisfy the cookie check). Users sign in again.

## Test plan

- [ ] Local: with `SESSION_SECRET` set, sign in via passcode → cookie present → /shifts/X/volunteers loads
- [ ] Local: clear cookie → /shifts/X/volunteers → redirected to /sign-in?returnTo=...
- [ ] Local: clear cookie → curl /api/shifts/X/volunteers → 401
- [ ] Local: forged cookie value → /api/shifts/X/volunteers → 401 (HMAC fail)
- [ ] Local: sign in via Okta → cookie present → page loads
- [ ] Local: sign-out clears the cookie
- [ ] Test droplet: dropdown still works on /sign-in (passcode autocomplete)
- [ ] Test droplet: end-to-end Okta still works
- [ ] Prod (post-merge): https://volunteers.census.burningman.org/shifts/78/volunteers → redirects to sign-in unauthenticated

## Reverting

If something breaks: `git revert` and restart. The cookie is httpOnly so won't pollute browser state long-term; the `SESSION_SECRET` env var can be left in place harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)