### PR TITLE
fix(shifts): set start_date_id / end_date_id on insert and update

### DIFF
--- a/client/src/pages/api/shifts/types/[typeId]/index.ts
+++ b/client/src/pages/api/shifts/types/[typeId]/index.ts
@@ -258,21 +258,28 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
 
       timeListUpdate.forEach(
         async ({ endTime, timeId, instance, meal, notes, startTime }) => {
+          // Refresh start_date_id / end_date_id alongside the start_time /
+          // end_time change — a date edit must update the FK or downstream
+          // joins keep pointing at the old date row. See [[fix-handleTimeListAdd]].
           await pool.query<RowDataPacket[]>(
             `UPDATE op_shift_times
             SET
+              end_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
               end_time=?,
               meal=?,
               notes=?,
               update_shift_time=true,
               shift_instance=?,
+              start_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
               start_time=?
             WHERE shift_times_id=?`,
             [
               endTime,
+              endTime,
               meal === "None" ? "" : meal,
               notes,
               instance,
+              startTime,
               startTime,
               timeId,
             ]

--- a/client/src/pages/api/shifts/types/index.ts
+++ b/client/src/pages/api/shifts/types/index.ts
@@ -26,19 +26,33 @@ export const handleTimeListAdd = async ({
         FROM op_shift_times`
       );
 
+      // start_date_id / end_date_id are FK lookups into op_dates by the
+      // calendar date portion of start_time / end_time. Every downstream
+      // query (/api/shifts, /api/shifts/types/[typeId], /api/shifts/[timeId]/
+      // volunteers, etc.) JOINs op_dates via these FKs to get the date label,
+      // so a row without them shows up as an orphan with NULL date/datename.
+      // Missing date matches resolve to NULL — same as the old behavior.
       await pool.query(
         `INSERT INTO op_shift_times (
           add_shift_time,
+          end_date_id,
           end_time,
           meal,
           notes,
           shift_instance,
           shift_name_id,
           shift_times_id,
+          start_date_id,
           start_time
         )
-        VALUES (true, ?, ?, ?, ?, ?, ?, ?)`,
-        [endTime, meal, notes, instance, typeId, timeIdNew, startTime]
+        VALUES (
+          true,
+          (SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
+          ?, ?, ?, ?, ?, ?,
+          (SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
+          ?
+        )`,
+        [endTime, endTime, meal, notes, instance, typeId, timeIdNew, startTime, startTime]
       );
 
       positionList.forEach(async ({ alias, positionId, sapPoints, slots }) => {


### PR DESCRIPTION
## Why

Yesterday's prod shifts dump turned up two rows with `date_id = NULL` — `Data Entry / "I see"` and `Tech Support / "5"`, both visibly UI-created test entries. Tracing back: `handleTimeListAdd` and the `[typeId]` PATCH `timeListUpdate` both wrote `op_shift_times` rows without touching `start_date_id` / `end_date_id`.

Every downstream query joins `op_dates` through those FKs to get the date label:

- `/api/shifts`
- `/api/shifts/types/[typeId]`
- `/api/shifts/[timeId]/volunteers`
- `/api/dates/[dateId]/shift-times`
- `/api/shifts/types/[typeId]/positions/[positionId]/times`
- `/api/volunteers/[shiftboardId]/shifts`
- `/api/volunteers/[shiftboardId]/info`

So any shift added through the UI disappears from `/shifts` and looks orphaned everywhere else.

## Fix

In both the INSERT and the UPDATE, look up `op_dates.date_id` by the calendar-date portion of the corresponding datetime and write it into `start_date_id` / `end_date_id`. Inline subquery so it's atomic. Missing match resolves to NULL — same as the silent-failure behavior the code had before, but the common case (date already exists in `op_dates`) now produces a correctly-joined row.

UPDATE path picks up the same lookup so editing a shift's date doesn't strand the FK pointing at the old date row.

## Risk

- `op_dates` lookup is per-row, but timeList inserts are small (handful of rows max), so no measurable perf impact.
- If a user picks a date that doesn't exist in `op_dates`, the resulting row will have NULL FKs and won't appear in `/shifts`. This matches today's behavior — not a regression. Worth a separate UX improvement (block the form on unknown dates) but out of scope here.

## Out of scope

- **Backfill** of the two existing orphan rows in prod (`shift_times_id 537577` and `959655`). Either delete as cruft or backfill manually with the right `date_id`. Will surface as a follow-up question once this lands.

## Test plan

- [ ] CI passes (the regression spec on `main` doesn't exercise this codepath but linting and the broader build do).
- [ ] After deploy: add a time to a shift type via the UI, confirm it appears on `/shifts` with the right date/datename.
- [ ] Edit an existing shift's date via the UI, confirm `/shifts` reflects the new date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)