### PR TITLE
ci: gate merges on /sign-in + /api/auth/okta regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - deploy/test-bundle
+
+# Cancel any in-flight run for the same ref when a new commit lands.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ci-root-password
+          MYSQL_DATABASE: census
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -pci-root-password"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      # App pool config — what the running Next.js dev server reads.
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_DATABASE: census
+      MYSQL_USER: root
+      MYSQL_PASSWORD: ci-root-password
+      # e2e helpers' direct DB writes
+      TEST_MYSQL_HOST: 127.0.0.1
+      TEST_MYSQL_DATABASE: census
+      TEST_MYSQL_USER: root
+      TEST_MYSQL_PASSWORD: ci-root-password
+      # Okta config — dummy issuer; tests assert /api/auth/okta builds the
+      # right 302 against whatever issuer is configured, no real network call.
+      NEXT_PUBLIC_OKTA_ENABLED: "true"
+      NEXT_PUBLIC_PIN_ENABLED: "true"
+      OKTA_CLIENT_ID: ci-test-client-id
+      OKTA_CLIENT_SECRET: ci-test-client-secret
+      OKTA_ISSUER: https://test-okta.example.com/oauth2/default
+      OKTA_REDIRECT_URI: http://localhost:3000/api/auth/okta/callback
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: client/yarn.lock
+
+      - name: Activate yarn 1.22.22 via corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Wait for MySQL to be ready
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -pci-root-password --silent; then
+              echo "MySQL is up"
+              exit 0
+            fi
+            echo "Waiting for MySQL... ($i/30)"
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          exit 1
+
+      - name: Load schema
+        run: |
+          mysql -h 127.0.0.1 -P 3306 -uroot -pci-root-password census \
+            < database/scheduler_schema.sql
+
+      - name: Install client dependencies
+        working-directory: client
+        run: yarn install --frozen-lockfile
+
+      # NOTE: lint is intentionally omitted. The `yarn lint` script invokes
+      # `next lint`, which Next.js 16 removed. Repairing the lint pipeline is
+      # out of scope for this PR — see issue #294 follow-ups.
+
+      - name: Install Playwright browsers (chromium)
+        working-directory: client
+        run: npx playwright install --with-deps chromium
+
+      # First CI gate: just the sign-in regression spec (issue #294).
+      # Expanding to the full suite is a follow-up — some specs depend on
+      # data shapes we haven't validated against a fresh schema-only seed.
+      - name: Run sign-in regression spec
+        working-directory: client
+        run: npx playwright test --config=e2e/playwright.config.ts e2e/tests/19-okta-signin-regression.spec.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: client/playwright-report/
+          retention-days: 7

--- a/client/e2e/playwright.config.ts
+++ b/client/e2e/playwright.config.ts
@@ -32,5 +32,22 @@ export default defineConfig({
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    // Defaults let the Okta sign-in regression tests run without external
+    // setup. Real deployments override these via .env.production. Tests
+    // never hit a real Okta tenant — they only assert that /api/auth/okta
+    // builds the correct 302 against whatever issuer is configured.
+    env: {
+      NEXT_PUBLIC_OKTA_ENABLED:
+        process.env.NEXT_PUBLIC_OKTA_ENABLED ?? "true",
+      NEXT_PUBLIC_PIN_ENABLED:
+        process.env.NEXT_PUBLIC_PIN_ENABLED ?? "true",
+      OKTA_CLIENT_ID: process.env.OKTA_CLIENT_ID ?? "test-client-id",
+      OKTA_ISSUER:
+        process.env.OKTA_ISSUER ??
+        "https://test-okta.example.com/oauth2/default",
+      OKTA_REDIRECT_URI:
+        process.env.OKTA_REDIRECT_URI ??
+        "http://localhost:3000/api/auth/okta/callback",
+    },
   },
 });

--- a/client/e2e/tests/19-okta-signin-regression.spec.ts
+++ b/client/e2e/tests/19-okta-signin-regression.spec.ts
@@ -1,0 +1,96 @@
+// Regression net for the sign-in path. Motivated by the 2026-05-13 prod
+// outage where `/sign-in` rendered the generic ErrorAlert because
+// `/api/volunteers/dropdown` returned 500 (wedged mysql2 pool), so the
+// Okta button never appeared. These tests assert the pieces that would
+// catch that class of failure before merge.
+//
+// See issue #294 for scope.
+
+import { test, expect, request } from "@playwright/test";
+
+import { closePool, cleanupAllTestData, insertVolunteer } from "../helpers/db";
+import { IDS, makeTestVolunteer } from "../fixtures/test-data";
+
+const seedVolunteer = makeTestVolunteer({
+  shiftboardId: IDS.volunteer1,
+  playaName: "E2E OktaProbe",
+  worldName: "Okta Probe",
+  email: "e2e-okta@test.local",
+  passcode: "0000",
+});
+
+test.describe("Sign-in regression net", () => {
+  test.beforeAll(async () => {
+    await cleanupAllTestData();
+    await insertVolunteer(seedVolunteer);
+  });
+
+  test.afterAll(async () => {
+    await cleanupAllTestData();
+    await closePool();
+  });
+
+  test("/sign-in renders the Okta button wired to /api/auth/okta", async ({
+    page,
+  }) => {
+    // Generous overall budget: Next.js dev server JIT-compiles the route on
+    // first hit, which can take 20s+ on a cold CI runner.
+    test.setTimeout(60_000);
+
+    await page.goto("/sign-in", { waitUntil: "networkidle", timeout: 45_000 });
+
+    const oktaButton = page.getByRole("link", {
+      name: /Sign in with Burning Man/i,
+    });
+    await expect(oktaButton).toBeVisible({ timeout: 15_000 });
+
+    const href = await oktaButton.getAttribute("href");
+    expect(href).toBe("/api/auth/okta");
+  });
+
+  test("/api/volunteers/dropdown returns a non-empty array", async ({
+    request: req,
+  }) => {
+    const res = await req.get("/api/volunteers/dropdown");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  test("/api/auth/okta returns a well-formed 302 to an authorize endpoint", async () => {
+    // own request context with redirect-following disabled so we can inspect
+    // the 302 itself
+    const ctx = await request.newContext({
+      baseURL: "http://localhost:3000",
+    });
+    const res = await ctx.fetch("/api/auth/okta", {
+      maxRedirects: 0,
+    });
+    await ctx.dispose();
+
+    expect(res.status()).toBe(302);
+
+    const location = res.headers()["location"];
+    expect(location).toBeTruthy();
+
+    // Shape check — don't pin the issuer value, since it differs between
+    // local .env.local, CI defaults, and real prod. Just assert the URL is
+    // well-formed and the OIDC params we control are all present.
+    const url = new URL(location!);
+    expect(url.protocol).toMatch(/^https?:$/);
+    expect(url.host).not.toBe("");
+    expect(url.pathname).toMatch(/\/v1\/authorize$/);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBeTruthy();
+    expect(url.searchParams.get("redirect_uri")).toBeTruthy();
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(url.searchParams.get("state")).toBeTruthy();
+
+    // CSRF state cookie should be set on the response
+    const setCookie = res.headers()["set-cookie"] ?? "";
+    expect(setCookie).toContain("oauth_state=");
+  });
+});


### PR DESCRIPTION
Closes #294 (the regression-test side; branch protection toggle in repo settings is a separate manual step after merge).

## Why

On 2026-05-13 prod sign-in (`https://volunteers.census.burningman.org/sign-in`) was unreachable for an unknown window: `GET /api/volunteers/dropdown` was returning 500 after a 10s timeout (wedged mysql2 pool), so the sign-in page rendered the generic ErrorAlert and the Okta button never appeared. This PR adds the regression net that would have caught the page-broken side of that incident, plus CI wiring to actually block merges on it.

Per @johnwoodell's ask, signed off by @mbhewitt.

## What

### Regression test — `client/e2e/tests/19-okta-signin-regression.spec.ts`

Three assertions:

1. **`/sign-in` renders the Okta button wired to `/api/auth/okta`.** The "Sign in with Burning Man" link is present and `href="/api/auth/okta"`. Catches "the page failed to render" — the exact symptom from 2026-05-13.
2. **`/api/volunteers/dropdown` returns 200 with a non-empty array.** Catches the wedged-pool / DB-down failure that broke sign-in indirectly.
3. **`/api/auth/okta` returns a well-formed 302** to an authorize endpoint with the OIDC params we control (`response_type`, `client_id`, `redirect_uri`, PKCE `code_challenge` + `code_challenge_method=S256`, `state`) and sets the `oauth_state` CSRF cookie. Issuer value is *not* pinned — the same assertion works against local `.env.local`, CI dummy creds, and prod.

### CI workflow — `.github/workflows/ci.yml`

- Triggers on every PR and on pushes to `main` and `deploy/test-bundle`.
- `mysql:8.0` service container, seeded with `database/scheduler_schema.sql`.
- Node 22 + yarn 1.22.22 via corepack — matches the prod Dockerfile.
- Runs only the new regression spec for now (see "follow-ups" below).
- Uploads the Playwright HTML report as an artifact on failure.

### Playwright config — `client/e2e/playwright.config.ts`

Adds dummy Okta env defaults (`NEXT_PUBLIC_OKTA_ENABLED=true`, `OKTA_CLIENT_ID=test-client-id`, etc.) to the spawned dev server. Lets the suite run anywhere without a real Okta tenant or `.env.local` present. Real deployments still override via their own env files.

## Why `deploy/test-bundle` as base

Prod runs from `deploy/test-bundle`, which has the Okta endpoints (#263) and the e2e suite (#261) merged. `main` doesn't have either yet, so a test targeting `main` couldn't reference the Okta button (it doesn't exist on that branch). When #263 + #261 land on `main`, this CI workflow comes with them and starts gating PRs there too.

## Manual step after merge

The acceptance criterion in #294 says a failing CI must *block merge*. The workflow file makes the check exist; flipping branch protection to require it is a Settings → Branches → Protect `main` / `deploy/test-bundle` toggle that has to be done in the GitHub UI. **Not in scope for this PR — needs @mbhewitt to flip it.**

## Follow-ups (separate issues if pursued)

- Repair `client/package.json` `lint` script: `next lint` was removed in Next.js 16, the script is stale. CI deliberately doesn't run lint as a result.
- Expand CI to run the full Playwright suite (not just the regression spec). Some specs depend on data shapes that need validation against a schema-only seed.
- Investigate the underlying mysql2 pool wedge that caused the 2026-05-13 incident (`enableKeepAlive`, idle timeout, health probe).

## Test plan

- [x] Local: `npx playwright test --config=e2e/playwright.config.ts e2e/tests/19-okta-signin-regression.spec.ts` — all 3 pass.
- [ ] CI: this PR's own workflow run should be green.
- [ ] Negative-control: temporarily break `/api/auth/okta` (e.g. remove the `OKTA_CLIENT_ID` env), confirm CI goes red.
- [ ] After merge: confirm branch-protection toggle is flipped on `main` + `deploy/test-bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)