### PR TITLE
docs(prod-deploy): add tcp_keepalive sysctls to compose template

### DIFF
--- a/PROD_DEPLOY.md
+++ b/PROD_DEPLOY.md
@@ -125,6 +125,16 @@ services:
       - ./client/.env.production
     security_opt:
       - apparmor:unconfined
+    sysctls:
+      # Tighten kernel TCP keep-alive retry math so dead pool
+      # connections surface in ~30s instead of Linux's default ~11min
+      # (defaults: tcp_keepalive_intvl=75, tcp_keepalive_probes=9 →
+      # 75 × 9 = 675s after the first probe before the kernel
+      # declares dead). Pairs with the mysql2 keepAliveInitialDelay
+      # in client/lib/database.ts. Both are net-namespaced sysctls so
+      # docker allows them without privileged mode.
+      net.ipv4.tcp_keepalive_intvl: "10"
+      net.ipv4.tcp_keepalive_probes: "3"
     ports:
       - "127.0.0.1:3000:3000"   # bound to loopback; nginx is the public face
     restart: always


### PR DESCRIPTION
Per the root-cause investigation (Discord 2026-05-24): Linux's default TCP keep-alive retry math (`tcp_keepalive_intvl=75s × tcp_keepalive_probes=9`) means a dead pool connection sits ~11 minutes before the kernel declares it dead. With those overridden to 10s / 3 probes the kernel declares dead in ~30s.

## What's in this PR

One file: `PROD_DEPLOY.md`. Adds a `sysctls:` block to the documented `docker-compose-prod.yaml` template so future prod stand-ups include it by default. These are net-namespaced sysctls so docker allows them without privileged mode.

```yaml
sysctls:
  net.ipv4.tcp_keepalive_intvl: "10"
  net.ipv4.tcp_keepalive_probes: "3"
```

## What's still required to land on the current prod box

`docker-compose-prod.yaml` lives only on the prod EC2 box (gitignored), so this PR doesn't change anything on the running deploy. The same sysctls block has to be added there manually, then the container restarted with `docker compose --file docker-compose-prod.yaml up -d --force-recreate` so the new sysctls take effect. I'll do that as an out-of-band operation once this PR is approved (or before, if you OK).

## Sibling

Pairs with #320 (app-layer retry-on-ETIMEDOUT) and with the existing pool keep-alive config from #296. Defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)