### PR TITLE
fix(vip): use existing banner image on /info hero

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -702,10 +702,13 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
   // ------------------------------------------------------------
   return (
     <>
-      {/* hero */}
+      {/* hero — reuse the account-page banner since the info page is now
+          the canonical volunteer page (per @mbhewitt 2026-05-23). The
+          previous `banner-volunteers.jpg` reference didn't resolve to a
+          file in public/banners. */}
       <Hero
         imageStyles={{
-          backgroundImage: "url(/banners/banner-volunteers.jpg)",
+          backgroundImage: "url(/banners/man-at-night.jpg)",
           backgroundSize: "cover",
         }}
         text="Volunteer Information"


### PR DESCRIPTION
Per @mbhewitt 2026-05-23: "There was a picture banner at the top of the account page could you add that now to the top of the info page?"

## Why

The info page (`/volunteers/[id]/info` — now the canonical volunteer page after #303) had a `<Hero>` with `backgroundImage: "url(/banners/banner-volunteers.jpg)"`. That file isn't in `client/public/banners/` — never shipped — so the hero area rendered with a blank background. The legacy `/account` page used `/banners/man-at-night.jpg`, which *does* ship.

## Fix

```diff
- backgroundImage: "url(/banners/banner-volunteers.jpg)",
+ backgroundImage: "url(/banners/man-at-night.jpg)",
```

One file, two-line diff (plus a comment explaining the swap). No logic changes.

## Test

Visual — needs a browser to verify the banner now shows the man-at-night image at the top of `/volunteers/[id]/info`. No e2e regression appropriate for this (we don't have visual regression in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)