### PR TITLE
fix(sign-in): forward returnTo from /sign-in into the Okta button href

### DIFF
--- a/client/e2e/tests/19-okta-signin-regression.spec.ts
+++ b/client/e2e/tests/19-okta-signin-regression.spec.ts
@@ -59,6 +59,30 @@ test.describe("Sign-in regression net", () => {
     expect(body.length).toBeGreaterThan(0);
   });
 
+  test("/sign-in forwards returnTo into the Okta button href", async ({
+    page,
+  }) => {
+    // Regression for the 2026-05-23 bug where the Okta button hard-coded
+    // /api/auth/okta and dropped the middleware-supplied returnTo, so
+    // clicking a Hive training link landed users on /info instead of the
+    // training-confirmation page.
+    test.setTimeout(60_000);
+
+    const target = "/training/confirmation/XQDDG";
+    await page.goto(`/sign-in?returnTo=${encodeURIComponent(target)}`, {
+      waitUntil: "networkidle",
+      timeout: 45_000,
+    });
+
+    const oktaButton = page.getByRole("link", {
+      name: /Sign in with Burning Man/i,
+    });
+    await expect(oktaButton).toBeVisible({ timeout: 15_000 });
+
+    const href = await oktaButton.getAttribute("href");
+    expect(href).toBe(`/api/auth/okta?returnTo=${encodeURIComponent(target)}`);
+  });
+
   test("/api/auth/okta returns a well-formed 302 to an authorize endpoint", async () => {
     // own request context with redirect-following disabled so we can inspect
     // the 302 itself

--- a/client/src/app/sign-in/SignIn.tsx
+++ b/client/src/app/sign-in/SignIn.tsx
@@ -91,6 +91,16 @@ export const SignIn = () => {
   const isOAuthConfigured = process.env.NEXT_PUBLIC_OKTA_ENABLED === "true";
   const isPinEnabled = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
 
+  // Forward returnTo through the Okta init so the callback can land the user
+  // back where they started (e.g. /training/confirmation/[code] after clicking
+  // a Hive course link). Without this the okta-init URL has no returnTo,
+  // /api/auth/okta/callback falls back to /volunteers/{id}/info, and the
+  // user loses their place in the training-confirmation flow.
+  const returnToParam = searchParams?.get("returnTo");
+  const oktaHref = returnToParam
+    ? `/api/auth/okta?returnTo=${encodeURIComponent(returnToParam)}`
+    : "/api/auth/okta";
+
   // logic
   // ------------------------------------------------------------
   if (error) return <ErrorPage />;
@@ -198,7 +208,7 @@ export const SignIn = () => {
             <CardContent>
               <Button
                 fullWidth
-                href="/api/auth/okta"
+                href={oktaHref}
                 size="large"
                 startIcon={<LoginIcon />}
                 variant="contained"


### PR DESCRIPTION
## Why

@mbhewitt 2026-05-23: after clicking a training-confirmation link (`https://volunteers.census.burningman.org/training/confirmation/XQDDG`) while unauthenticated, sign-in landed users on `/volunteers/{id}/info` instead of back at the training page.

## Trace

1. Unauth `GET /training/confirmation/XQDDG`
2. Middleware bounces with `307 → /sign-in?returnTo=%2Ftraining%2Fconfirmation%2FXQDDG` ✓
3. User clicks the Okta button. **Bug:** href was hard-coded `"/api/auth/okta"`. returnTo dropped.
4. okta-init handler reads no returnTo from query → state has no `|returnTo` segment.
5. Okta callback decodes state, finds no returnTo → falls back to `\`/volunteers/${shiftboardId}/info\``.
6. User lands on info page instead of the training-confirmation page.

## Fix

`client/src/app/sign-in/SignIn.tsx` — forward `searchParams.get("returnTo")` into the button href when present:

```ts
const returnToParam = searchParams?.get("returnTo");
const oktaHref = returnToParam
  ? `/api/auth/okta?returnTo=${encodeURIComponent(returnToParam)}`
  : "/api/auth/okta";
```

```diff
- <Button href="/api/auth/okta" ...>
+ <Button href={oktaHref} ...>
```

No backend changes needed — `/api/auth/okta` already reads `returnTo` from the query, encodes it into the `state` param sent to Okta, and the callback already decodes + honors it on the way back. The pipe was just broken at the button.

## Tests

- **New e2e** in `19-okta-signin-regression.spec.ts`: visiting `/sign-in?returnTo=<X>` renders the Okta button with `href=/api/auth/okta?returnTo=<X-encoded>`. Tested locally — passes.
- **Existing test** that asserts plain `/sign-in` produces `href === "/api/auth/okta"` — still passes (no-returnTo case is unchanged).

## Risk

Very low. One-line semantic change in the button's href, behind a feature flag (`isOAuthConfigured`). The forwarded `returnTo` is URL-encoded so a hostile returnTo can't break out of the URL. The okta callback already validates `returnTo.startsWith("/")` before honoring it, so an external URL can't be smuggled through (it'd be treated as falsy and fall back to the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)