### PR TITLE
ui(training-confirmation): pull What's next into the main card

### DIFF
--- a/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
+++ b/client/src/app/training/confirmation/[code]/TrainingConfirmation.tsx
@@ -146,7 +146,7 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
         text="Training confirmation"
       />
       <Container component="main">
-        <Box component="section" sx={{ mb: 3 }}>
+        <Box component="section">
           <Card>
             <CardContent>
               <Typography component="h2" sx={{ mb: 1 }} variant="h5">
@@ -155,50 +155,48 @@ export const TrainingConfirmation = ({ code }: ITrainingConfirmationProps) => {
                   : `Confirming your completion of ${training.name} training…`}
               </Typography>
               {alreadyConfirmed && (
-                <Typography>
-                  We have marked this training as complete on{" "}
-                  <MuiLink
-                    component={NextLink}
-                    href={`/volunteers/${shiftboardId}/info`}
-                  >
-                    your volunteer account
-                  </MuiLink>
-                  .
-                </Typography>
+                <>
+                  <Typography sx={{ mb: 3 }}>
+                    We have marked this training as complete on{" "}
+                    <MuiLink
+                      component={NextLink}
+                      href={`/volunteers/${shiftboardId}/info`}
+                    >
+                      your volunteer account
+                    </MuiLink>
+                    .
+                  </Typography>
+                  <Typography component="h3" sx={{ mb: 1 }} variant="h6">
+                    What&rsquo;s next?
+                  </Typography>
+                  <Typography sx={{ mb: 1 }}>
+                    View your existing shifts on your{" "}
+                    <MuiLink
+                      component={NextLink}
+                      href={`/volunteers/${shiftboardId}/info`}
+                    >
+                      Account page
+                    </MuiLink>
+                    .
+                  </Typography>
+                  <Typography sx={{ mb: 2 }}>
+                    View available shifts on the{" "}
+                    <MuiLink component={NextLink} href="/shifts">
+                      Shifts page
+                    </MuiLink>
+                    .
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Note: To review this training material later, use the
+                    links from the completed checklist item on your account.
+                    From there, you can return to the course on Hive or
+                    view/print a PDF copy of the course.
+                  </Typography>
+                </>
               )}
             </CardContent>
           </Card>
         </Box>
-        {alreadyConfirmed && (
-          <Box component="section">
-            <Typography component="h2" sx={{ mb: 1 }} variant="h5">
-              What&rsquo;s next?
-            </Typography>
-            <Typography sx={{ mb: 1 }}>
-              View your existing shifts on your{" "}
-              <MuiLink
-                component={NextLink}
-                href={`/volunteers/${shiftboardId}/info`}
-              >
-                Account page
-              </MuiLink>
-              .
-            </Typography>
-            <Typography sx={{ mb: 2 }}>
-              View available shifts on the{" "}
-              <MuiLink component={NextLink} href="/shifts">
-                Shifts page
-              </MuiLink>
-              .
-            </Typography>
-            <Typography color="text.secondary" variant="body2">
-              Note: To review this training material later, use the links
-              from the completed checklist item on your account. From there,
-              you can return to the course on Hive or view/print a PDF copy
-              of the course.
-            </Typography>
-          </Box>
-        )}
       </Container>
     </>
   );


### PR DESCRIPTION
Per Chipper (Discord, 2026-05-25):

> I was hoping that the text at the bottom would all be in the main section that's lighter colored in that main box

The What's next section + Note in #343 lived outside the Card, so they sat on the beige page background. This PR pulls them inside the same `Card` / `CardContent` for visual unity.

## Changes
- Single Card/CardContent now wraps everything: headline, "marked complete" sentence, What's next? sub-heading, two prose links, Note footnote.
- Demoted "What's next?" from h2/h5 to h3/h6 since it's now a sub-heading within the same surface (h2 is reserved for the "Thank you" headline).
- Added `mb: 3` on the "marked complete" sentence so there's visible breathing room before the sub-heading.

## Test plan
- [ ] `/training/confirmation/<code>` shows everything on the same light card.
- [ ] Loading state (data not yet returned) still shows only the headline, no leakage.
- [ ] All three links route correctly (volunteer account, Account page, Shifts page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)