### PR TITLE
fix(training): tidy the confirmed-state card

### DIFF
--- a/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
+++ b/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
@@ -157,10 +157,17 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
                   : `Confirming your completion of ${training.name}…`}
               </Typography>
               {alreadyConfirmed && (
-                <Typography sx={{ mb: 1 }}>
-                  Your <strong>{training.roleName}</strong> role has been added
-                  to your account.
-                </Typography>
+                <Stack direction="row" spacing={2} sx={{ mt: 1, mb: 1 }}>
+                  <MuiLink component={NextLink} href="/shifts">
+                    Browse shifts
+                  </MuiLink>
+                  <MuiLink
+                    component={NextLink}
+                    href={`/volunteers/${shiftboardId}/info`}
+                  >
+                    Your volunteer checklist
+                  </MuiLink>
+                </Stack>
               )}
               {training.url && (
                 <Typography sx={{ mt: 2 }}>
@@ -180,19 +187,6 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
               )}
             </CardContent>
           </Card>
-        </Box>
-        <Box component="section">
-          <Stack direction="row" spacing={2}>
-            <MuiLink component={NextLink} href="/shifts">
-              Browse shifts
-            </MuiLink>
-            <MuiLink
-              component={NextLink}
-              href={`/volunteers/${shiftboardId}/info`}
-            >
-              Your volunteer page
-            </MuiLink>
-          </Stack>
         </Box>
       </Container>
     </>


### PR DESCRIPTION
Per @mbhewitt 2026-05-23: "remove this line 'Your TrainingCensusBasicsComplete role has been added to your account.' put browse shifts and your volunteer checklist in its place."

## Changes

`client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx`:

- **Removed** the `<Typography>Your <strong>{training.roleName}</strong> role has been added to your account.</Typography>` line. The raw role identifier (`TrainingCensusBasicsComplete`) is ugly and the info is redundant with the thank-you headline above it.
- **Moved** the Browse-shifts / volunteer links into the card, in the slot the removed line vacated. They were previously in a separate `<Box>` below the card.
- **Renamed** "Your volunteer page" → "Your volunteer checklist". Matches the framing the volunteer actually expects to find when clicked.

Net effect: the confirmed-state card is now one tight block — thank-you headline, two links (Browse shifts, Your volunteer checklist), and (when present) the training-material link. The trailing bottom section is gone.

## Tests

API unchanged. Existing e2e tests in `22-training-confirmation.spec.ts` still pass — no behavior change to the GET / POST endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)