### PR TITLE
feat(passcode): auto-generate for new Okta accounts + self-only reveal endpoint

### DIFF
--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { buildSessionCookie } from "@/lib/session";
 import { generateId } from "@/utils/generateId";
+import { generatePasscode } from "@/utils/generatePasscode";
 import { pool } from "lib/database";
 
 interface OktaTokenResponse {
@@ -316,12 +317,16 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
         FROM op_volunteers
         WHERE shiftboard_id=?
       `);
+      // Auto-generate a 4-digit passcode so the volunteer can sign in
+      // on-playa via the tablet PIN UI without an admin having to set
+      // one for them. The volunteer can see and update it from /info.
+      const passcode = generatePasscode();
 
       await pool.query<RowDataPacket[]>(
         `INSERT INTO op_volunteers (
-          shiftboard_id, playa_name, world_name, email, okta_id, create_volunteer
-        ) VALUES (?, ?, ?, ?, ?, true)`,
-        [newId, playaName, worldName, email, oktaId]
+          shiftboard_id, playa_name, world_name, email, okta_id, passcode, create_volunteer
+        ) VALUES (?, ?, ?, ?, ?, ?, true)`,
+        [newId, playaName, worldName, email, oktaId, passcode]
       );
       shiftboardId = newId;
     }

--- a/client/src/pages/api/volunteers/[shiftboardId]/account/passcode/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/account/passcode/index.ts
@@ -5,10 +5,47 @@ import type { IReqPasscode } from "@/components/types/volunteers";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
 
-const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
+const volunteers = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
   const { shiftboardId } = req.query;
 
   switch (req.method) {
+    // get
+    // ------------------------------------------------------------
+    // Self-only reveal. An admin can SET someone else's passcode (PATCH
+    // below — not gated; see #350 for the broader tightening), but
+    // nobody — including admins — can READ an existing one through this
+    // endpoint. Per Mew 2026-05-25.
+    case "GET": {
+      const requestId = Number(shiftboardId);
+      if (!session || session.shiftboardId !== requestId) {
+        return res.status(403).json({
+          statusCode: 403,
+          message: "Forbidden",
+        });
+      }
+      const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT passcode
+        FROM op_volunteers
+        WHERE shiftboard_id=?
+        LIMIT 1`,
+        [requestId]
+      );
+      if (rows.length === 0) {
+        return res.status(404).json({
+          statusCode: 404,
+          message: "Not found",
+        });
+      }
+      return res.status(200).json({
+        statusCode: 200,
+        passcode: rows[0].passcode ?? "",
+      });
+    }
+
     // patch
     // ------------------------------------------------------------
     case "PATCH": {

--- a/client/src/utils/generatePasscode.ts
+++ b/client/src/utils/generatePasscode.ts
@@ -1,0 +1,11 @@
+// Generate a 4-digit passcode used for on-playa tablet sign-in.
+// Returns a 4-character string with leading zeros preserved (e.g. "0042").
+//
+// Uses crypto.randomInt when available (Node runtime — API routes) so the
+// digits aren't predictable from Math.random's seeded PRNG.
+import { randomInt } from "crypto";
+
+export const generatePasscode = (): string => {
+  const n = randomInt(0, 10_000);
+  return String(n).padStart(4, "0");
+};


### PR DESCRIPTION
Backend half of the on-playa passcode UX work (per Mew 2026-05-25). UI follow-up in a separate PR — drops "Reveal Passcode" button on the /info Security section + Census-logo image with digits embedded.

Filed adjacent: #350 (PATCH auth gap on the same endpoint — not fixed here per Mew's explicit "admin can still set someone's passcode" scope).

## Three pieces

1. **New helper** `client/src/utils/generatePasscode.ts` — 4-digit passcode via `crypto.randomInt`, leading zeros preserved (e.g. `"0042"`).

2. **Okta callback** (`callback.ts:312-327`) — when creating a brand-new volunteer row (no prior shiftboard_id, no existing email match), also INSERT a random passcode so the user can sign in on-playa without an admin having to set one for them.

3. **New GET method** on `/api/volunteers/[shiftboardId]/account/passcode` — returns `{ passcode }` for self-callers only. **403 for anyone else, including admins.** The existing PATCH method is untouched.

## Backfill (post-deploy)

4 existing volunteers on prod have no passcode. After deploy:
```sql
UPDATE op_volunteers
SET passcode = LPAD(FLOOR(RAND()*10000), 4, '0'),
    update_volunteer = true
WHERE passcode IS NULL OR passcode = '';
```
Run as a one-off SQL, not as part of this PR.

## Test plan
- [ ] New Okta signup → new `op_volunteers` row has a 4-digit `passcode`.
- [ ] GET `/api/volunteers/<own-id>/account/passcode` as self → 200 with `{ passcode }`.
- [ ] GET `/api/volunteers/<other-id>/account/passcode` as different volunteer → 403.
- [ ] GET as admin viewing someone else → 403 (admin reveal not allowed per spec).
- [ ] Existing PATCH `/api/volunteers/<id>/account/passcode` unchanged in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)