### PR TITLE
ui(passcode-reveal): move on-playa-only copy to header + iterate logo mask

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/account/PasscodeReveal.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/PasscodeReveal.tsx
@@ -15,15 +15,17 @@ interface IPasscodeRevealProps {
 // 2026-05-25: replace the "CENSUS" wordmark with the 4-digit passcode so
 // it reads as a delight artifact rather than a plain text reveal.
 //
-// Coordinates below are tuned to logo-census.png (1019×1015 native). The
-// pink wash matches the brand pink (#EA008B) so the rectangle blends
-// into the badge background.
+// Coordinates below are tuned to logo-census.png (1019×1015 native).
+// Mew 2026-05-25 iteration: leave the "C" of CENSUS visible (the badge
+// reads as "C[4-digit code]"), so the mask starts after the "C" rather
+// than at the start of the wordmark.
 const LOGO_SRC = "/general/logo-census.png";
 const PINK = "#EA008B";
-const MASK_X = 195;
+const MASK_X = 305;
 const MASK_Y = 460;
-const MASK_W = 630;
+const MASK_W = 520;
 const MASK_H = 130;
+const DIGIT_FONT_PX = 180;
 
 export const PasscodeReveal = ({ shiftboardId }: IPasscodeRevealProps) => {
   const [passcode, setPasscode] = useState<null | string>(null);
@@ -72,7 +74,7 @@ export const PasscodeReveal = ({ shiftboardId }: IPasscodeRevealProps) => {
       // Stamp the 4 digits in the same vertical band, chunky sans-serif
       // matching the logo's wordmark weight.
       ctx.fillStyle = "#000";
-      ctx.font = "bold 160px Arial Black, Impact, sans-serif";
+      ctx.font = `bold ${DIGIT_FONT_PX}px Arial Black, Impact, sans-serif`;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
       const digits = (passcode || "----").split("");
@@ -115,9 +117,6 @@ export const PasscodeReveal = ({ shiftboardId }: IPasscodeRevealProps) => {
           maxWidth: "100%",
         }}
       />
-      <Typography color="text.secondary" variant="caption">
-        This passcode is for signing in on tablets on-playa only.
-      </Typography>
       <Button
         onClick={handleHide}
         startIcon={<VisibilityOffIcon />}

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -1052,6 +1052,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                   <Typography component="h3" variant="h6">
                     Passcode
                   </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    This passcode is for signing in on tablets on-playa
+                    only.
+                  </Typography>
                 </Grid>
                 <Grid size={8}>
                   <Stack


### PR DESCRIPTION
Iteration on #358 per Mew (Discord, 2026-05-25):

> move the passcode description to the main part where it currently says just "Passcode" ... 2 leave the C in Census and move the numbers over and make them a touch larger.

## Changes
1. **Helper copy** moves from the canvas-revealed state into a `body2` sub-label under "Passcode" in the Security card header. Now visible whether or not the user has clicked Reveal.
2. **Mask start** shifts right (MASK_X 195 → 305) so the "C" of CENSUS stays visible. Mask width drops accordingly (630 → 520). Badge reads as "C ####".
3. **Digit font** bumps 160 → 180 to fill the remaining space better.

No other behavior changes — still self-only, still client-side canvas, still Hide button to collapse.

## Test plan
- [ ] /info Security section: "This passcode is for signing in on tablets on-playa only." is always visible under "Passcode" (no reveal needed).
- [ ] Click Reveal → canvas renders the badge with "C ####" visible instead of "####".
- [ ] Digits look comfortably sized inside the masked area (not crowded, not floating).
- [ ] Hide button still collapses back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)