### PR TITLE
ui(burner-profile): tell users how to get to the edit page

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -575,9 +575,11 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
             target="_blank"
           >
             Burner Profile
-          </a>{" "}
-          and make sure your information is current. Update any fields that have
-          changed since last year, then check the box below to confirm.
+          </a>
+          . Once logged in, click <strong>SETTINGS</strong> in the top right,
+          then <strong>My Profile</strong> to edit your information. Update any
+          fields that have changed since last year, then check the box below to
+          confirm.
         </Typography>
         <FormControlLabel
           control={


### PR DESCRIPTION
Per Chipper (Discord, 2026-05-25, with screenshots): clicking the Burner Profile link lands users on a marketing-looking dashboard with no obvious "edit profile" affordance. The actual edit screen is two clicks deep — **SETTINGS** in the top-right nav, then **My Profile**.

## Change
One body-copy update on the Burner Profile checklist item (`VolunteerInfo.tsx:570`). Adds a one-sentence navigation hint after the link.

## Test plan
- [ ] Visit `/info`, expand the Burner Profile checklist item, confirm the hint text appears after the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)