### PR TITLE
ui(checklist): underline the Behavioral Standards Agreement link

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -484,7 +484,11 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
         </Typography>
         <Link
           href={`/roles/behavioral-standards/${shiftboardId}`}
-          style={{ color: theme.palette.primary.main, fontWeight: 500 }}
+          style={{
+            color: theme.palette.primary.main,
+            fontWeight: 500,
+            textDecoration: "underline",
+          }}
         >
           Review and sign the Behavioral Standards Agreement
         </Link>


### PR DESCRIPTION
## Summary

Per Chipper feedback 2026-05-24: the checklist's link to the Behavioral Standards Agreement was bold + brown but had no underline, so it didn't read as a link. This adds `textDecoration: \"underline\"` to match the styling already used by training links elsewhere in the same checklist (`VolunteerInfo.tsx:530`).

Single-attribute style addition, one file, no behavior change.

## Test plan
- [ ] Visit `/volunteers/<id>/info`, expand the Behavioral Standards checklist item, confirm the \"Review and sign the Behavioral Standards Agreement\" link is underlined.
- [ ] Confirm clicking the link still navigates to `/roles/behavioral-standards/<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)