### PR TITLE
feat(training): confirmation endpoint + wire up landing page

### DIFF
--- a/client/e2e/helpers/session.ts
+++ b/client/e2e/helpers/session.ts
@@ -1,0 +1,33 @@
+// Session-cookie helper for tests that need to call API endpoints behind
+// withAuth. Signs a payload with the same HMAC secret the dev server is
+// configured with via SESSION_SECRET in playwright.config.ts.
+//
+// Mirrors the logic in client/src/lib/session.ts — kept in sync by
+// matching constant names and the {b64(json)}.{hmac} format. Do not import
+// the real session module here; it pulls in Next.js types that don't load
+// in the Node-only test runner.
+
+import crypto from "crypto";
+
+const SECRET =
+  process.env.SESSION_SECRET ?? "e2e-test-session-secret-not-for-prod";
+const COOKIE_NAME = "census-session";
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export function buildSessionCookieValue(
+  shiftboardId: number,
+  expiresAt: number = Date.now() + ONE_HOUR_MS
+): string {
+  const payload = JSON.stringify({ shiftboardId, expires: expiresAt });
+  const b64 = Buffer.from(payload, "utf8").toString("base64url");
+  const hmac = crypto
+    .createHmac("sha256", SECRET)
+    .update(b64)
+    .digest("base64url");
+  return `${b64}.${hmac}`;
+}
+
+// Header string ready to pass as { Cookie: ... } to playwright request.
+export function buildSessionCookieHeader(shiftboardId: number): string {
+  return `${COOKIE_NAME}=${buildSessionCookieValue(shiftboardId)}`;
+}

--- a/client/e2e/playwright.config.ts
+++ b/client/e2e/playwright.config.ts
@@ -48,6 +48,11 @@ export default defineConfig({
       OKTA_REDIRECT_URI:
         process.env.OKTA_REDIRECT_URI ??
         "http://localhost:3000/api/auth/okta/callback",
+      // SESSION_SECRET is the HMAC key for the census-session cookie. Tests
+      // that need an authenticated session import e2e/helpers/session.ts,
+      // which signs a cookie with this same value.
+      SESSION_SECRET:
+        process.env.SESSION_SECRET ?? "e2e-test-session-secret-not-for-prod",
     },
   },
 });

--- a/client/e2e/tests/22-training-confirmation.spec.ts
+++ b/client/e2e/tests/22-training-confirmation.spec.ts
@@ -1,0 +1,124 @@
+// /api/training/confirmation/[code] sanity tests.
+//
+// Seeds two volunteers (one to assign the role to; one for an admin
+// session) and uses the "Census Basics" training row that ships with the
+// schema seed (code XQDDG, role_id 2000001). Confirms GET → 200 with
+// expected shape, POST → 201 + role written, GET-after-POST →
+// alreadyConfirmed:true, POST is idempotent.
+
+import { test, expect, request } from "@playwright/test";
+
+import { closePool, cleanupAllTestData, getPool, insertVolunteer } from "../helpers/db";
+import { buildSessionCookieHeader } from "../helpers/session";
+import { IDS, makeTestVolunteer } from "../fixtures/test-data";
+
+const TRAINING_CODE = "XQDDG";
+const TRAINING_ROLE_ID = 2000001;
+
+const seedVolunteer = makeTestVolunteer({
+  shiftboardId: IDS.volunteer1,
+  playaName: "E2E TrainingProbe",
+  worldName: "Training Probe",
+  email: "e2e-training@test.local",
+  passcode: "0000",
+});
+
+test.describe("Training confirmation endpoint", () => {
+  test.beforeAll(async () => {
+    await cleanupAllTestData();
+    await insertVolunteer(seedVolunteer);
+    // ensure the training role/training row exist (idempotent re-seed)
+    const db = getPool();
+    await db.execute(
+      `INSERT IGNORE INTO op_roles (role_id, role, display, create_role, delete_role, role_src)
+       VALUES (?, 'TrainingCensusBasicsComplete', 0, 1, 0, 'tablet')`,
+      [TRAINING_ROLE_ID]
+    );
+    await db.execute(
+      `INSERT IGNORE INTO op_trainings (training_name, role_id, code, url, create_training)
+       VALUES ('Census Basics', ?, ?, '', 1)`,
+      [TRAINING_ROLE_ID, TRAINING_CODE]
+    );
+    // make sure the volunteer doesn't already hold the role from a prior run
+    await db.execute(
+      `DELETE FROM op_volunteer_roles WHERE shiftboard_id = ? AND role_id = ?`,
+      [seedVolunteer.shiftboardId, TRAINING_ROLE_ID]
+    );
+  });
+
+  test.afterAll(async () => {
+    const db = getPool();
+    await db.execute(
+      `DELETE FROM op_volunteer_roles WHERE shiftboard_id = ? AND role_id = ?`,
+      [seedVolunteer.shiftboardId, TRAINING_ROLE_ID]
+    );
+    await cleanupAllTestData();
+    await closePool();
+  });
+
+  async function authedContext() {
+    return request.newContext({
+      baseURL: "http://localhost:3000",
+      extraHTTPHeaders: {
+        Cookie: buildSessionCookieHeader(seedVolunteer.shiftboardId),
+      },
+    });
+  }
+
+  test("GET with valid code returns training + alreadyConfirmed=false", async () => {
+    const ctx = await authedContext();
+    const res = await ctx.get(
+      `/api/training/confirmation/${TRAINING_CODE}`
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    await ctx.dispose();
+
+    expect(body.training.name).toBe("Census Basics");
+    expect(body.training.roleId).toBe(TRAINING_ROLE_ID);
+    expect(body.training.roleName).toBe("TrainingCensusBasicsComplete");
+    expect(body.volunteer.playaName).toBe(seedVolunteer.playaName);
+    expect(body.alreadyConfirmed).toBe(false);
+    expect(Array.isArray(body.availableShifts)).toBe(true);
+  });
+
+  test("GET with unknown code returns 404", async () => {
+    const ctx = await authedContext();
+    const res = await ctx.get(
+      `/api/training/confirmation/this-code-does-not-exist`
+    );
+    const status = res.status();
+    await ctx.dispose();
+    expect(status).toBe(404);
+  });
+
+  test("unauthenticated request gets 401 (withAuth gate)", async ({
+    request: req,
+  }) => {
+    const res = await req.get(`/api/training/confirmation/${TRAINING_CODE}`);
+    expect(res.status()).toBe(401);
+  });
+
+  test("POST assigns the role; subsequent GET shows alreadyConfirmed; idempotent", async () => {
+    const ctx = await authedContext();
+
+    const post = await ctx.post(`/api/training/confirmation/${TRAINING_CODE}`, {
+      data: { shiftboardId: seedVolunteer.shiftboardId },
+    });
+    expect([200, 201]).toContain(post.status());
+
+    const get = await ctx.get(
+      `/api/training/confirmation/${TRAINING_CODE}`
+    );
+    expect(get.status()).toBe(200);
+    const body = await get.json();
+    expect(body.alreadyConfirmed).toBe(true);
+
+    const post2 = await ctx.post(`/api/training/confirmation/${TRAINING_CODE}`, {
+      data: { shiftboardId: seedVolunteer.shiftboardId },
+    });
+    expect([200, 201]).toContain(post2.status());
+
+    await ctx.dispose();
+  });
+});

--- a/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
+++ b/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
@@ -1,27 +1,126 @@
 "use client";
 
-import { Check as CheckIcon } from "@mui/icons-material";
+import {
+  Check as CheckIcon,
+  OpenInNew as OpenInNewIcon,
+} from "@mui/icons-material";
 import {
   Box,
   Button,
   Card,
   CardActions,
   CardContent,
+  CircularProgress,
   Container,
+  Link as MuiLink,
+  List,
+  ListItem,
+  ListItemText,
   Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import NextLink from "next/link";
+import { useSnackbar } from "notistack";
+import { useContext } from "react";
+import useSWR from "swr";
+import useSWRMutation from "swr/mutation";
 
+import { ErrorPage } from "@/components/general/ErrorPage";
+import { Loading } from "@/components/general/Loading";
+import { SnackbarText } from "@/components/general/SnackbarText";
 import { Hero } from "@/components/layout/Hero";
+import type {
+  IReqTrainingConfirm,
+  IResTrainingConfirmation,
+} from "@/components/types/confirm";
+import { SESSION_ROLE_ITEM_ADD } from "@/constants";
+import { SessionContext } from "@/state/session/context";
+import { fetcherGet, fetcherTrigger } from "@/utils/fetcher";
 
 interface ITrainingConfirmationProps {
-  code: number;
+  code: string;
 }
 
 export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
+  // context
+  // ------------------------------------------------------------
+  const {
+    sessionDispatch,
+    sessionState: {
+      user: { shiftboardId },
+    },
+  } = useContext(SessionContext);
+
+  // fetching, mutation, revalidation
+  // ------------------------------------------------------------
+  const swrKey = shiftboardId
+    ? `/api/training/confirmation/${code}?shiftboardId=${shiftboardId}`
+    : null;
+  const {
+    data,
+    error,
+    mutate,
+  }: {
+    data: IResTrainingConfirmation | undefined;
+    error: Error | undefined;
+    mutate: (opts?: unknown) => void;
+  } = useSWR(swrKey, fetcherGet);
+  const { isMutating, trigger } = useSWRMutation(
+    `/api/training/confirmation/${code}`,
+    fetcherTrigger
+  );
+
   // other hooks
   // ------------------------------------------------------------
   const theme = useTheme();
+  const { enqueueSnackbar } = useSnackbar();
+
+  // logic
+  // ------------------------------------------------------------
+  if (error) return <ErrorPage />;
+  if (!data) return <Loading />;
+  // GET returns { statusCode, message } shaped objects on 404 / 400 — treat
+  // those as the error page rather than rendering the success layout.
+  if (
+    (data as unknown as { statusCode?: number }).statusCode &&
+    (data as unknown as { statusCode?: number }).statusCode !== 200
+  ) {
+    return <ErrorPage />;
+  }
+
+  const handleConfirm = async () => {
+    try {
+      const body: IReqTrainingConfirm = { shiftboardId };
+      await trigger({ method: "POST", body });
+      // update client-side role list so the rest of the app knows
+      sessionDispatch({
+        type: SESSION_ROLE_ITEM_ADD,
+        payload: {
+          id: data.training.roleId,
+          name: data.training.roleName,
+        },
+      });
+      enqueueSnackbar(
+        <SnackbarText>
+          <strong>{data.training.name}</strong> training confirmed
+        </SnackbarText>,
+        { variant: "success" }
+      );
+      // refetch so alreadyConfirmed flips and shifts list is fresh
+      mutate();
+    } catch (e) {
+      if (e instanceof Error) {
+        enqueueSnackbar(
+          <SnackbarText>
+            <strong>{e.message}</strong>
+          </SnackbarText>,
+          { persist: true, variant: "error" }
+        );
+      }
+    }
+  };
+
+  const { training, volunteer, alreadyConfirmed, availableShifts } = data;
 
   // render
   // ------------------------------------------------------------
@@ -35,39 +134,93 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
         text="Training confirmation"
       />
       <Container component="main">
-        <Box component="section">
+        <Box component="section" sx={{ mb: 3 }}>
           <Card>
             <CardContent>
-              <Typography>
-                Congratulations on completing the training course. Click on the
-                confirm button to be taken to the shifts page.
+              <Typography component="h2" sx={{ mb: 1 }} variant="h5">
+                {alreadyConfirmed
+                  ? `Thank you, ${volunteer.playaName}, for confirming completion of ${training.name}!`
+                  : `Hi ${volunteer.playaName}! Confirm your completion of ${training.name} to unlock shifts that require this training.`}
               </Typography>
+              {alreadyConfirmed && (
+                <Typography sx={{ mb: 1 }}>
+                  Your <strong>{training.roleName}</strong> role has been added
+                  to your account.
+                </Typography>
+              )}
+              {training.url && (
+                <Typography sx={{ mt: 2 }}>
+                  <MuiLink
+                    component={NextLink}
+                    href={training.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Training course material{" "}
+                    <OpenInNewIcon
+                      fontSize="inherit"
+                      sx={{ verticalAlign: "middle" }}
+                    />
+                  </MuiLink>
+                </Typography>
+              )}
             </CardContent>
-            <CardActions
-              sx={{
-                justifyContent: "flex-end",
-                pb: 2,
-                pt: 0,
-                pr: 2,
-              }}
-            >
-              <Button
-                onClick={() => {
-                  console.log("clicked");
+            {!alreadyConfirmed && (
+              <CardActions
+                sx={{
+                  justifyContent: "flex-end",
+                  pb: 2,
+                  pt: 0,
+                  pr: 2,
                 }}
-                startIcon={<CheckIcon />}
-                type="button"
-                variant="contained"
               >
-                Confirm
-              </Button>
-            </CardActions>
+                <Button
+                  disabled={isMutating}
+                  onClick={handleConfirm}
+                  startIcon={
+                    isMutating ? (
+                      <CircularProgress size="1rem" />
+                    ) : (
+                      <CheckIcon />
+                    )
+                  }
+                  type="button"
+                  variant="contained"
+                >
+                  Confirm
+                </Button>
+              </CardActions>
+            )}
           </Card>
         </Box>
-        <Box component={"section"}>
-          <Typography component="h2" variant="h4">
-            Dev only: your code is {code}
+        <Box component="section">
+          <Typography component="h2" sx={{ mb: 2 }} variant="h6">
+            {alreadyConfirmed
+              ? `Sign up for shifts that need ${training.name}:`
+              : `Available shifts requiring ${training.name}:`}
           </Typography>
+          {availableShifts.length === 0 ? (
+            <Typography>
+              There are no open shifts requiring {training.name} at this time.
+            </Typography>
+          ) : (
+            <Card>
+              <List>
+                {availableShifts.map((shift) => (
+                  <ListItem
+                    key={`${shift.shiftTimesId}-${shift.positionId}`}
+                    component={NextLink}
+                    href={`/shifts/${shift.shiftTimesId}/volunteers`}
+                  >
+                    <ListItemText
+                      primary={`${shift.shiftName} — ${shift.position}`}
+                      secondary={`${shift.dateName || shift.startTime} · ${shift.department}`}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Card>
+          )}
         </Box>
       </Container>
     </>

--- a/client/src/app/training/confirmation/[code]/page.tsx
+++ b/client/src/app/training/confirmation/[code]/page.tsx
@@ -1,4 +1,6 @@
 import { TrainingConfirmation } from "@/app/training/confirmation/[code]/TrainingConfirmation";
+import { AuthGate } from "@/components/general/AuthGate";
+import { ACCOUNT_TYPE_AUTHENTICATED } from "@/constants";
 
 interface ITrainingConfirmationPageProps {
   params: Promise<{ code: string }>;
@@ -10,13 +12,13 @@ export const metadata = {
 const TrainingConfirmationPage = async ({
   params,
 }: ITrainingConfirmationPageProps) => {
-  // logic
-  // ------------------------------------------------------------
   const { code } = await params;
 
-  // render
-  // ------------------------------------------------------------
-  return <TrainingConfirmation code={Number(code)} />;
+  return (
+    <AuthGate accountTypeToCheck={ACCOUNT_TYPE_AUTHENTICATED}>
+      <TrainingConfirmation code={code} />
+    </AuthGate>
+  );
 };
 
 export default TrainingConfirmationPage;

--- a/client/src/components/types/confirm.ts
+++ b/client/src/components/types/confirm.ts
@@ -1,0 +1,31 @@
+// Types for /api/training/confirmation/[code]. See specs/training-
+// confirmation-endpoint.md.
+
+export interface IResTrainingShiftItem {
+  dateName: string;
+  department: string;
+  endTime: string;
+  position: string;
+  positionId: number;
+  shiftName: string;
+  shiftTimesId: number;
+  startTime: string;
+}
+
+export interface IResTrainingConfirmation {
+  training: {
+    name: string;
+    roleId: number;
+    roleName: string;
+    url: string;
+  };
+  volunteer: {
+    playaName: string;
+  };
+  alreadyConfirmed: boolean;
+  availableShifts: IResTrainingShiftItem[];
+}
+
+export interface IReqTrainingConfirm {
+  shiftboardId: number;
+}

--- a/client/src/pages/api/training/confirmation/[code]/index.ts
+++ b/client/src/pages/api/training/confirmation/[code]/index.ts
@@ -1,0 +1,187 @@
+import { RowDataPacket } from "mysql2";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type {
+  IResTrainingConfirmation,
+  IResTrainingShiftItem,
+} from "@/components/types/confirm";
+import { withAuth } from "@/lib/withAuth";
+import { pool } from "lib/database";
+
+// /api/training/confirmation/[code]
+// GET reads training + shifts that require it.
+// POST assigns the training-completion role to the signed-in volunteer.
+// See specs/training-confirmation-endpoint.md.
+//
+// Auth: wrapped in withAuth so the shiftboardId comes from the
+// HMAC-verified session cookie, not a caller-supplied param. The spec's
+// "client-side only" note predates the hotfix #288 withAuth infrastructure.
+
+const trainingConfirmation = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
+  const { code } = req.query;
+  if (typeof code !== "string" || !code) {
+    return res.status(400).json({ statusCode: 400, message: "code required" });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const [dbTrainingList] = await pool.query<RowDataPacket[]>(
+        `SELECT
+          t.training_id,
+          t.training_name,
+          t.role_id,
+          t.url,
+          r.role AS role_name
+        FROM op_trainings AS t
+        JOIN op_roles AS r ON r.role_id = t.role_id
+        WHERE t.code = ? AND t.delete_training = false
+        LIMIT 1`,
+        [code]
+      );
+      const dbTraining = dbTrainingList[0];
+      if (!dbTraining) {
+        return res.status(404).json({ statusCode: 404, message: "Not found" });
+      }
+
+      const [dbVolunteerList] = await pool.query<RowDataPacket[]>(
+        `SELECT playa_name
+        FROM op_volunteers
+        WHERE shiftboard_id = ?
+        LIMIT 1`,
+        [session.shiftboardId]
+      );
+      const dbVolunteer = dbVolunteerList[0];
+      if (!dbVolunteer) {
+        return res
+          .status(404)
+          .json({ statusCode: 404, message: "Volunteer not found" });
+      }
+
+      const [dbRoleList] = await pool.query<RowDataPacket[]>(
+        `SELECT role_id
+        FROM op_volunteer_roles
+        WHERE shiftboard_id = ? AND role_id = ? AND remove_role = false
+        LIMIT 1`,
+        [session.shiftboardId, dbTraining.role_id]
+      );
+      const alreadyConfirmed = dbRoleList.length > 0;
+
+      // Shifts that require this training. Soft-delete filters on every
+      // link in the join (see spec gotcha #13).
+      // d.date is in SELECT to satisfy MySQL strict mode (DISTINCT +
+      // ORDER BY require the sort column to be in the select list). It's
+      // also useful client-side for display.
+      const [dbShiftList] = await pool.query<RowDataPacket[]>(
+        `SELECT DISTINCT
+          sn.shift_name,
+          sn.shift_name_id,
+          sc.shift_category AS department,
+          pt.position,
+          pt.position_type_id,
+          st.shift_instance,
+          st.start_time,
+          st.start_time_text,
+          st.end_time,
+          st.end_time_text,
+          st.shift_times_id,
+          d.date,
+          d.datename
+        FROM op_position_trainings AS ptr
+        JOIN op_position_type AS pt ON ptr.position_type_id = pt.position_type_id
+        JOIN op_shift_time_position AS stp ON pt.position_type_id = stp.position_type_id
+        JOIN op_shift_times AS st ON stp.shift_times_id = st.shift_times_id
+        JOIN op_shift_name AS sn ON st.shift_name_id = sn.shift_name_id
+        JOIN op_shift_category AS sc ON sn.shift_category_id = sc.shift_category_id
+        LEFT JOIN op_dates AS d ON st.start_date_id = d.date_id
+        WHERE ptr.training_id = ?
+          AND ptr.delete_position_training = false
+          AND stp.remove_time_position = false
+          AND st.remove_shift_time = false
+          AND st.canceled = false
+          AND sn.delete_shift = false
+          AND sc.delete_category = false
+        ORDER BY d.date, st.start_time_text`,
+        [dbTraining.training_id]
+      );
+
+      const availableShifts: IResTrainingShiftItem[] = dbShiftList.map(
+        (row: RowDataPacket) => ({
+          dateName: row.datename ?? "",
+          department: row.department ?? "",
+          endTime: row.end_time ?? row.end_time_text ?? "",
+          position: row.position ?? "",
+          positionId: row.position_type_id,
+          shiftName: row.shift_name ?? "",
+          shiftTimesId: row.shift_times_id,
+          startTime: row.start_time ?? row.start_time_text ?? "",
+        })
+      );
+
+      const body: IResTrainingConfirmation = {
+        training: {
+          name: dbTraining.training_name,
+          roleId: dbTraining.role_id,
+          roleName: dbTraining.role_name,
+          url: dbTraining.url ?? "",
+        },
+        volunteer: {
+          playaName: dbVolunteer.playa_name ?? "",
+        },
+        alreadyConfirmed,
+        availableShifts,
+      };
+
+      return res.status(200).json(body);
+    }
+
+    case "POST": {
+      const [dbTrainingList] = await pool.query<RowDataPacket[]>(
+        `SELECT role_id
+        FROM op_trainings
+        WHERE code = ? AND delete_training = false
+        LIMIT 1`,
+        [code]
+      );
+      const dbTraining = dbTrainingList[0];
+      if (!dbTraining) {
+        return res.status(404).json({ statusCode: 404, message: "Not found" });
+      }
+
+      // SELECT-then-branch (matches existing pattern in roles/[id]/volunteers).
+      const [dbExistingList] = await pool.query<RowDataPacket[]>(
+        `SELECT role_id
+        FROM op_volunteer_roles
+        WHERE role_id = ? AND shiftboard_id = ?
+        LIMIT 1`,
+        [dbTraining.role_id, session.shiftboardId]
+      );
+
+      if (dbExistingList.length > 0) {
+        await pool.query(
+          `UPDATE op_volunteer_roles
+          SET add_role = true, remove_role = false
+          WHERE role_id = ? AND shiftboard_id = ?`,
+          [dbTraining.role_id, session.shiftboardId]
+        );
+        return res.status(200).json({ statusCode: 200, message: "OK" });
+      }
+
+      await pool.query(
+        `INSERT INTO op_volunteer_roles
+          (shiftboard_id, role_id, add_role, remove_role)
+        VALUES (?, ?, true, false)`,
+        [session.shiftboardId, dbTraining.role_id]
+      );
+      return res.status(201).json({ statusCode: 201, message: "Created" });
+    }
+
+    default:
+      return res.status(404).json({ statusCode: 404, message: "Not found" });
+  }
+};
+
+export default withAuth(trainingConfirmation);

--- a/database/scheduler_schema.sql
+++ b/database/scheduler_schema.sql
@@ -301,6 +301,53 @@ CREATE TABLE `op_volunteers` (
   KEY `passcode` (`passcode`,`shiftboard_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `op_trainings`
+-- (See specs/training-confirmation-endpoint.md.)
+--
+
+DROP TABLE IF EXISTS `op_trainings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `op_trainings` (
+  `training_id` bigint NOT NULL AUTO_INCREMENT,
+  `training_name` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `role_id` bigint DEFAULT NULL,
+  `code` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `url` varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `create_training` tinyint(1) DEFAULT '0',
+  `update_training` tinyint(1) DEFAULT '0',
+  `delete_training` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`training_id`),
+  UNIQUE KEY `training_name` (`training_name`),
+  UNIQUE KEY `code` (`code`),
+  KEY `fk_training_role` (`role_id`),
+  CONSTRAINT `fk_training_role` FOREIGN KEY (`role_id`) REFERENCES `op_roles` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `op_position_trainings`
+--
+
+DROP TABLE IF EXISTS `op_position_trainings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `op_position_trainings` (
+  `position_training_id` bigint NOT NULL AUTO_INCREMENT,
+  `position_type_id` bigint DEFAULT NULL,
+  `training_id` bigint DEFAULT NULL,
+  `create_position_training` tinyint(1) DEFAULT '0',
+  `update_position_training` tinyint(1) DEFAULT '0',
+  `delete_position_training` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`position_training_id`),
+  UNIQUE KEY `uk_position_training` (`position_type_id`,`training_id`),
+  KEY `fk_pt_training` (`training_id`),
+  CONSTRAINT `fk_pt_position` FOREIGN KEY (`position_type_id`) REFERENCES `op_position_type` (`position_type_id`),
+  CONSTRAINT `fk_pt_training` FOREIGN KEY (`training_id`) REFERENCES `op_trainings` (`training_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
@@ -314,4 +361,24 @@ CREATE TABLE `op_volunteers` (
 insert ignore into op_volunteers (shiftboard_id,playa_name,world_name,passcode) values (1, "Admin","Admin","123456");
 insert ignore into op_roles (role_id,role,display,role_src) values (1,"SuperAdmin",1,"tablet"),(2,"Admin",1,"tablet");
 insert ignore into op_volunteer_roles (shiftboard_id,role_id) values (1,1),(1,2);
+
+-- Training completion roles (op_roles.display=0 keeps them off the admin
+-- roles list; they still appear on the volunteer's role list). See
+-- specs/training-confirmation-endpoint.md. Position-training links are
+-- not seeded here because they reference specific position_type_ids that
+-- don't exist in a fresh DB — apply those via the admin UI / a separate
+-- data migration once the position types are loaded.
+insert ignore into op_roles (role_id,role,display,create_role,delete_role,role_src) values
+  (2000001, 'TrainingCensusBasicsComplete',   0, 1, 0, 'tablet'),
+  (2000002, 'TrainingRandomSamplingComplete', 0, 1, 0, 'tablet'),
+  (2000003, 'TrainingOutReachComplete',       0, 1, 0, 'tablet'),
+  (2000004, 'TrainingDataEntryWizComplete',   0, 1, 0, 'tablet'),
+  (2000005, 'TrainingDataBeastDriverComplete',0, 1, 0, 'tablet');
+
+insert ignore into op_trainings (training_name, role_id, code, url, create_training) values
+  ('Census Basics',     2000001, 'XQDDG', 'https://hive.burningman.org/posts/census-course-basics-start-here-course-overview-84578159', 1),
+  ('Random Sampling',   2000002, 'AH73H', 'https://hive.burningman.org/posts/census-course-random-sampling-start-here-random-sampling-course-overview', 1),
+  ('OutReach',          2000003, 'XQ9VD', 'https://hive.burningman.org/posts/census-course-outreach-course-overview-start-here-84578181', 1),
+  ('DataEntry Wiz',     2000004, 'TMBSW', 'https://drive.google.com/file/d/1rhB75gEhYQ7gctzHZEHG7xLrRWiejyth/view?usp=drivesdk', 1),
+  ('DataBeast Driver',  2000005, 'PZBWG', 'https://hive.burningman.org/posts/census-course-databeast-drive-start-here-databeast-driver-course-overview', 1);
 insert ignore into op_doodles (id,image_url) values (1,"");


### PR DESCRIPTION
Closes #300.

Implements the GET/POST training-confirmation flow described in `specs/training-confirmation-endpoint.md` and connects the existing `/training/confirmation/[code]` landing page (PR #284) to a real backend.

## API — `client/src/pages/api/training/confirmation/[code]/index.ts`

- **GET** returns `{ training, volunteer, alreadyConfirmed, availableShifts }` for the signed-in user. Joins:
  ```
  op_position_trainings → op_position_type → op_shift_time_position →
  op_shift_times → op_shift_name → op_shift_category → op_dates
  ```
  Soft-delete filters on every link in the join per spec gotcha #13.
- **POST** SELECT-then-branch upsert into `op_volunteer_roles`. Idempotent (re-confirming returns 200 instead of 201).
- Wrapped in `withAuth` so `shiftboardId` comes from the HMAC-verified session cookie, not a caller-supplied param. Supersedes spec gotcha #6 ("auth is client-side only"), which predates the PR #288 `withAuth` infrastructure.

## Frontend

- `client/src/app/training/confirmation/[code]/page.tsx` wraps the component in `AuthGate` and passes `code` as a **string** (was wrongly `Number()`-coerced in the placeholder).
- `client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx` replaces the placeholder UI with real SWR/SWRMutation fetches. Confirm button posts, dispatches `SESSION_ROLE_ITEM_ADD` to update the client session, then revalidates. Two state variants: not-confirmed (call-to-action) and already-confirmed (thank-you + role assigned). Lists available shifts that require this training, each linking to its volunteers page.
- `client/src/components/types/confirm.ts` holds request/response interfaces.

## Schema

- `database/scheduler_schema.sql` adds `CREATE TABLE` for `op_trainings` and `op_position_trainings` (FK-keyed to `op_roles` and `op_position_type` respectively).
- Seeds the five training rows with their codes and completion roles (op_roles 2000001–2000005, `display=0` so they stay off the admin roles list).
- **Position-training links are NOT seeded.** They reference specific `position_type_id`s that don't exist in a fresh DB. Apply via admin UI / a separate data migration once positions are loaded.

## Tests

- **New** `client/e2e/helpers/session.ts` — forges a valid `census-session` cookie by HMAC-signing the same payload the dev server expects. Reads `SESSION_SECRET` env var, which the e2e `playwright.config.ts` now exports with a test default.
- **New** `client/e2e/tests/22-training-confirmation.spec.ts` — 4 specs:
  - GET valid code returns training + `alreadyConfirmed=false`
  - GET unknown code returns 404
  - Unauthenticated request returns 401 (withAuth gate works)
  - POST assigns role, GET-after shows `alreadyConfirmed=true`, second POST is idempotent
- Sign-in regression spec (#19) still green alongside.

## Out of scope — separate PRs / issues

- **Admin CRUD for trainings** (spec "Admin Management"). Confirmation flow works without it; admin UI is a follow-up.
- **Position-training link seed/migration** — needs the right `position_type_id`s for whatever's loaded on prod.
- **`ShiftVolunteersDialogAdd` checking training-role prerequisites** (spec gotcha #8).
- **`sessionStorage` redirect-after-sign-in mechanism** from the spec — the existing middleware `?returnTo=` flow already handles "land back on /training/confirmation/CODE after sign-in" for both passcode and Okta paths, so the spec's proposal isn't needed.

## Note on commit base

This branch is parented on `deploy/test-bundle` HEAD (`5b7a492`) which is the same tree as `origin/main` (`1d5ed83` is the merge commit of test-bundle into main). The PR diff against `main` shows only this commit's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)