### PR TITLE
ui(home): host the login affordance on Home, drop the / → /sign-in redirect

### DIFF
--- a/client/src/app/Home.tsx
+++ b/client/src/app/Home.tsx
@@ -1,12 +1,47 @@
 "use client";
 
-import { Box, Card, CardContent, Container, Typography } from "@mui/material";
+import {
+  Login as LoginIcon,
+  ManageAccounts as ManageAccountsIcon,
+} from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Stack,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
+import { useContext } from "react";
 
 import { reportList } from "@/app/reports/Reports";
 import { Hero } from "@/components/layout/Hero";
+import { SessionContext } from "@/state/session/context";
+import { checkIsAuthenticated } from "@/utils/checkIsRoleExist";
+import { DeveloperModeContext } from "@/state/developer-mode/context";
 
 export const Home = () => {
+  // context
+  // ------------------------------------------------------------
+  const {
+    developerModeState: { accountType },
+  } = useContext(DeveloperModeContext);
+  const {
+    sessionState: {
+      settings: { isAuthenticated: isAuthenticatedSession },
+      user: { playaName, shiftboardId, worldName },
+    },
+  } = useContext(SessionContext);
+
+  const isAuthenticated = checkIsAuthenticated(
+    accountType,
+    isAuthenticatedSession
+  );
+  const isOAuthConfigured = process.env.NEXT_PUBLIC_OKTA_ENABLED === "true";
+  const isPinEnabled = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
+
   // render
   // ------------------------------------------------------------
   return (
@@ -23,6 +58,50 @@ export const Home = () => {
           <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
             Welcome!
           </Typography>
+
+          {/*
+           * Login affordance sits between the Welcome header and the body
+           * copy (per Chipper + Mew, 2026-05-25). Auth state drives the
+           * content:
+           *   - authenticated → "View your account" link to /info
+           *   - unauth + Okta enabled (off-playa) → Okta SSO button
+           *   - unauth + PIN enabled (on-playa) → link to /sign-in for
+           *     the passcode form (volunteer dropdown stays off Home)
+           */}
+          <Stack alignItems="center" sx={{ mb: 3 }}>
+            {isAuthenticated ? (
+              <Button
+                component={Link}
+                href={`/volunteers/${shiftboardId}/info`}
+                size="large"
+                startIcon={<ManageAccountsIcon />}
+                variant="contained"
+              >
+                Welcome, {playaName} &quot;{worldName}&quot; — view your account
+              </Button>
+            ) : isOAuthConfigured ? (
+              <Button
+                component="a"
+                href="/api/auth/okta"
+                size="large"
+                startIcon={<LoginIcon />}
+                variant="contained"
+              >
+                Sign in to Census
+              </Button>
+            ) : isPinEnabled ? (
+              <Button
+                component={Link}
+                href="/sign-in"
+                size="large"
+                startIcon={<LoginIcon />}
+                variant="contained"
+              >
+                Sign in with passcode
+              </Button>
+            ) : null}
+          </Stack>
+
           <Card>
             <CardContent>
               <Typography>

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -63,10 +63,12 @@ const ALLOWLIST = [
   ...(isOnPlaya ? ["/shifts", "/api/shifts"] : []),
 ];
 
-// Closes #306: unauthenticated visitors hit /sign-in directly instead of
-// landing on the marketing Home page and hunting for the sign-in link.
-// Signed-in users still get /sign-in's auto-redirect → home.
-const PUBLIC_PATHS = new Set<string>();
+// Home is public again as of 2026-05-25 — the page now hosts the
+// login affordance inline (Okta button off-playa, "Sign in with
+// passcode" link on-playa for the PIN form), so there's no longer a
+// reason to redirect unauth visitors away from it. Reverts the
+// PUBLIC_PATHS purge that came in with PR #337 / closed-#306.
+const PUBLIC_PATHS = new Set(["/"]);
 
 function isAllowlisted(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return true;


### PR DESCRIPTION
Reverses the direction of PR #337 + closes #345 partially. Per Chipper + Mew (Discord, 2026-05-25): instead of redirecting unauth users to `/sign-in`, put the login button on Home so the landing page actually says something useful.

## Changes
- **middleware.ts** — `/` back in `PUBLIC_PATHS` so unauth users can reach Home.
- **Home.tsx** — auth-state-aware login block between the "Welcome!" h2 and the welcome body card:
  - **Authenticated** → "Welcome, {playaName} \"worldName\" — view your account" button → `/volunteers/<id>/info`.
  - **Unauth + Okta enabled (off-playa)** → "Sign in to Census" button → `/api/auth/okta`.
  - **Unauth + PIN enabled (on-playa)** → "Sign in with passcode" button → `/sign-in` (the existing PIN form — Chipper explicitly didn't want the volunteer dropdown on Home).
- `/sign-in` stays as a valid route — used by the on-playa PIN flow and as the Okta callback's error-redirect target. Old bookmarks keep working.
- Existing welcome / learn-more body copy unchanged.

## Test plan
- [ ] Off-playa (NEXT_PUBLIC_PIN_ENABLED=false), unauth `GET /` → Home renders with "Sign in to Census" button. Clicking → Okta init.
- [ ] Off-playa, auth `GET /` → Home renders with "Welcome, ... — view your account" button. Clicking → `/info`.
- [ ] On-playa (NEXT_PUBLIC_PIN_ENABLED unset/true), unauth `GET /` → Home renders with "Sign in with passcode" button. Clicking → `/sign-in` with the PIN form.
- [ ] On-playa, auth `GET /` → Home renders with "Welcome, ... — view your account" button.
- [ ] Drawer's "Sign in" link still navigates to `/sign-in` and renders the existing sign-in card.
- [ ] Okta callback error redirects to `/sign-in?error=...` still surface the alert correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)