### PR TITLE
feat(passcode-reveal): self-only Reveal button + Census-logo PNG embed

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/account/PasscodeReveal.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/PasscodeReveal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import {
+  Visibility as VisibilityIcon,
+  VisibilityOff as VisibilityOffIcon,
+} from "@mui/icons-material";
+import { Button, Stack, Typography } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
+interface IPasscodeRevealProps {
+  shiftboardId: number;
+}
+
+// Render the volunteer's passcode embedded in the Census logo. Per Mew
+// 2026-05-25: replace the "CENSUS" wordmark with the 4-digit passcode so
+// it reads as a delight artifact rather than a plain text reveal.
+//
+// Coordinates below are tuned to logo-census.png (1019×1015 native). The
+// pink wash matches the brand pink (#EA008B) so the rectangle blends
+// into the badge background.
+const LOGO_SRC = "/general/logo-census.png";
+const PINK = "#EA008B";
+const MASK_X = 195;
+const MASK_Y = 460;
+const MASK_W = 630;
+const MASK_H = 130;
+
+export const PasscodeReveal = ({ shiftboardId }: IPasscodeRevealProps) => {
+  const [passcode, setPasscode] = useState<null | string>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<null | string>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const handleReveal = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/volunteers/${shiftboardId}/account/passcode`
+      );
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setPasscode(json.passcode ?? "");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to fetch passcode");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleHide = () => {
+    setPasscode(null);
+    setError(null);
+  };
+
+  useEffect(() => {
+    if (passcode === null) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const img = new Image();
+    img.onload = () => {
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      ctx.drawImage(img, 0, 0);
+      // Overlay a pink rectangle that wipes the "CENSUS" wordmark.
+      ctx.fillStyle = PINK;
+      ctx.fillRect(MASK_X, MASK_Y, MASK_W, MASK_H);
+      // Stamp the 4 digits in the same vertical band, chunky sans-serif
+      // matching the logo's wordmark weight.
+      ctx.fillStyle = "#000";
+      ctx.font = "bold 160px Arial Black, Impact, sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      const digits = (passcode || "----").split("");
+      const slot = MASK_W / digits.length;
+      digits.forEach((d, i) => {
+        ctx.fillText(d, MASK_X + slot * (i + 0.5), MASK_Y + MASK_H / 2);
+      });
+    };
+    img.src = LOGO_SRC;
+  }, [passcode]);
+
+  if (passcode === null) {
+    return (
+      <Stack alignItems="flex-end" spacing={1}>
+        <Button
+          disabled={isLoading}
+          onClick={handleReveal}
+          startIcon={<VisibilityIcon />}
+          type="button"
+          variant="outlined"
+        >
+          {isLoading ? "Loading…" : "Reveal passcode"}
+        </Button>
+        {error && (
+          <Typography color="error" variant="caption">
+            {error}
+          </Typography>
+        )}
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack alignItems="center" spacing={1}>
+      <canvas
+        ref={canvasRef}
+        style={{
+          width: 260,
+          height: 260,
+          maxWidth: "100%",
+        }}
+      />
+      <Typography color="text.secondary" variant="caption">
+        This passcode is for signing in on tablets on-playa only.
+      </Typography>
+      <Button
+        onClick={handleHide}
+        startIcon={<VisibilityOffIcon />}
+        size="small"
+        type="button"
+        variant="text"
+      >
+        Hide
+      </Button>
+    </Stack>
+  );
+};

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -44,6 +44,7 @@ import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 
 import { PasscodeDialogUpdate } from "@/app/volunteers/[shiftboardId]/account/PasscodeDialogUpdate";
+import { PasscodeReveal } from "@/app/volunteers/[shiftboardId]/account/PasscodeReveal";
 import { VolunteerShifts } from "@/app/volunteers/[shiftboardId]/account/VolunteerShifts";
 import { BreadcrumbsNav } from "@/components/general/BreadcrumbsNav";
 import { ErrorPage } from "@/components/general/ErrorPage";
@@ -138,9 +139,18 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
   } = useContext(DeveloperModeContext);
   const {
     sessionState: {
-      user: { roleList: roleListSession },
+      user: {
+        roleList: roleListSession,
+        shiftboardId: shiftboardIdSession,
+      },
     },
   } = useContext(SessionContext);
+
+  // Self-view = the viewer is the same volunteer whose /info page they
+  // opened. Used to gate the passcode-reveal button so admins can't see
+  // other volunteers' passcodes (they can still RESET via the Update
+  // dialog, just can't read existing values). Per Mew 2026-05-25.
+  const isSelfView = shiftboardIdSession === shiftboardId;
 
   // refs
   // ------------------------------------------------------------
@@ -1044,7 +1054,16 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                   </Typography>
                 </Grid>
                 <Grid size={8}>
-                  <Stack direction="row" justifyContent="flex-end">
+                  <Stack
+                    direction="row"
+                    justifyContent="flex-end"
+                    spacing={1}
+                  >
+                    {/* Reveal is self-only — admins can reset (below) but not
+                        see existing values. */}
+                    {isSelfView && (
+                      <PasscodeReveal shiftboardId={shiftboardId} />
+                    )}
                     <Button
                       onClick={() => setIsPasscodeDialogOpen(true)}
                       startIcon={<LockResetIcon />}


### PR DESCRIPTION
UI half of the passcode UX work (per Mew 2026-05-25). Backend shipped in #351 + the backfill SQL ran today.

## Component
New `PasscodeReveal` in `client/src/app/volunteers/[shiftboardId]/account/`. Lives in the Security section on `/info`, **only when the viewer is looking at their own account** (`session.shiftboardId === url shiftboardId`). Admins viewing someone else's `/info` don't get the button — they can still reset via the existing Update Passcode dialog right next to it, just can't read the existing value.

## Flow
1. Volunteer clicks "Reveal passcode".
2. `fetch GET /api/volunteers/<id>/account/passcode` (the self-only endpoint added in #351).
3. Canvas loads `/general/logo-census.png` and overlays a pink rectangle on top of the "CENSUS" wordmark, then stamps the 4 digits in chunky sans-serif in the same vertical band.
4. Renders at 260×260 CSS pixels (canvas backing is the logo's native 1019×1015 so the digits stay crisp).
5. Helper caption: *"This passcode is for signing in on tablets on-playa only."*
6. "Hide" button collapses back to the reveal-button state.

## Notes
- Mask coordinates are tuned to the existing PNG. If the logo asset changes those need re-tuning. Could switch to SVG later for resolution independence — not needed right now.
- The reveal endpoint is self-only at the API layer too (#351), so even with the button hidden in the UI, admins still can't fetch.

## Test plan
- [ ] Sign in as a volunteer, visit `/volunteers/<own-id>/info`, scroll to Security. See "Reveal passcode" button next to "Update passcode".
- [ ] Click → canvas renders the Census logo with the 4-digit passcode where "CENSUS" used to be.
- [ ] "Hide" button collapses back.
- [ ] Sign in as an admin, visit `/volunteers/<other-id>/info`. No Reveal button. "Update passcode" button still there.
- [ ] Fetch `GET /api/volunteers/<other-id>/account/passcode` directly as admin → 403 (verifies API layer matches UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)