### PR TITLE
fix(shifts): dedupe by shift_times_id (was a fragile linear check)

### DIFF
--- a/client/e2e/tests/20-on-playa-shifts-open.spec.ts
+++ b/client/e2e/tests/20-on-playa-shifts-open.spec.ts
@@ -25,4 +25,26 @@ test.describe("On-playa: /shifts is reachable without a session", () => {
     const body = await res.json();
     expect(Array.isArray(body)).toBe(true);
   });
+
+  test("GET /api/shifts returns no duplicate shift_times_ids", async ({
+    request: req,
+  }) => {
+    // Regression for the 2026-05-23 dedupe bug in getShiftList: the
+    // previous linear "is the last pushed item the same?" check broke
+    // when two shifts shared (date, start_time_text) and the SQL ORDER BY
+    // interleaved their position rows. Re-check that each shift appears
+    // exactly once in the response.
+    const res = await req.get("/api/shifts");
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+
+    const ids = body.map((s: { id: number }) => s.id);
+    const seen = new Set<number>();
+    const dupes: number[] = [];
+    for (const id of ids) {
+      if (seen.has(id)) dupes.push(id);
+      seen.add(id);
+    }
+    expect(dupes).toEqual([]);
+  });
 });

--- a/client/src/utils/getShiftList.ts
+++ b/client/src/utils/getShiftList.ts
@@ -2,12 +2,23 @@ import { RowDataPacket } from "mysql2";
 
 import type { IResShiftRowItem } from "@/components/types/shifts";
 
+// Collapse the per-position-per-volunteer rows that come out of /api/shifts
+// into one IResShiftRowItem per shift_times_id, summing slotsTotal across
+// distinct positions and slotsFilled across rows that have a shiftboard_id.
+//
+// Previously this used a "is the last pushed item the same shift?" check,
+// which silently broke when two shifts shared the exact same
+// (date, start_time_text) — the SQL `ORDER BY d.date, st.start_time_text`
+// interleaved their position rows, so the linear dedupe lost. Switched to
+// a Map keyed by shift_times_id so the dedupe is order-independent.
+// (Observed 2026-05-23 on prod: Data Entry and Airport Sampling both at
+// Aug 31 09:00 → each appeared twice on /shifts.)
 export const getShiftList = (dbShiftList: RowDataPacket[]) => {
-  const timePositionIdMap: { [key: string]: boolean } = {};
-  const shiftListNew: IResShiftRowItem[] = [];
+  const timePositionSeen: Set<number> = new Set();
+  const shiftMap: Map<number, IResShiftRowItem> = new Map();
 
-  dbShiftList.forEach(
-    ({
+  dbShiftList.forEach((row: RowDataPacket) => {
+    const {
       date,
       datename,
       department,
@@ -21,43 +32,39 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
       start_time_text,
       slots,
       time_position_id,
-    }: RowDataPacket) => {
-      const dbShiftLast: IResShiftRowItem | undefined = shiftListNew.at(-1);
+    } = row;
 
-      // if the database row has new time position ID
-      // then create new object
-      if (!dbShiftLast || dbShiftLast.id !== shift_times_id) {
-        timePositionIdMap[time_position_id] = true;
-
-        const dbShiftItemNew: IResShiftRowItem = {
-          category: { id: shift_category_id },
-          date: date,
-          dateName: datename ?? "",
-          department: { name: department ?? "" },
-          endTime: end_time ?? end_time_text,
-          id: shift_times_id,
-          slotsFilled: shiftboard_id ? 1 : 0,
-          slotsTotal: slots,
-          startTime: start_time ?? start_time_text,
-          type: shift_name,
-        };
-
-        shiftListNew.push(dbShiftItemNew);
-      }
-
-      // if database row has same shift times ID
-      // but has new position ID
-      // then add to total slots
-      if (dbShiftLast && !timePositionIdMap[time_position_id]) {
-        timePositionIdMap[time_position_id] = true;
-        dbShiftLast.slotsTotal += slots;
-      }
-      // if volunteer ID exists
-      // then add to filled slots
-      if (dbShiftLast && dbShiftLast.id === shift_times_id && shiftboard_id)
-        dbShiftLast.slotsFilled += 1;
+    let shift = shiftMap.get(shift_times_id);
+    if (!shift) {
+      shift = {
+        category: { id: shift_category_id },
+        date,
+        dateName: datename ?? "",
+        department: { name: department ?? "" },
+        endTime: end_time ?? end_time_text,
+        id: shift_times_id,
+        slotsFilled: 0,
+        slotsTotal: 0,
+        startTime: start_time ?? start_time_text,
+        type: shift_name,
+      };
+      shiftMap.set(shift_times_id, shift);
     }
-  );
 
-  return shiftListNew;
+    // slotsTotal: each distinct position contributes its `slots` value once
+    if (!timePositionSeen.has(time_position_id)) {
+      timePositionSeen.add(time_position_id);
+      shift.slotsTotal += slots;
+    }
+
+    // slotsFilled: each row with a non-null shiftboard_id is one assignment
+    if (shiftboard_id) {
+      shift.slotsFilled += 1;
+    }
+  });
+
+  // Map iteration preserves insertion order, so the output keeps the order
+  // the first row of each shift appeared in (date + start_time_text from
+  // the SQL ORDER BY).
+  return Array.from(shiftMap.values());
 };


### PR DESCRIPTION
Per @mbhewitt 2026-05-23: duplicate shifts visible on `/shifts`. Confirmed by pulling the live `/api/shifts` response — `shift_times_id` 33 (Data Entry, Aug 31 09:00) and 927074 (Airport Sampling, Aug 31 09:00) both appearing twice in the same response.

## Bug

`client/src/utils/getShiftList.ts` decided whether a row started a new shift by comparing it only to the *immediately previous* pushed shift:

```ts
const dbShiftLast = shiftListNew.at(-1);
if (!dbShiftLast || dbShiftLast.id !== shift_times_id) {
  shiftListNew.push(...);
}
```

That works as long as all rows for a given `shift_times_id` sit consecutively in the SQL result. But `/api/shifts` orders by `d.date, st.start_time_text`, so when two different shifts share the same date+time their per-position rows interleave:

```
DE-pos1, AS-pos1, DE-pos2, AS-pos2
```

Each row sees the previous row as a different shift → both end up duplicated in the response. Pre-existing — un-cancelling 13 shifts earlier today just made it noticeable.

## Fix

Rewrite to a `Map<shift_times_id, shift>`. Order-independent collapse. `slotsTotal` still sums distinct positions via a Set of seen `time_position_id`s. `slotsFilled` still increments per row with a non-null `shiftboard_id`. Map iteration preserves insertion order so the output keeps the same date+time ordering as before.

## Tests

New e2e assertion in `client/e2e/tests/20-on-playa-shifts-open.spec.ts` — `/api/shifts` response must have no duplicate `shift_times_id`s. Passes locally.

## Risk

Behavioral change is the absence of duplicates — same shift, same counts, just no duplicate rows. No other surfaces touch `getShiftList`. All callsites (`/api/shifts` single use) return the same `IResShiftRowItem[]` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)