### PR TITLE
feat(shifts): show CSP on /shifts list + /shifts/[timeId]/volunteers

### DIFF
--- a/client/src/app/shifts/Shifts.tsx
+++ b/client/src/app/shifts/Shifts.tsx
@@ -125,6 +125,13 @@ export const Shifts = () => {
         sort: false,
       },
     },
+    {
+      name: "CSP",
+      options: {
+        filter: false,
+        sort: false,
+      },
+    },
   ]);
 
   // fetching, mutation, and revalidation
@@ -242,6 +249,8 @@ export const Shifts = () => {
   const colorMapDisplay = getColorMap(data);
   const dataTable = data.map(
     ({
+      cspMax,
+      cspMin,
       date,
       dateName,
       department: { name: departmentName },
@@ -252,6 +261,8 @@ export const Shifts = () => {
       startTime,
       type,
     }) => {
+      const cspDisplay =
+        cspMin === cspMax ? `${cspMin}` : `${cspMin}-${cspMax}`;
       return [
         id, // hide for row click
         date, // hide for filter dialog (Present/Future vs Past)
@@ -264,6 +275,7 @@ export const Shifts = () => {
           sx={{ backgroundColor: colorMapDisplay[departmentName] }}
         />,
         `${slotsFilled} / ${slotsTotal}`,
+        cspDisplay,
       ];
     }
   );

--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -378,10 +378,22 @@ export const ShiftVolunteers = ({
         sort: false,
       },
     },
+    {
+      name: "CSP",
+      options: {
+        filter: false,
+        sort: false,
+      },
+    },
   ];
   const dataTablePositions = dataShiftVolunteersItem.positionList.map(
-    ({ positionName, slotsFilled, slotsTotal }: IResShiftPositionCountItem) => {
-      return [positionName, `${slotsFilled} / ${slotsTotal}`];
+    ({
+      csp,
+      positionName,
+      slotsFilled,
+      slotsTotal,
+    }: IResShiftPositionCountItem) => {
+      return [positionName, `${slotsFilled} / ${slotsTotal}`, csp];
     }
   );
   const optionListCustomPositions = {

--- a/client/src/components/types/shifts/index.ts
+++ b/client/src/components/types/shifts/index.ts
@@ -4,6 +4,10 @@ export interface IResShiftRowItem {
   category: {
     id: number;
   };
+  // Min / max sap_points across the shift's positions. Equal when every
+  // position pays the same; different otherwise (UI renders a range).
+  cspMin: number;
+  cspMax: number;
   date: string;
   dateName: string;
   department: {
@@ -26,6 +30,9 @@ export interface IReqShiftVolunteerItem {
 // details
 // ------------------------------------------------------------
 export interface IResShiftPositionCountItem {
+  // sap_points for the position; surfaced in the positions table on
+  // /shifts/[timeId]/volunteers and used wherever CSP per position is shown.
+  csp: number;
   positionDetails: string;
   positionId: number;
   positionName: string;

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -38,6 +38,7 @@ const shiftVolunteers = async (req: NextApiRequest, res: NextApiResponse) => {
           st.start_time,
           st.start_time_text,
           stp.position_type_id,
+          stp.sap_points,
           stp.slots,
           stp.time_position_id
         FROM op_shift_times AS st
@@ -94,10 +95,12 @@ const shiftVolunteers = async (req: NextApiRequest, res: NextApiResponse) => {
           position,
           prerequisite_id,
           role_id,
+          sap_points,
           slots,
           time_position_id,
         }) => {
           const resShiftPositionItem: IResShiftPositionCountItem = {
+            csp: Number(sap_points ?? 0),
             positionDetails: position_details,
             positionId: position_type_id,
             positionName: position,

--- a/client/src/pages/api/shifts/index.ts
+++ b/client/src/pages/api/shifts/index.ts
@@ -27,6 +27,7 @@ const shifts = async (req: NextApiRequest, res: NextApiResponse) => {
             st.shift_times_id,
             st.start_time,
             st.start_time_text,
+            stp.sap_points,
             stp.slots,
             stp.time_position_id,
             vs.remove_shift,
@@ -66,6 +67,7 @@ const shifts = async (req: NextApiRequest, res: NextApiResponse) => {
             st.shift_times_id,
             st.start_time,
             st.start_time_text,
+            stp.sap_points,
             stp.slots,
             stp.time_position_id,
             vs.shiftboard_id

--- a/client/src/utils/getShiftList.ts
+++ b/client/src/utils/getShiftList.ts
@@ -24,6 +24,7 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
       department,
       end_time,
       end_time_text,
+      sap_points,
       shift_category_id,
       shift_name,
       shift_times_id,
@@ -38,6 +39,8 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
     if (!shift) {
       shift = {
         category: { id: shift_category_id },
+        cspMin: Number.POSITIVE_INFINITY,
+        cspMax: Number.NEGATIVE_INFINITY,
         date,
         dateName: datename ?? "",
         department: { name: department ?? "" },
@@ -51,10 +54,15 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
       shiftMap.set(shift_times_id, shift);
     }
 
-    // slotsTotal: each distinct position contributes its `slots` value once
+    // slotsTotal + cspMin/Max: each distinct position contributes its `slots`
+    // and `sap_points` once. (LEFT JOIN op_volunteer_shifts multiplies rows
+    // per position when several volunteers are assigned.)
     if (!timePositionSeen.has(time_position_id)) {
       timePositionSeen.add(time_position_id);
       shift.slotsTotal += slots;
+      const csp = Number(sap_points ?? 0);
+      if (csp < shift.cspMin) shift.cspMin = csp;
+      if (csp > shift.cspMax) shift.cspMax = csp;
     }
 
     // slotsFilled: each row with a non-null shiftboard_id is one assignment
@@ -62,6 +70,13 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
       shift.slotsFilled += 1;
     }
   });
+
+  // Normalize: a shift with no positions never updated the CSP sentinels.
+  // Collapse to 0 so the UI doesn't render Infinity / -Infinity.
+  for (const shift of shiftMap.values()) {
+    if (!Number.isFinite(shift.cspMin)) shift.cspMin = 0;
+    if (!Number.isFinite(shift.cspMax)) shift.cspMax = 0;
+  }
 
   // Map iteration preserves insertion order, so the output keeps the order
   // the first row of each shift appeared in (date + start_time_text from


### PR DESCRIPTION
Closes #339.

## Summary

Volunteers couldn't see CSP value until *after* sign-up — they had to take a position blind, then check `/info` to learn what it was worth. Mew flagged this after debugging a \"21 CSP feels high\" report; turned out the math was right but the visibility was missing.

Two surfaces get the new column:

1. **`/shifts`** (list page) — new \"CSP\" column. Renders a single number when every position on the shift agrees (the common case), or a range like `2-4` when they differ. Format chosen by Mew.

2. **`/shifts/[timeId]/volunteers`** — the positions table at the top gets a per-position \"CSP\" column alongside the existing Name and Filled / Total columns.

## Files
- `client/src/pages/api/shifts/index.ts` — both training and non-training SELECTs now fetch `stp.sap_points`.
- `client/src/pages/api/shifts/[timeId]/volunteers/index.ts` — position SELECT fetches `stp.sap_points`; payload exposes it as `csp`.
- `client/src/utils/getShiftList.ts` — track `cspMin` / `cspMax` per shift while iterating the LEFT-JOIN row stream. Sentinels normalized to 0 in the (defensive) no-position case.
- `client/src/components/types/shifts/index.ts` — additive: `IResShiftRowItem` gains `cspMin`/`cspMax`; `IResShiftPositionCountItem` gains `csp`. Existing destructuring callsites compile unchanged.
- `client/src/app/shifts/Shifts.tsx` — column def + cell formatter (single vs range).
- `client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx` — column def + cell formatter.

## Out of scope
- The position-picker dropdown (`ShiftVolunteersDialogAdd.tsx`) doesn't yet show CSP — Mew's explicit ask was the list page and the positions table, not the picker. If wanted, that's a small follow-up using the same `csp` field already exposed by the API.

## Test plan
- [ ] `/shifts` shows a \"CSP\" column. Shifts where all positions share `sap_points` show one number (e.g. `4`); shifts with varying values show a range (e.g. `2-4`).
- [ ] `/shifts/<timeId>/volunteers` positions table shows a \"CSP\" column matching each position's `sap_points`.
- [ ] Existing slot-count math unchanged (Map-keyed dedupe from #318 stays correct — verified by reading the modified getShiftList against the existing tests' expected shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)