### PR TITLE
ui(account): rename "Volunteer Information" page to "Account"

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -723,7 +723,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
           backgroundImage: "url(/banners/man-at-night.jpg)",
           backgroundSize: "cover",
         }}
-        text="Volunteer Information"
+        text="Account"
       />
       <Container maxWidth="md">
         {/* breadcrumbs */}
@@ -741,8 +741,8 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
               Welcome, {volunteer.playaName}!
             </Typography>
             <Typography color="text.secondary" sx={{ mb: 2 }}>
-              Review your volunteer information and complete the checklist items
-              below to get ready for the event.
+              Review your account and complete the checklist items below to
+              get ready for the event.
             </Typography>
             <Stack direction="row" spacing={3}>
               <Box>

--- a/client/src/app/volunteers/[shiftboardId]/info/page.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/page.tsx
@@ -7,7 +7,7 @@ interface IVolunteerInfoPageProps {
 }
 
 export const metadata = {
-  title: "Census | Volunteer Info",
+  title: "Census | Account",
 };
 const VolunteerInfoPage = async ({ params }: IVolunteerInfoPageProps) => {
   // logic


### PR DESCRIPTION
Closes #346.

Per Mew (Discord, 2026-05-25): the in-page header should match the "Account" label used in the drawer menu and the training-confirmation "Account page" link. URL stays \`/info\`; the legacy \`/account\` route already redirects here.

## Files

- `client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx:726` — Hero text: "Volunteer Information" → "Account"
- `client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx:744` — body: "Review your volunteer information and complete the checklist items below…" → "Review your account and complete the checklist items below…"
- `client/src/app/volunteers/[shiftboardId]/info/page.tsx:10` — browser tab title: "Census | Volunteer Info" → "Census | Account"

Verified no other call-sites in `client/src` still reference "Volunteer Information" / "Volunteer Info".

## Test plan
- [ ] Visit `/volunteers/<id>/info`, Hero banner reads "Account".
- [ ] Browser tab reads "Census | Account".
- [ ] Welcome card body reads new copy.
- [ ] All existing functionality (checklist, role toggles, profile update, etc.) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)