### PR TITLE
fix(mysql): cap maxIdle so the pool reaper runs, evict idle sockets

### DIFF
--- a/client/lib/database.ts
+++ b/client/lib/database.ts
@@ -4,11 +4,37 @@ import mysql from "mysql2";
 // transport. Local docker DB on test/playa boxes leaves it unset.
 const sslOption = process.env.MYSQL_SSL ? { ssl: "Amazon RDS" } : {};
 
+// Pool wedge avoidance — observed on prod 2026-05-13 and 2026-05-17:
+// after a few days the pool starts returning ETIMEDOUT on every query
+// even though a fresh mysql.createConnection() to the same host works.
+// Root cause: mysql2's idle-connection reaper only runs when
+// maxIdle < connectionLimit (see lib/base/pool.js constructor). With
+// the defaults, idle pool sockets sit forever and eventually get killed
+// server-side by RDS wait_timeout (8h default). mysql2 hands those dead
+// sockets back out on the next query — ETIMEDOUT.
+//
+//   maxIdle: 5            — strictly less than connectionLimit so the
+//                           reaper actually runs.
+//   idleTimeout: 60_000   — kill idle sockets after 60s. Well under any
+//                           RDS / NAT / LB idle window we'd plausibly hit.
+//   enableKeepAlive: true — default in mysql2 3.x, made explicit so the
+//                           intent is obvious in code review.
+//   keepAliveInitialDelay: 10_000
+//                         — first TCP keep-alive probe after 10s of
+//                           socket inactivity. Default 0 falls back to
+//                           the OS default (Linux: 2h before first
+//                           probe), which is too late to surface a
+//                           dead connection before the next query.
+
 export const pool = mysql
   .createPool({
     connectionLimit: 10,
     database: process.env.MYSQL_DATABASE,
+    enableKeepAlive: true,
     host: process.env.MYSQL_HOST,
+    idleTimeout: 60_000,
+    keepAliveInitialDelay: 10_000,
+    maxIdle: 5,
     password: process.env.MYSQL_PASSWORD,
     user: process.env.MYSQL_USER,
     ...sslOption,


### PR DESCRIPTION
Permanent fix for the recurring prod sign-in outages on 2026-05-13 and 2026-05-17.

## What broke

Both incidents: container had been up for days, `GET /api/volunteers/dropdown` started returning 500 after a ~10s timeout, sign-in page rendered the generic ErrorAlert. A `docker compose restart` healed it each time. A fresh `mysql.createConnection()` from inside the same container worked fine — so it wasn't creds / SG / SSL / RDS, the pool itself was the problem.

## Root cause

mysql2's idle-connection reaper only runs **when `maxIdle < connectionLimit`**. The check is one-shot at pool creation:

```js
// node_modules/mysql2/lib/base/pool.js, constructor
if (this.config.maxIdle < this.config.connectionLimit) {
  this._removeIdleTimeoutConnections();
}
```

Defaults: `maxIdle === connectionLimit` (both 10), so the reaper **never starts**. Pool sockets sit idle indefinitely, eventually get killed server-side by RDS `wait_timeout` (8h default), and mysql2 hands the dead sockets back out on the next query — `ETIMEDOUT`. Three days between incidents is consistent with that.

## Fix

| option | new value | why |
|---|---|---|
| `maxIdle` | `5` | strictly less than `connectionLimit`, so the reaper actually runs |
| `idleTimeout` | `60_000` (60s) | destroy idle sockets long before any RDS / NAT / LB idle window |
| `enableKeepAlive` | `true` | already the mysql2 3.x default; explicit so the intent is obvious in review |
| `keepAliveInitialDelay` | `10_000` (10s) | default `0` falls back to OS default (Linux: 2h before first probe), too late to surface a dead connection. 10s probes catch dead sockets fast |

Defense in depth: the reaper kills idle sockets long before they go stale, and TCP keep-alive surfaces any that survive.

## Why `deploy/test-bundle` as base

Same reason as #293 and #295 — prod runs from `deploy/test-bundle`, and that's what needs the fix. When `main` catches up, this comes along with it.

## Risk

Pool turnover goes up slightly (idle sockets recycled after 60s instead of held forever). Trivial overhead — a few connection handshakes per minute under steady traffic. No behavior change on the request path.

## Test plan

- [ ] CI passes (the regression spec on PR #295 hits this same pool indirectly via `/api/volunteers/dropdown`).
- [ ] Negative-control locally: set `maxIdle: 0` and confirm the dropdown still works (every query opens a fresh conn).
- [ ] Deploy to prod, leave it for >72h, confirm `/api/volunteers/dropdown` does not wedge.

## Out of scope

- A `SELECT 1` health probe before handing a connection out. This PR aims to *prevent* the dead-connection scenario; a health probe would *detect* one that somehow slipped through. Worth filing separately if we see another wedge despite this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)