### PR TITLE
feat(middleware): keep /shifts open on-playa, gated off-playa

### DIFF
--- a/client/e2e/tests/20-on-playa-shifts-open.spec.ts
+++ b/client/e2e/tests/20-on-playa-shifts-open.spec.ts
@@ -1,0 +1,28 @@
+// On-playa walk-up volunteers need to see /shifts without a session.
+// Off-playa keeps it gated by the hotfix #288 middleware.
+// The test dev server runs with NEXT_PUBLIC_PIN_ENABLED="true" (on-playa
+// default in client/e2e/playwright.config.ts), so this exercises the
+// on-playa branch of the conditional allowlist.
+
+import { test, expect, request } from "@playwright/test";
+
+test.describe("On-playa: /shifts is reachable without a session", () => {
+  test("GET /shifts returns 200, no redirect to /sign-in", async () => {
+    const ctx = await request.newContext({
+      baseURL: "http://localhost:3000",
+    });
+    const res = await ctx.fetch("/shifts", { maxRedirects: 0 });
+    await ctx.dispose();
+
+    // Middleware would 307-redirect to /sign-in if it were gating this path.
+    expect(res.status()).toBe(200);
+  });
+
+  test("GET /api/shifts returns 200 (not 401)", async ({ request: req }) => {
+    const res = await req.get("/api/shifts");
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+});

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -17,6 +17,13 @@ const SESSION_COOKIE_NAME = "census-session";
 // This is a stopgap. The proper fix is per-route role-based authorization
 // (issue #237). For now: block the obvious enumeration paths.
 
+// On-playa deployments (passcode UI enabled) leave /shifts open so a
+// walk-up volunteer with no session can see what's available without
+// signing in. Off-playa (Okta-only, PIN_ENABLED=false) keeps it gated.
+// NEXT_PUBLIC_* is inlined at build time, so this is a static decision
+// per deployment.
+const isOnPlaya = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
+
 const ALLOWLIST = [
   // Sign-in surface (must be reachable while unauthenticated)
   "/sign-in",
@@ -46,6 +53,9 @@ const ALLOWLIST = [
   "/general",
   "/help/",
   "/reports/",
+
+  // On-playa only: walk-up shifts view
+  ...(isOnPlaya ? ["/shifts", "/api/shifts"] : []),
 ];
 
 const PUBLIC_PATHS = new Set(["/"]);


### PR DESCRIPTION
Closes #298.

## Why

Hotfix #288 gates everything-except-allowlist on the `census-session` cookie. That closes the off-playa info-leak (Okta-only deployments) but also blocks walk-up volunteers on the playa tablet from seeing the public shifts board.

Per @mbhewitt's 2026-05-23 direction: shifts behind the login only for off-playa.

## Fix

Add `/shifts` and `/api/shifts` to the middleware allowlist *conditionally* when `NEXT_PUBLIC_PIN_ENABLED` is not `"false"` (the on-playa default). Off-playa builds explicitly set `NEXT_PUBLIC_PIN_ENABLED="false"` and keep `/shifts` gated as it is today. `NEXT_PUBLIC_*` inlines at build time, so this is a static per-deployment decision and no runtime overhead.

## Tests

- New e2e: `client/e2e/tests/20-on-playa-shifts-open.spec.ts` — asserts `/shifts` (page) and `/api/shifts` (API) return 200 without a session, under the on-playa default env that the Playwright config already sets.
- Existing sign-in regression spec (#19) still passes — unchanged code path.

## Off-playa coverage (not in this PR)

The off-playa-gated case is implicitly covered by the existing middleware (anything not on the allowlist gets redirected). An explicit e2e test for it would need a second dev-server config with `NEXT_PUBLIC_PIN_ENABLED="false"` — worth doing but separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)