### PR TITLE
ui(sign-in): PIN success now lands on /info (or returnTo if present)

### DIFF
--- a/client/src/app/sign-in/SignIn.tsx
+++ b/client/src/app/sign-in/SignIn.tsx
@@ -154,6 +154,16 @@ export const SignIn = () => {
             variant: "success",
           }
         );
+
+        // Land them somewhere useful: a returnTo if present (e.g. they
+        // came from a training-confirmation link), otherwise their
+        // account page. Matches the Okta callback default in
+        // pages/api/auth/okta/callback.ts. Per Mew 2026-05-25.
+        const returnTo =
+          returnToParam && returnToParam.startsWith("/")
+            ? returnToParam
+            : `/volunteers/${dataVolunteerItem.shiftboardId}/info`;
+        router.push(returnTo);
       }
     } catch (error) {
       if (error instanceof Error) {


### PR DESCRIPTION
Per Mew (Discord, 2026-05-25):

> if there is no redirect in the login (eg going to mark training) then going to account should be the default redirect after login.

The Okta callback (`pages/api/auth/okta/callback.ts:341`) already defaults to `/volunteers/<id>/info` when `returnTo` is absent. The PIN sign-in path never navigated at all — user just stayed on `/sign-in` with a "signed in" snackbar.

This PR mirrors the Okta behavior in the PIN onSubmit success branch:
- honor a `returnTo` query param if it starts with `/` (e.g. coming from a training-confirmation deep link)
- otherwise `router.push("/volunteers/<id>/info")`

Both `router` and `returnToParam` are already in scope at the call site (declared at the top of `SignIn.tsx`).

## Test plan
- [ ] On-playa: PIN sign in without returnTo → lands on `/volunteers/<id>/info`.
- [ ] On-playa: PIN sign in with `?returnTo=/training/confirmation/XYZ` → lands on `/training/confirmation/XYZ`.
- [ ] Okta path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)