### PR TITLE
fix(account-create): new-user shiftboard_id floor of 10,000,000

### DIFF
--- a/client/src/pages/api/volunteers/account/index.ts
+++ b/client/src/pages/api/volunteers/account/index.ts
@@ -2,8 +2,34 @@ import { RowDataPacket } from "mysql2";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IResVolunteerAccount } from "@/components/types/volunteers";
-import { generateId } from "@/utils/generateId";
 import { pool } from "lib/database";
+
+// New-account shiftboard_ids start at 10,000,000 — keeps a clear range
+// above e2e test data (which uses 9,000,000+ per client/e2e/helpers/db.ts)
+// and above all legacy imported volunteers. Per @mbhewitt 2026-05-23.
+const NEW_USER_ID_FLOOR = 10_000_000;
+const NEW_USER_ID_RANGE = 10_000_000; // candidate space [10M, 20M)
+
+const generateNewUserShiftboardId = async (): Promise<number> => {
+  // Loop until we find a free id. At 10M slots versus a handful of
+  // sign-ups per day, collisions are vanishing — but the loop makes the
+  // duplicate-check guarantee explicit (the legacy generateId() has a
+  // known async race where the duplicate check resolves after the value
+  // is already returned, see specs/training-confirmation-endpoint.md
+  // gotcha #1).
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const candidate =
+      NEW_USER_ID_FLOOR + Math.floor(Math.random() * NEW_USER_ID_RANGE);
+    const [rows] = await pool.query<RowDataPacket[]>(
+      "SELECT shiftboard_id FROM op_volunteers WHERE shiftboard_id = ? LIMIT 1",
+      [candidate]
+    );
+    if (rows.length === 0) return candidate;
+  }
+  throw new Error(
+    "could not allocate a new shiftboard_id after 10 attempts — DB unusually full"
+  );
+};
 
 const account = async (req: NextApiRequest, res: NextApiResponse) => {
   switch (req.method) {
@@ -20,11 +46,7 @@ const account = async (req: NextApiRequest, res: NextApiResponse) => {
         playaName,
         worldName,
       } = JSON.parse(req.body);
-      const shiftboardIdNew = generateId(`
-        SELECT shiftboard_id
-        FROM op_volunteers
-        WHERE shiftboard_id=?
-      `);
+      const shiftboardIdNew = await generateNewUserShiftboardId();
 
       // insert new account row
       await pool.query<RowDataPacket[]>(


### PR DESCRIPTION
Per @mbhewitt 2026-05-23: new users should start with shiftboard_ids ≥ 10,000,000.

## Why

`/api/volunteers/account` POST used the legacy `generateId()` which picks in `[1, 1_000_000)`. That range:
1. Overlaps active legacy data (real volunteers were imported with IDs in that range).
2. Sits *below* the `9_000_000+` range the e2e suite reserves for test volunteers (see `client/e2e/helpers/db.ts:TEST_ID_BASE = 9_000_000`).

Moving new sign-ups to `[10_000_000, 20_000_000)` keeps a clear separation: legacy data < tests (9M+) < new prod accounts (10M+).

## Fix

Replaces `generateId()` in `client/src/pages/api/volunteers/account/index.ts` with an inline `generateNewUserShiftboardId()` that:
- Picks a candidate in `[10_000_000, 20_000_000)`
- Confirms it's free with a SELECT loop (`await`-ed properly — the legacy `generateId()` has a known async race where the duplicate-check Promise resolves *after* the value is already returned; see `specs/training-confirmation-endpoint.md` gotcha #1)
- Throws after 10 attempts (10M slots vs a handful of daily sign-ups: collision-then-loop-exhaustion is effectively impossible)

## Out of scope

- **Replacing `generateId()` everywhere it's used** — same race bug in shift type creation, time-position creation, etc. Worth a separate refactor; not bundling it here to keep the change focused.
- **The middleware-allowlist gap for `/api/volunteers/account`** — only the page route `/volunteers/account/create` is on the allowlist, so self-signup POST is currently gated and returns 401. Pre-existing latent bug, separate fix.

## Test

Verified manually that the random selection lands in the right range. Not adding an e2e test for this PR because the unrelated middleware-allowlist bug above blocks an end-to-end account-create flow from working; a meaningful e2e test should land alongside that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)