### PR TITLE
ui(shifts): move CSP column before Type + pink/bold filled count if open

### DIFF
--- a/client/src/app/shifts/Shifts.tsx
+++ b/client/src/app/shifts/Shifts.tsx
@@ -79,6 +79,13 @@ export const Shifts = () => {
       options: { filter: false, sortThirdClickReset: true },
     },
     {
+      name: "CSP",
+      options: {
+        filter: false,
+        sort: false,
+      },
+    },
+    {
       name: columnNameTypeHidden, // hide for filter dialog
       label: "Type",
       options: {
@@ -108,6 +115,31 @@ export const Shifts = () => {
     {
       name: "Filled / Total",
       options: {
+        // Underlying value stays "<filled> / <total>" so the filter logic
+        // below and the existing Date-row alternation (which sorts by
+        // string) keep working. customBodyRender just transforms the cell
+        // *display*: highlight the filled count in pink + bold when the
+        // shift still has open slots (Mew, 2026-05-25).
+        customBodyRender: (value: string) => {
+          const [filledStr, totalStr] = value.split(" / ");
+          const filled = Number(filledStr);
+          const total = Number(totalStr);
+          const isOpen = filled < total;
+          if (!isOpen) return value;
+          return (
+            <span>
+              <span
+                style={{
+                  color: theme.palette.secondary.main,
+                  fontWeight: 700,
+                }}
+              >
+                {filledStr}
+              </span>
+              {` / ${totalStr}`}
+            </span>
+          );
+        },
         filterOptions: {
           logic: (value: string, filterValue: string[]) => {
             const [filled, total] = value
@@ -122,13 +154,6 @@ export const Shifts = () => {
           },
           names: ["Full", "Open"],
         },
-        sort: false,
-      },
-    },
-    {
-      name: "CSP",
-      options: {
-        filter: false,
         sort: false,
       },
     },
@@ -268,6 +293,7 @@ export const Shifts = () => {
         date, // hide for filter dialog (Present/Future vs Past)
         formatDateName(date, dateName),
         formatTime(startTime, endTime),
+        cspDisplay,
         type, // hide for filter dialog
         <Chip
           key={`${id}-chip`}
@@ -275,7 +301,6 @@ export const Shifts = () => {
           sx={{ backgroundColor: colorMapDisplay[departmentName] }}
         />,
         `${slotsFilled} / ${slotsTotal}`,
-        cspDisplay,
       ];
     }
   );


### PR DESCRIPTION
Two small tweaks from Mew (2026-05-25, follow-up to #340):

## Changes

1. **CSP column position**: was rightmost, now sits between Time and Type. Column index reordering only touches positions 4-7 in the dataTable row; indexes 0 (id for row click), 1 (hidden date for sort), and 2 (display date for row alternation) are untouched, so existing `sortCompare` / `setRowProps` / `onRowClick` keep working.

2. **Filled count emphasis**: when `filled < total`, the filled portion of the cell renders in **pink + bold** (e.g. `**2** / 5`). Full shifts (`filled >= total`) render plain. Uses `customBodyRender` so the underlying string `"<filled> / <total>"` is preserved for the Full / Open filter logic that splits on `" / "`.

## Pink reference
`theme.palette.secondary.main` — Census brand pink (#EA008B per the Standards doc).

## Test plan
- [ ] /shifts column order: Date / Time / **CSP** / Type / Filled / Total.
- [ ] Open shift (e.g. 0 / 5): "0" is pink and bold; " / 5" is plain.
- [ ] Full shift (e.g. 5 / 5): plain text.
- [ ] Full / Open filter still works.
- [ ] Row click still navigates to /shifts/<id>/volunteers (column index 0 untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)