### PR TITLE
ui(info): Staff exempt from CSP — rewrite copy + auto-complete role thresholds

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -723,8 +723,12 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
   const completedItems = checklistItems.filter((item) => item.done);
 
   // show CSP bar when relevant
+  // Staff are CSP-exempt across the whole checklist (per Mew 2026-05-25),
+  // so the global gauge should not appear at all for them — even if they
+  // happen to have a role threshold attached.
   const showCspBar =
-    (isPreOpen && !hasOtherSap && !isStaff) || roleThresholds.length > 0;
+    !isStaff &&
+    ((isPreOpen && !hasOtherSap) || roleThresholds.length > 0);
 
   // render
   // ------------------------------------------------------------

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -656,25 +656,41 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     });
   }
 
+  // Staff are exempt from CSP tracking \u2014 same copy is reused below for
+  // role-threshold (camp / ticket) items so a Staff volunteer never sees a
+  // CSP gauge anywhere in the checklist (per Mew 2026-05-25).
+  const staffNoCspCopy = (
+    <Typography>
+      As Census Staff we know you will work your butt off, so we don&rsquo;t
+      track CSP.
+    </Typography>
+  );
+
   // Staff bypass
   if (isStaff) {
     checklistItems.push({
       id: "staff",
       label: "Staff \u2014 Early entry confirmed",
       done: true,
-      content: (
-        <Typography>
-          As Census staff, your early entry is handled separately. Work your butt
-          off and have a great burn!
-        </Typography>
-      ),
+      content: staffNoCspCopy,
     });
   }
 
-  // Role-based thresholds (Counter Culture, Census Lab, Census Ticket)
+  // Role-based thresholds (Counter Culture, Census Lab, Census Ticket).
+  // Staff short-circuit: emit a "Requirements met" item with the no-CSP
+  // copy, regardless of actual currentCsp/requiredCsp.
   for (const rt of roleThresholds) {
-    const pct = Math.min(100, Math.round((rt.currentCsp / rt.requiredCsp) * 100));
     const displayRole = ROLE_DISPLAY_NAMES[rt.role] ?? rt.role;
+    if (isStaff) {
+      checklistItems.push({
+        id: `role-${rt.role}`,
+        label: `${displayRole} \u2014 Requirements met`,
+        done: true,
+        content: staffNoCspCopy,
+      });
+      continue;
+    }
+    const pct = Math.min(100, Math.round((rt.currentCsp / rt.requiredCsp) * 100));
     checklistItems.push({
       id: `role-${rt.role}`,
       label: rt.fulfilled


### PR DESCRIPTION
Per Mew (Discord, 2026-05-25):

> On the check list for staff it says, "As Census staff, your early entry is handled separately. Work your butt off and have a great burn!" It should say "As Census Staff we know you will work your butt off, so we dont track CSP." And anywhere you see CSP in the checklist such as for camp, just put that line and regardless if they meet the csp mark it complete for any that require a CSP check.

## Two changes
1. **Staff bypass item** — copy updated to the new "we don't track CSP" line.
2. **Role-threshold loop** (Counter Culture / Census Lab / Census Ticket) — short-circuit for Staff: emit a "Requirements met" item with the no-CSP copy and `done: true`, regardless of actual `currentCsp`. Non-staff path unchanged.

Shared copy hoisted to a local `staffNoCspCopy` Typography so the two sites stay in sync.

(SAP Requirements block above already skips Staff via the existing `!isStaff` guard — no change needed there.)

## Test plan
- [ ] Staff volunteer view `/info`: "Staff — Early entry confirmed" item shows new copy.
- [ ] Staff volunteer with a camp/ticket role (e.g. Counter Culture, Census Lab, Census Ticket) sees "Requirements met" for that item with the same no-CSP copy.
- [ ] Non-staff volunteer with the same camp/ticket role still sees CSP progress bar and old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)