### PR TITLE
fix(burner-profile): delete role row on uncheck so it actually unchecks

### DIFF
--- a/client/src/pages/api/volunteers/[shiftboardId]/info/profile-updated/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/profile-updated/index.ts
@@ -15,9 +15,25 @@ const profileUpdated = async (req: NextApiRequest, res: NextApiResponse) => {
     // ------------------------------------------------------------
     case "POST": {
       const { updated }: IReqToggleProfileUpdated = JSON.parse(req.body);
-      const [addRole, removeRole] = [updated === true, updated === false];
 
-      // check if role row exists
+      // GET (info/index.ts) computes burnerProfileUpdated from row
+      // existence: `roleIdSet.has(ROLE_BURNER_PROFILE_UPDATED_ID)`.
+      // So to actually uncheck the box we must DELETE the row;
+      // flipping add_role/remove_role keeps it visible. (Issue #332)
+      if (updated === false) {
+        await pool.query<RowDataPacket[]>(
+          `DELETE FROM op_volunteer_roles
+          WHERE role_id=?
+          AND shiftboard_id=?`,
+          [ROLE_BURNER_PROFILE_UPDATED_ID, shiftboardId]
+        );
+        return res.status(200).json({
+          statusCode: 200,
+          message: "Deleted",
+        });
+      }
+
+      // updated === true: ensure the row exists with add_role=true.
       const [dbVolunteerRoleList] = await pool.query<RowDataPacket[]>(
         `SELECT shiftboard_id
         FROM op_volunteer_roles
@@ -28,16 +44,14 @@ const profileUpdated = async (req: NextApiRequest, res: NextApiResponse) => {
       const [dbVolunteerRoleFirst] = dbVolunteerRoleList;
 
       if (dbVolunteerRoleFirst) {
-        // update existing row
         await pool.query<RowDataPacket[]>(
           `UPDATE op_volunteer_roles
           SET add_role=?, remove_role=?
           WHERE role_id=?
           AND shiftboard_id=?`,
-          [addRole, removeRole, ROLE_BURNER_PROFILE_UPDATED_ID, shiftboardId]
+          [true, false, ROLE_BURNER_PROFILE_UPDATED_ID, shiftboardId]
         );
       } else {
-        // insert new row
         await pool.query<RowDataPacket[]>(
           `INSERT INTO op_volunteer_roles (
             add_role,
@@ -46,7 +60,7 @@ const profileUpdated = async (req: NextApiRequest, res: NextApiResponse) => {
             shiftboard_id
           )
           VALUES (?, ?, ?, ?)`,
-          [addRole, removeRole, ROLE_BURNER_PROFILE_UPDATED_ID, shiftboardId]
+          [true, false, ROLE_BURNER_PROFILE_UPDATED_ID, shiftboardId]
         );
       }
 


### PR DESCRIPTION
Fixes #332.

## The bug
Found by Chipper (Discord, 2026-05-24): clicking the "I have reviewed and updated my Burner Profile" checkbox to uncheck has no effect — refreshing the page snaps it back to checked.

## Root cause
`profile-updated/index.ts` (POST) updates `add_role=false, remove_role=true` on uncheck but leaves the row in place. `info/index.ts:301` (GET) reads:

```ts
const burnerProfileUpdated = roleIdSet.has(ROLE_BURNER_PROFILE_UPDATED_ID);
```

— so the row existing is enough to report the box as checked, regardless of the flags.

## Fix
When `updated === false`, DELETE the row. Same pattern as `handleRoleToggle` in `VolunteerInfo.tsx:335` which already uses DELETE against `/api/roles/<id>/volunteers` for the admin role-toggle UI.

The "checked" path is unchanged in behavior — just simplified to hardcode `add_role=true, remove_role=false` since the parameterized form wasn't doing anything different.

## Data revert
Alek (shiftboard_id 38872) has the spurious row from Chipper's accidental click — needs a one-off `DELETE FROM op_volunteer_roles WHERE shiftboard_id = 38872 AND role_id = 2000010` so they don't see a phantom check after deploy. Awaiting Mew's OK.

## Test plan
- [ ] Pre-deploy DB revert for Alek.
- [ ] As any volunteer, check the box, refresh → still checked.
- [ ] Uncheck → refresh → still unchecked.
- [ ] Re-check after uncheck → refresh → checked again.
- [ ] Verify checkbox state on `/volunteers/<id>/info` matches DB row presence in `op_volunteer_roles` for `role_id=2000010`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)