### PR TITLE
ui(training): keep the course link clickable even after completion

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -527,7 +527,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                   fontSize="small"
                 />
               )}
-              {t.completed || !t.url ? (
+              {!t.url ? (
                 <Typography variant="body2">{t.trainingName}</Typography>
               ) : (
                 <Typography


### PR DESCRIPTION
Per Chipper (Discord, 2026-05-25):

> Another one on the checklist is now that I've completed the basics course the link is gone. My understanding was that we were going to leave the link so that they could come back later and view the course again if they really have forgotten the basics.

## Change
`VolunteerInfo.tsx:530` — change `t.completed || !t.url` → `!t.url` so completed trainings still render as clickable links. Plain-text fallback now only kicks in when the row genuinely has no URL configured.

Green check icon still conveys completion state, so no info is lost from the visual.

## Test plan
- [ ] Visit `/info` with a completed training, expand it, confirm the course name is still a clickable link to the Hive course.
- [ ] Verify incomplete trainings still render as links (unchanged behavior).
- [ ] Verify a training row with no `url` still falls back to plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)