### PR TITLE
ui(training-confirmation): redesign per Chipper's mockup

### DIFF
--- a/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
+++ b/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
@@ -153,8 +153,8 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
             <CardContent>
               <Typography component="h2" sx={{ mb: 1 }} variant="h5">
                 {alreadyConfirmed
-                  ? `Thank you, ${volunteer.playaName}, for confirming completion of ${training.name}!`
-                  : `Confirming your completion of ${training.name}…`}
+                  ? `Thank you, ${volunteer.playaName}, for confirming completion of ${training.name} training!`
+                  : `Confirming your completion of ${training.name} training…`}
               </Typography>
               {alreadyConfirmed && (
                 <Typography sx={{ mb: 1 }}>

--- a/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
+++ b/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { OpenInNew as OpenInNewIcon } from "@mui/icons-material";
 import {
   Box,
   Card,
   CardContent,
   Container,
   Link as MuiLink,
-  Stack,
   Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
@@ -153,47 +151,54 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
             <CardContent>
               <Typography component="h2" sx={{ mb: 1 }} variant="h5">
                 {alreadyConfirmed
-                  ? `Thank you, ${volunteer.playaName}, for confirming completion of ${training.name} training!`
+                  ? `Thank you, ${volunteer.playaName}, for confirming completion of ${training.name} training.`
                   : `Confirming your completion of ${training.name} training…`}
               </Typography>
               {alreadyConfirmed && (
-                <Typography sx={{ mb: 1 }}>
-                  Your <strong>{training.roleName}</strong> role has been added
-                  to your account.
-                </Typography>
-              )}
-              {training.url && (
-                <Typography sx={{ mt: 2 }}>
+                <Typography>
+                  We have marked this training as complete on{" "}
                   <MuiLink
                     component={NextLink}
-                    href={training.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                    href={`/volunteers/${shiftboardId}/info`}
                   >
-                    Training course material{" "}
-                    <OpenInNewIcon
-                      fontSize="inherit"
-                      sx={{ verticalAlign: "middle" }}
-                    />
+                    your volunteer account
                   </MuiLink>
+                  .
                 </Typography>
               )}
             </CardContent>
           </Card>
         </Box>
-        <Box component="section">
-          <Stack direction="row" spacing={2}>
-            <MuiLink component={NextLink} href="/shifts">
-              Browse shifts
-            </MuiLink>
-            <MuiLink
-              component={NextLink}
-              href={`/volunteers/${shiftboardId}/info`}
-            >
-              Your volunteer page
-            </MuiLink>
-          </Stack>
-        </Box>
+        {alreadyConfirmed && (
+          <Box component="section">
+            <Typography component="h2" sx={{ mb: 1 }} variant="h5">
+              What&rsquo;s next?
+            </Typography>
+            <Typography sx={{ mb: 1 }}>
+              View your existing shifts on your{" "}
+              <MuiLink
+                component={NextLink}
+                href={`/volunteers/${shiftboardId}/info`}
+              >
+                Account page
+              </MuiLink>
+              .
+            </Typography>
+            <Typography sx={{ mb: 2 }}>
+              View available shifts on the{" "}
+              <MuiLink component={NextLink} href="/shifts">
+                Shifts page
+              </MuiLink>
+              .
+            </Typography>
+            <Typography color="text.secondary" variant="body2">
+              Note: To review this training material later, use the links
+              from the completed checklist item on your account. From there,
+              you can return to the course on Hive or view/print a PDF copy
+              of the course.
+            </Typography>
+          </Box>
+        )}
       </Container>
     </>
   );


### PR DESCRIPTION
Per Chipper (Discord, 2026-05-25, mockup posted in-thread):

> Training confirmation
>
> Thank you, Chipper, for confirming completion of DataBeast Driver training.
>
> We have marked this training as complete on [your volunteer account](link).
>
> ## What's next?
>
> View your existing shifts on your [Account page](link).
>
> View available shifts on the [Shifts page](link).
>
> Note: To review this training material later, use the links from the completed checklist item on your account. From there, you can return to the course on Hive or view/print a PDF copy of the course.

## Changes
- Headline gets a \"training\" suffix and a period (was \"…DataBeast Driver!\").
- Adds \"We have marked this training as complete on [your volunteer account].\" inside the card.
- Drops the \"Your TrainingXComplete role has been added\" sentence — exposed the internal role name, Chipper flagged as confusing.
- Drops the inline \"Training course material\" outbound Hive link — Chipper flagged as unclear whether the user should click.
- Replaces the side-by-side \"Browse shifts / Your volunteer page\" links with a labelled **What's next?** section: prose-style links + a body-2 \"Note:\" footnote pointing back to the checklist for course material retrieval.
- Renders the next-steps section only when `alreadyConfirmed`, so the in-flight loading state still shows just the headline.

Same template renders for all 5 Hive courses (Basics / Random Sampling / OutReach / DataEntry Wiz / DataBeast Driver) — one fix covers them all.

## Test plan
- [ ] Visit `/training/confirmation/<code>` while signed in. Confirm next-steps section appears after auto-confirm fires.
- [ ] Visit again (already-confirmed state). Same page layout; the auto-confirm POST short-circuits via `alreadyConfirmed`.
- [ ] All three links route: \"your volunteer account\" → `/volunteers/<id>/info`, \"Account page\" → `/volunteers/<id>/info`, \"Shifts page\" → `/shifts`.
- [ ] Loading state (data not yet returned) shows only the headline, no next-steps section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)