### PR TITLE
fix(middleware): allowlist /api/volunteers/account for self-signup POST

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -38,9 +38,14 @@ const ALLOWLIST = [
   "/help",
   "/reports",
 
-  // Account creation (lets new volunteers self-register)
+  // Account creation (lets new volunteers self-register).
+  // The page is at /volunteers/account/create but it POSTs to
+  // /api/volunteers/account (no /create suffix — the handler file is
+  // client/src/pages/api/volunteers/account/index.ts). Without the
+  // bare /api/volunteers/account entry the self-signup POST gets 401
+  // from this middleware before reaching the handler.
   "/volunteers/account/create",
-  "/api/volunteers/account/create",
+  "/api/volunteers/account",
 
   // Volunteer dropdown for sign-in autocomplete — needed for on-playa
   // passcode UI. Off-playa Okta-only mode will gate this via PR #275.


### PR DESCRIPTION
## Summary

Hotfix #288 added a global middleware allowlist that gates everything not explicitly listed. The self-signup page at `/volunteers/account/create` was allowlisted, but the API endpoint it POSTs to is `/api/volunteers/account` (no `/create` suffix — the handler file is `client/src/pages/api/volunteers/account/index.ts`).

The previous allowlist entry `/api/volunteers/account/create` did not match any real endpoint, so every unauthenticated signup attempt got 401'd by middleware before reaching the handler. Surfaced by the 2026-05-23 pre-launch audit.

This PR replaces the dead entry with the correct path. The broader prefix only matches the single signup handler — per-volunteer endpoints live under `/api/volunteers/[shiftboardId]/account/...` (different URL pattern) and remain gated.

## Test plan
- [ ] On main locally, hit POST `/api/volunteers/account` unauthenticated → expect 401 (middleware blocks).
- [ ] On this branch, hit POST `/api/volunteers/account` unauthenticated → expect handler runs (validates payload, creates row, or returns handler-level error — anything except middleware 401).
- [ ] Confirm `/api/volunteers/[shiftboardId]/account` and `/api/volunteers/[shiftboardId]/account/passcode` still 401 unauthenticated (they don't match the new prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)