### PR TITLE
ui(contact): rename heading to "Off-playa contact form"

### DIFF
--- a/client/e2e/tests/06-contact-form.spec.ts
+++ b/client/e2e/tests/06-contact-form.spec.ts
@@ -39,7 +39,7 @@ test.describe("Contact Form", () => {
     await page.goto("/contact");
 
     await expect(
-      page.getByText("Post-burn contact form")
+      page.getByText("Off-playa contact form")
     ).toBeVisible({ timeout: 10_000 });
   });
 

--- a/client/src/app/contact/Contact.tsx
+++ b/client/src/app/contact/Contact.tsx
@@ -169,7 +169,7 @@ export const Contact = () => {
       <Container component="main">
         <Box component="section">
           <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
-            Post-burn contact form
+            Off-playa contact form
           </Typography>
           <Card>
             <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
## Summary

Per Chipper feedback + Mew approval (2026-05-24): the Contact page heading is the off-playa contact channel year-round, not just post-burn. Renaming makes the purpose clear and also obviates the BM Editorial capitalization point Chipper raised ("Burn" requires capital B) by removing the word entirely.

One-line copy change in `Contact.tsx:172`.

## Test plan
- [ ] Visit `/contact`, confirm heading reads "Off-playa contact form".
- [ ] Confirm the form itself, submission, and validation behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)