### PR TITLE
ui(sign-in): redirect / to /sign-in and tighten sign-in copy

### DIFF
--- a/client/e2e/tests/19-okta-signin-regression.spec.ts
+++ b/client/e2e/tests/19-okta-signin-regression.spec.ts
@@ -40,7 +40,7 @@ test.describe("Sign-in regression net", () => {
     await page.goto("/sign-in", { waitUntil: "networkidle", timeout: 45_000 });
 
     const oktaButton = page.getByRole("link", {
-      name: /Sign in with Burning Man/i,
+      name: /Sign in to Census/i,
     });
     await expect(oktaButton).toBeVisible({ timeout: 15_000 });
 
@@ -75,7 +75,7 @@ test.describe("Sign-in regression net", () => {
     });
 
     const oktaButton = page.getByRole("link", {
-      name: /Sign in with Burning Man/i,
+      name: /Sign in to Census/i,
     });
     await expect(oktaButton).toBeVisible({ timeout: 15_000 });
 

--- a/client/src/app/sign-in/SignIn.tsx
+++ b/client/src/app/sign-in/SignIn.tsx
@@ -30,7 +30,6 @@ import useSWRMutation from "swr/mutation";
 import { ErrorPage } from "@/components/general/ErrorPage";
 import { Loading } from "@/components/general/Loading";
 import { SnackbarText } from "@/components/general/SnackbarText";
-import { Hero } from "@/components/layout/Hero";
 import type { IVolunteerOption } from "@/components/types";
 import type { IReqSignIn } from "@/components/types/sign-in";
 import type { IResVolunteerDefaultItem } from "@/components/types/volunteers";
@@ -177,14 +176,7 @@ export const SignIn = () => {
   // ------------------------------------------------------------
   return (
     <>
-      <Hero
-        imageStyles={{
-          backgroundImage: "url(/banners/desk-group.jpg)",
-          backgroundSize: "cover",
-        }}
-        text="Sign in"
-      />
-      <Container component="main">
+      <Container component="main" sx={{ pt: 3 }}>
         <Card
           sx={{
             margin: "auto",
@@ -213,7 +205,7 @@ export const SignIn = () => {
                 startIcon={<LoginIcon />}
                 variant="contained"
               >
-                Sign in with Burning Man
+                Sign in to Census
               </Button>
               {isPinEnabled && (
                 <Divider sx={{ mt: 2 }}>

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -63,7 +63,10 @@ const ALLOWLIST = [
   ...(isOnPlaya ? ["/shifts", "/api/shifts"] : []),
 ];
 
-const PUBLIC_PATHS = new Set(["/"]);
+// Closes #306: unauthenticated visitors hit /sign-in directly instead of
+// landing on the marketing Home page and hunting for the sign-in link.
+// Signed-in users still get /sign-in's auto-redirect → home.
+const PUBLIC_PATHS = new Set<string>();
 
 function isAllowlisted(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return true;


### PR DESCRIPTION
Closes #306.

## Summary
Three coordinated UX changes from the Mew/John discussion (Discord, 2026-05-24):

1. **Redirect `/` to `/sign-in` for unauth users.** Drops `/` from `PUBLIC_PATHS` in middleware. Unauthenticated visitors get `307 → /sign-in?returnTo=/` instead of landing on Home and hunting for sign-in. Signed-in users still see Home at `/`.

2. **Drop the giant \"Sign in\" Hero from the sign-in page.** John: \"I've always felt the welcome page was confusing because it feels like the scheduler app wants to be the org website. We're so much better than that.\" The page now opens with the sign-in card directly — focused on the action, not the branding.

3. **Rename Okta button.** \"Sign in with Burning Man\" → \"Sign in to Census\". John: \"There are four people in the world that understand 'Sign in with Burning Man' is correct, but others will want us to explain what's happening.\" Mew + John converged on \"Sign in to Census\" — short, unambiguous, plain-English.

## Files
- `client/src/middleware.ts` — `PUBLIC_PATHS = new Set<string>()`.
- `client/src/app/sign-in/SignIn.tsx` — remove `<Hero>`, update button text, drop unused `Hero` import.
- `client/e2e/tests/19-okta-signin-regression.spec.ts` — update both button-text assertions to match new copy.

## Test plan
- [ ] Unauth `GET /` → 307 to `/sign-in?returnTo=%2F`.
- [ ] Signed-in `GET /` → 200, Home page.
- [ ] `/sign-in` renders without the giant top banner; sign-in card visible immediately.
- [ ] Okta button text reads \"Sign in to Census\"; clicking still goes to `/api/auth/okta`.
- [ ] Existing Playwright regression spec passes against the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)