### PR TITLE
ui(header): hide Shifts menu item when unauth off-playa

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -194,7 +194,19 @@ export const Header = () => {
           <Box>
             {/* general nav */}
             <List>
-              {pageListDefault.map(({ icon, label, path }) => (
+              {pageListDefault
+                .filter(({ path }) => {
+                  // Off-playa /shifts requires auth (middleware redirects
+                  // to sign-in). Hide the menu entry for unauthenticated
+                  // users so it doesn't appear to "go nowhere". On-playa
+                  // walk-up flow keeps it visible — /shifts is in the
+                  // on-playa allowlist there.
+                  if (path === "/shifts" && !isAuthenticated && !isOnPlaya) {
+                    return false;
+                  }
+                  return true;
+                })
+                .map(({ icon, label, path }) => (
                 <ListItem disablePadding key={path}>
                   <Link href={path} onClick={handleDrawerClose}>
                     <ListItemButton selected={pathname === path}>


### PR DESCRIPTION
## Summary

Per Chipper feedback 2026-05-24: the \"Shifts\" entry in the drawer menu is visible to unauthenticated users, but off-playa the `/shifts` route is gated by the middleware allowlist. Clicking it redirects to `/sign-in?returnTo=/shifts` — Chipper described this as \"goes nowhere\" (visually the menu item just bounces the user away).

Adds a filter: when **unauthenticated AND off-playa**, drop the Shifts entry from `pageListDefault` before rendering. On-playa walk-up flow still shows it — `/shifts` is in the on-playa allowlist there so anonymous users can browse what's available.

Authenticated users in both deployments continue to see the entry.

## Test plan
- [ ] Off-playa, signed out → drawer menu has Home / Reports / Help / Contact, no Shifts.
- [ ] Off-playa, signed in → drawer menu shows Shifts.
- [ ] On-playa, signed out → drawer menu still shows Shifts (walk-up path).
- [ ] On-playa, signed in → drawer menu shows Shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)