### PR TITLE
fix(dates): return MySQL DATE as strings to stop tz day-shift

### DIFF
--- a/client/lib/database.ts
+++ b/client/lib/database.ts
@@ -4,6 +4,12 @@ import mysql from "mysql2";
 // transport. Local docker DB on test/playa boxes leaves it unset.
 const sslOption = process.env.MYSQL_SSL ? { ssl: "Amazon RDS" } : {};
 
+// dateStrings: return DATE/DATETIME columns as "YYYY-MM-DD" strings instead of
+// JS Date objects pinned to UTC midnight. Without this, a DATE value like
+// 2026-08-25 arrives as 2026-08-25T00:00:00Z and dayjs renders it in the
+// browser's local zone — west-of-UTC browsers see Aug 24, and re-saving writes
+// the shifted day back to the DB.
+
 // Pool wedge avoidance — observed on prod 2026-05-13 and 2026-05-17:
 // after a few days the pool starts returning ETIMEDOUT on every query
 // even though a fresh mysql.createConnection() to the same host works.
@@ -30,6 +36,7 @@ export const pool = mysql
   .createPool({
     connectionLimit: 10,
     database: process.env.MYSQL_DATABASE,
+    dateStrings: true,
     enableKeepAlive: true,
     host: process.env.MYSQL_HOST,
     idleTimeout: 60_000,


### PR DESCRIPTION
## Summary

The `/dates` update dialog displays the day before what's stored in the DB on west-of-UTC browsers, and re-saving without re-picking silently writes the shifted day back. Root cause: mysql2 returns `DATE` columns as JS `Date` objects pinned to UTC midnight; `dayjs(value)` then renders them in the browser's local zone.

- Pacific browser: DB `2026-08-25` → `2026-08-25T00:00:00Z` → dayjs renders as Aug 24 5pm local → DatePicker shows **Aug 24**.
- UTC runtime: no shift, which is why this didn't reproduce on the test container.

Setting `dateStrings: true` on the pool returns DATE/DATETIME as plain `"YYYY-MM-DD"` strings; dayjs parses them in local time, no math, no shift. One-line config change, fixes every DATE-column flow at once.

## Risk

Any code that calls Date-object methods on these fields (`.getTime()`, `.toISOString()`, `instanceof Date`) would now hit a string. I grep'd the entire client tree — **zero callsites**. All date rendering goes through dayjs / the `formatDate*` helpers in `client/src/utils/formatDateTime.ts`, which accept strings.

## Test plan

- [ ] Pull, build locally, open `/dates`, edit a row — DatePicker should show the *actual* DB date, not one day earlier.
- [ ] Change the date, save, reload — value persists exactly as picked.
- [ ] Sanity-check other date surfaces: shifts list, account page shift history — dates should match what's in the DB unchanged.
- [ ] Confirm Playwright E2E suite still green (\`npx playwright test --config=e2e/playwright.config.ts\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)