### PR TITLE
fix(api): 404 from /api/volunteers/[id]/account when volunteer not found

### DIFF
--- a/client/src/pages/api/volunteers/[shiftboardId]/account/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/account/index.ts
@@ -50,6 +50,12 @@ const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
         name: role,
       }));
       const [dbVolunteerFirst] = dbVolunteerList;
+      if (!dbVolunteerFirst) {
+        return res.status(404).json({
+          statusCode: 404,
+          message: "Volunteer not found",
+        });
+      }
       const resVolunteerItem: IResVolunteerAccount = {
         email: dbVolunteerFirst.email ?? "",
         emergencyContact: dbVolunteerFirst.emergency_contact ?? "",


### PR DESCRIPTION
## Why
Prod logs showed:
```
TypeError: Cannot read properties of undefined (reading 'email')
```
Triggered when a session referenced a `shiftboard_id` that no longer existed in `op_volunteers` (concretely: I had deleted a test account while the user's browser still held a session for it). The GET handler unconditionally dereferences `dbVolunteerFirst.email`, so the server 500s and the profile page breaks.

## What
Add the same 404 guard already present in `/api/volunteers/[id]/info`:
```ts
const [dbVolunteerFirst] = dbVolunteerList;
if (!dbVolunteerFirst) {
  return res.status(404).json({ statusCode: 404, message: "Volunteer not found" });
}
```

## Test plan
- [ ] Hitting `/api/volunteers/9999999/account` (a non-existent id) returns 404, not 500
- [ ] Existing accounts still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)