### PR TITLE
feat(vip): mockup parity bundle — UI polish

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import {
-  CheckCircle as CheckCircleIcon,
+  CheckBox as CheckBoxIcon,
+  CheckBoxOutlineBlank as CheckBoxOutlineBlankIcon,
   Download as DownloadIcon,
   ExpandMore as ExpandMoreIcon,
   LockReset as LockResetIcon,
   OpenInNew as OpenInNewIcon,
-  RadioButtonUnchecked as RadioButtonUncheckedIcon,
   RateReview as RateReviewIcon,
   VerifiedUser as VerifiedUserIcon,
 } from "@mui/icons-material";
@@ -496,20 +496,9 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
       content: (
         <Box>
           <Typography sx={{ mb: 1 }}>
-            Complete all required training courses on the Census Hive community
-            page.
+            Complete each required training course on Census Hive. Click a
+            course name below to open it.
           </Typography>
-          <Button
-            component="a"
-            href="https://hive.burningman.org/spaces/14264554"
-            rel="noopener noreferrer"
-            startIcon={<OpenInNewIcon />}
-            sx={{ mb: 2 }}
-            target="_blank"
-            variant="text"
-          >
-            Go to Census Training on Hive
-          </Button>
           {trainings.map((t) => (
             <Stack
               alignItems="center"
@@ -519,14 +508,31 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
               sx={{ py: 0.5 }}
             >
               {t.completed ? (
-                <CheckCircleIcon color="success" fontSize="small" />
+                <CheckBoxIcon color="success" fontSize="small" />
               ) : (
-                <RadioButtonUncheckedIcon
-                  sx={{ color: theme.palette.error.main }}
+                <CheckBoxOutlineBlankIcon
+                  sx={{ color: theme.palette.secondary.main }}
                   fontSize="small"
                 />
               )}
-              <Typography variant="body2">{t.trainingName}</Typography>
+              {t.completed || !t.url ? (
+                <Typography variant="body2">{t.trainingName}</Typography>
+              ) : (
+                <Typography
+                  component="a"
+                  href={t.url}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  variant="body2"
+                  sx={{
+                    color: theme.palette.secondary.main,
+                    fontWeight: 500,
+                    textDecoration: "underline",
+                  }}
+                >
+                  {t.trainingName}
+                </Typography>
+              )}
               <Typography
                 color="text.secondary"
                 variant="body2"
@@ -595,10 +601,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
           <Stack spacing={0.5}>
             <Stack alignItems="center" direction="row" spacing={1}>
               {sapStatus.cspFulfilled ? (
-                <CheckCircleIcon color="success" fontSize="small" />
+                <CheckBoxIcon color="success" fontSize="small" />
               ) : (
-                <RadioButtonUncheckedIcon
-                  sx={{ color: theme.palette.error.main }}
+                <CheckBoxOutlineBlankIcon
+                  sx={{ color: theme.palette.secondary.main }}
                   fontSize="small"
                 />
               )}
@@ -617,10 +623,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                 spacing={1}
               >
                 {day.fulfilled ? (
-                  <CheckCircleIcon color="success" fontSize="small" />
+                  <CheckBoxIcon color="success" fontSize="small" />
                 ) : (
-                  <RadioButtonUncheckedIcon
-                    sx={{ color: theme.palette.error.main }}
+                  <CheckBoxOutlineBlankIcon
+                    sx={{ color: theme.palette.secondary.main }}
                     fontSize="small"
                   />
                 )}
@@ -841,7 +847,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
             {/* camping location */}
             <Box>
               <Typography sx={{ mb: 0.5 }} variant="subtitle2">
-                Where will you be camping?
+                Tell us about where you will be camping
               </Typography>
               <TextField
                 defaultValue={volunteer.location}
@@ -866,6 +872,33 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
               Census Volunteer Pre-playa Checklist
             </Typography>
 
+            {/* color/status legend */}
+            <Stack
+              direction="row"
+              spacing={3}
+              sx={{
+                mb: 2,
+                py: 1,
+                px: 2,
+                bgcolor: "rgba(0,0,0,0.02)",
+                borderRadius: 1,
+                fontSize: "0.875rem",
+                color: "text.secondary",
+              }}
+            >
+              <Stack alignItems="center" direction="row" spacing={0.5}>
+                <CheckBoxOutlineBlankIcon
+                  sx={{ color: theme.palette.secondary.main }}
+                  fontSize="small"
+                />
+                <Typography variant="caption">Action needed</Typography>
+              </Stack>
+              <Stack alignItems="center" direction="row" spacing={0.5}>
+                <CheckBoxIcon color="success" fontSize="small" />
+                <Typography variant="caption">Completed</Typography>
+              </Stack>
+            </Stack>
+
             {/* CSP bar */}
             {showCspBar && (
               <Alert severity="info" sx={{ mb: 2 }}>
@@ -884,6 +917,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
               incompleteItems.map((item) => (
                 <Accordion
                   key={item.id}
+                  defaultExpanded
                   sx={{
                     "&:before": { display: "none" },
                     boxShadow: "none",
@@ -893,8 +927,8 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                 >
                   <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                     <Stack alignItems="center" direction="row" spacing={1}>
-                      <RadioButtonUncheckedIcon
-                        sx={{ color: theme.palette.error.main }}
+                      <CheckBoxOutlineBlankIcon
+                        sx={{ color: theme.palette.secondary.main }}
                         fontSize="small"
                       />
                       <Typography>{item.label}</Typography>
@@ -920,7 +954,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                 >
                   <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                     <Stack alignItems="center" direction="row" spacing={1}>
-                      <CheckCircleIcon color="success" fontSize="small" />
+                      <CheckBoxIcon color="success" fontSize="small" />
                       <Typography>
                         View {completedItems.length} completed item
                         {completedItems.length > 1 ? "s" : ""}
@@ -943,7 +977,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                             direction="row"
                             spacing={1}
                           >
-                            <CheckCircleIcon color="success" fontSize="small" />
+                            <CheckBoxIcon color="success" fontSize="small" />
                             <Typography>{item.label}</Typography>
                           </Stack>
                         </AccordionSummary>


### PR DESCRIPTION
## Summary

Brings the live `/volunteers/[id]/info` page in line with v5 mockup (`specs/mockup-vip.html`) for the smaller-effort items Mew approved on 2026-05-04 + 2026-05-09. Larger items (passcode reveal, SAP top banner, read-only mode, lead training) are intentionally separate PRs.

Targets the `census/vip-page` branch since this is a continuation of the VIP page work, keeping the diff scoped to the polish changes themselves.

## Five surgical changes

### 1. Per-course training links (mockup parity item 1)

Replaces the single "Go to Census Training on Hive" community button with per-course links sourced from `op_trainings.url` (already returned by `/api/volunteers/[id]/info`). The training name itself becomes the link, styled in Census pink. Completed courses render as plain text since the link is no longer actionable.

Approved by Mew 2026-05-04. Cross-reference: issue #290 tracks the actual 2026 URL update in the `op_trainings` table — that's a separate data change.

### 2. Hot pink open box / green check indicators (item 2)

Replaces MUI's circle-shaped status icons (`RadioButtonUnchecked` in red + `CheckCircle` in green) with square checkbox-shape icons (`CheckBoxOutlineBlank` in Census pink + `CheckBox` in green). Matches the v5 mockup's `.vbox` style. Reduces "you failed" anxiety per Chipper's 2026-04-23 UX feedback that drove the pink/green palette decision.

Approved by Mew 2026-04-24 (initial) + 2026-05-04 (extended to live page).

### 3. Default-expanded for incomplete checklist items (item 5)

Adds `defaultExpanded` to the incomplete-items Accordion. Mew's reasoning 2026-05-04: *"if you don't know to click, you don't know to click."* Completed items still collapse into the "View N completed items" toggle below, preserving Chipper's less-overwhelming-list goal.

Approved by Mew 2026-05-04 + reaffirmed 2026-05-09.

### 4. Color/status legend (item 10, approved 2026-05-09)

Small key row above the checklist showing pink-open-box = "Action needed" and green-check = "Completed". Helps first-time volunteers parse the visual indicators (Woodie's 2026-04-27 suggestion).

### 5. Camping label wording (item 11, approved 2026-05-09)

`Where will you be camping?` → `Tell us about where you will be camping`. Woodie's more conversational phrasing (2026-04-27).

## Test plan

- [ ] Visit `/volunteers/<id>/info` as an authenticated volunteer
- [ ] Color/status legend visible directly under "Census Volunteer Pre-playa Checklist"
- [ ] Incomplete items render expanded on page load (no extra click needed)
- [ ] Completed items still collapse into "View N completed items"
- [ ] Pink open square (square, not circle) on incomplete items; green filled checkbox on completed
- [ ] Training section: each course name is clickable, opens its specific Hive URL in a new tab
- [ ] Camping field label reads "Tell us about where you will be camping"
- [ ] Type-check clean (verified)

## Out of scope (intentional)

- Updating `op_trainings.url` rows to 2026 Hive course URLs — tracked in issue #290
- Passcode reveal/hide UI (mockup parity item 3) — separate PR
- SAP top banner (item 4) — separate PR
- Read-only mode banner + env flag (item 6) — separate PR
- Lead Training section (item 7) — separate PR
- OAuth 1hr session timeout (item 8) — separate PR
- `legalname` scope (item 9) — separate PR
- Auth-gate hotfix (PR #288) — landing first, this depends on it for prod

## Deploy

No new env vars. No DB changes. Standard rebuild + restart on whichever environments pull in `census/vip-page` (currently `deploy/test-bundle` once merged into the chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)