### PR TITLE
feat(vip): redirect /account to /info, repoint all volunteer links

### DIFF
--- a/client/e2e/tests/21-account-redirects-to-info.spec.ts
+++ b/client/e2e/tests/21-account-redirects-to-info.spec.ts
@@ -1,0 +1,33 @@
+// /volunteers/[id]/account is the legacy URL; canonical is now /info.
+// This test asserts the server-side redirect chain.
+//
+// Note: middleware gates /volunteers/* by default (hotfix #288), so an
+// unauthenticated request to /account first redirects to /sign-in (with
+// returnTo=/volunteers/X/account). We follow that and assert the chain
+// ends at /sign-in for the unauth case — the redirect-to-/info path runs
+// post-auth, which the existing sign-in test covers via the okta callback.
+
+import { test, expect, request } from "@playwright/test";
+
+test.describe("/volunteers/[id]/account redirects to /info", () => {
+  test("unauth hit goes through /sign-in (middleware) before any redirect", async () => {
+    const ctx = await request.newContext({
+      baseURL: "http://localhost:3000",
+    });
+    const res = await ctx.fetch("/volunteers/9999999/account", {
+      maxRedirects: 0,
+    });
+    await ctx.dispose();
+
+    // Middleware sends 307 to /sign-in with returnTo preserving the
+    // ORIGINAL /account URL (so post-auth landing still hits the page,
+    // which then issues the /account → /info redirect).
+    expect(res.status()).toBe(307);
+    const location = res.headers()["location"]!;
+    expect(location).toContain("/sign-in");
+    expect(location).toContain("returnTo=");
+    expect(decodeURIComponent(location)).toContain(
+      "/volunteers/9999999/account"
+    );
+  });
+});

--- a/client/src/app/auth/complete/AuthComplete.tsx
+++ b/client/src/app/auth/complete/AuthComplete.tsx
@@ -58,7 +58,7 @@ export const AuthComplete = () => {
       const redirectPath =
         returnTo && returnTo.startsWith("/")
           ? returnTo
-          : `/volunteers/${account.shiftboardId}/account`;
+          : `/volunteers/${account.shiftboardId}/info`;
       router.replace(redirectPath);
     } catch {
       router.replace("/sign-in?error=invalid_data");

--- a/client/src/app/roles/[roleId]/volunteers/RoleVolunteers.tsx
+++ b/client/src/app/roles/[roleId]/volunteers/RoleVolunteers.tsx
@@ -142,7 +142,7 @@ export const RoleVolunteers = ({ roleId }: IRoleVolunteersProps) => {
           key={`${shiftboardId}-menu`}
           MenuList={
             <MenuList>
-              <Link href={`/volunteers/${shiftboardId}/account`}>
+              <Link href={`/volunteers/${shiftboardId}/info`}>
                 <MenuItem>
                   <ListItemIcon>
                     <ManageAccountsIcon />

--- a/client/src/app/roles/behavioral-standards/[shiftboardId]/BehavioralStandards.tsx
+++ b/client/src/app/roles/behavioral-standards/[shiftboardId]/BehavioralStandards.tsx
@@ -179,8 +179,8 @@ export const BehavioralStandards = ({
         }
       );
 
-      // route to volunteer account page
-      router.push(`/volunteers/${shiftboardId}/account`);
+      // route to volunteer info page (replaces the old account page)
+      router.push(`/volunteers/${shiftboardId}/info`);
     } catch (error) {
       if (error instanceof Error) {
         enqueueSnackbar(

--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -509,7 +509,7 @@ export const ShiftVolunteers = ({
             key={`${shiftboardId}-menu`}
             MenuList={
               <MenuList>
-                <Link href={`/volunteers/${shiftboardId}/account`}>
+                <Link href={`/volunteers/${shiftboardId}/info`}>
                   <MenuItem>
                     <ListItemIcon>
                       <ManageAccountsIcon />

--- a/client/src/app/sign-in/SignInAuthGate.tsx
+++ b/client/src/app/sign-in/SignInAuthGate.tsx
@@ -40,7 +40,7 @@ export const SignInAuthGate = () => {
       if (returnTo && returnTo.startsWith("/")) {
         router.push(returnTo);
       } else {
-        router.push(`/volunteers/${shiftboardId}/account`);
+        router.push(`/volunteers/${shiftboardId}/info`);
       }
     }
   }, [isAuthenticated, router, searchParams, shiftboardId]);

--- a/client/src/app/volunteers/Volunteers.tsx
+++ b/client/src/app/volunteers/Volunteers.tsx
@@ -213,7 +213,7 @@ export const Volunteers = () => {
   );
   const optionListCustom = {
     onRowClick: (row: string[]) => {
-      router.push(`/volunteers/${row[0]}/account`);
+      router.push(`/volunteers/${row[0]}/info`);
     },
     rowHover: true,
     setRowProps: () => {

--- a/client/src/app/volunteers/[shiftboardId]/account/page.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/page.tsx
@@ -1,26 +1,16 @@
-import { Account } from "@/app/volunteers/[shiftboardId]/account/Account";
-import { AuthGate } from "@/components/general/AuthGate";
-import { ACCOUNT_TYPE_AUTHENTICATED } from "@/constants";
+import { redirect } from "next/navigation";
+
+// /volunteers/[id]/account is the legacy URL — the canonical page is now
+// /volunteers/[id]/info (the VIP page). Server-side redirect preserves
+// bookmarks and external links. Per @mbhewitt 2026-05-23.
 
 interface IAccountPageProps {
   params: Promise<{ shiftboardId: string }>;
 }
 
-export const metadata = {
-  title: "Census | Account",
-};
 const AccountPage = async ({ params }: IAccountPageProps) => {
-  // logic
-  // ------------------------------------------------------------
   const { shiftboardId } = await params;
-
-  // render
-  // ------------------------------------------------------------
-  return (
-    <AuthGate accountTypeToCheck={ACCOUNT_TYPE_AUTHENTICATED}>
-      <Account shiftboardId={Number(shiftboardId)} />
-    </AuthGate>
-  );
+  redirect(`/volunteers/${shiftboardId}/info`);
 };
 
 export default AccountPage;

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -715,10 +715,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
         <Box sx={{ mb: 3 }}>
           <BreadcrumbsNav>
             <Link href="/volunteers">Volunteers</Link>
-            <Link href={`/volunteers/${shiftboardId}/account`}>
-              {volunteer.playaName}
-            </Link>
-            <Typography>Info</Typography>
+            <Typography>{volunteer.playaName}</Typography>
           </BreadcrumbsNav>
         </Box>
 

--- a/client/src/app/volunteers/account/create/AccountCreate.tsx
+++ b/client/src/app/volunteers/account/create/AccountCreate.tsx
@@ -113,8 +113,8 @@ export const AccountCreate = () => {
         }
       );
 
-      // route to volunteer account page
-      router.push(`/volunteers/${dataVolunteerItem.shiftboardId}/account`);
+      // route to volunteer info page (replaces the old account page)
+      router.push(`/volunteers/${dataVolunteerItem.shiftboardId}/info`);
     } catch (error) {
       if (error instanceof Error) {
         enqueueSnackbar(

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -288,12 +288,12 @@ export const Header = () => {
               >
                 <ListItem disablePadding>
                   <Link
-                    href={`/volunteers/${shiftboardId}/account`}
+                    href={`/volunteers/${shiftboardId}/info`}
                     onClick={handleDrawerClose}
                   >
                     <ListItemButton
                       selected={
-                        pathname === `/volunteers/${shiftboardId}/account`
+                        pathname === `/volunteers/${shiftboardId}/info`
                       }
                     >
                       <ListItemIcon>

--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -338,7 +338,7 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // encode account data for client-side session hydration
     const accountData = encodeURIComponent(JSON.stringify(account));
-    const redirectPath = returnTo && returnTo.startsWith("/") ? returnTo : `/volunteers/${shiftboardId}/account`;
+    const redirectPath = returnTo && returnTo.startsWith("/") ? returnTo : `/volunteers/${shiftboardId}/info`;
 
     return res.redirect(
       `/auth/complete?data=${accountData}&returnTo=${encodeURIComponent(redirectPath)}`


### PR DESCRIPTION
Closes the [[vip-replaces-account]] thread — per @mbhewitt 2026-05-23, the VIP page (`/volunteers/[id]/info`) is now the canonical volunteer page and `/account` is the legacy URL.

## Changes

**10 internal navigation sites repointed** from `/volunteers/[id]/account` → `/volunteers/[id]/info`:
- `app/auth/complete/AuthComplete.tsx` (OAuth landing)
- `app/sign-in/SignInAuthGate.tsx` (post-sign-in destination)
- `pages/api/auth/okta/callback.ts` (default returnTo)
- `app/volunteers/account/create/AccountCreate.tsx` (account-create success)
- `app/roles/behavioral-standards/[shiftboardId]/BehavioralStandards.tsx` (post-acknowledge)
- `components/layout/Header.tsx` (user menu link + active-route check)
- `app/volunteers/Volunteers.tsx` (admin row click)
- `app/roles/[roleId]/volunteers/RoleVolunteers.tsx` (admin row menu)
- `app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx` (admin shift detail menu)
- `app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx` (breadcrumb no longer self-links via /account)

**`/volunteers/[id]/account/page.tsx` is now a server-side redirect** to `/info`. Preserves old bookmarks / external links so nobody hits a dead URL.

**Account/ folder is preserved as a shared-components dir** — `VolunteerInfo` still imports `VolunteerShifts`, `PasscodeDialogUpdate`, `VolunteerShiftsDialogRemove`, `VolunteerShiftsDialogReview` from there. The `Account.tsx` component file itself is now unused but I'm leaving the directory intact for review (a separate cleanup PR can decide whether to move components up a level and delete `account/`).

**API path is unchanged.** `/api/volunteers/[id]/account` is still the data endpoint — that's a name, not a route, and renaming it would mean updating every caller for no UX benefit.

## Test

New e2e (`21-account-redirects-to-info.spec.ts`) asserts the legacy `/account` URL still resolves through the middleware sign-in path (the post-auth `account → info` redirect runs from the page itself; the middleware gates it first).

Existing sign-in regression spec (#19) still passes.

## Note on stacking

This PR is independent of #301 (start_date_id fix) and #302 (on-playa shifts allowlist). They touch different files. Merge order doesn't matter; final state of `main` is the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)