### PR TITLE
fix(passcode-reveal): make pink mask taller — covers full glyph height

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/account/PasscodeReveal.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/PasscodeReveal.tsx
@@ -22,9 +22,9 @@ interface IPasscodeRevealProps {
 const LOGO_SRC = "/general/logo-census.png";
 const PINK = "#EA008B";
 const MASK_X = 305;
-const MASK_Y = 460;
+const MASK_Y = 435;
 const MASK_W = 520;
-const MASK_H = 130;
+const MASK_H = 175;
 const DIGIT_FONT_PX = 180;
 
 export const PasscodeReveal = ({ shiftboardId }: IPasscodeRevealProps) => {


### PR DESCRIPTION
Per Mew (Discord, 2026-05-25):

> the top of the numbers is not fully blocking the very top of the letters.

The previous 130px-tall mask left the tops of E/N/S/U/S poking above the pink rectangle. Bumping MASK_Y 460 → 435 and MASK_H 130 → 175 so the mask fully covers the wordmark's vertical extent.

Digit position recenters automatically (drawn at `MASK_Y + MASK_H / 2`).

## Test plan
- [ ] Reveal passcode on /info. No black letter tops visible above the digits.
- [ ] Digits still centered visually within the masked area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)