### PR TITLE
feat(mail): email queue foundation (#307)

### DIFF
--- a/client/instrumentation.ts
+++ b/client/instrumentation.ts
@@ -1,0 +1,9 @@
+// Next.js calls this once per process at server boot. We use it to start
+// the email queue worker (#307). The Edge runtime is skipped — only the
+// Node runtime can reach MySQL and Node SMTP.
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  const { bootstrapMailWorker } = await import("./lib/mail");
+  bootstrapMailWorker();
+}

--- a/client/lib/mail/backoff.ts
+++ b/client/lib/mail/backoff.ts
@@ -1,0 +1,11 @@
+// Backoff schedule (seconds), indexed by attempt count (1-based).
+// Caps at 24h and stays there forever. Rationale (#307):
+// on-playa internet can be out for days, so we never give up on a
+// transient failure — only permanent SMTP errors mark the row `dead`.
+const BACKOFF_SECONDS = [60, 300, 900, 3_600, 21_600, 86_400] as const;
+
+export function nextAttemptDelaySeconds(attempts: number): number {
+  if (attempts < 1) return BACKOFF_SECONDS[0];
+  const idx = Math.min(attempts - 1, BACKOFF_SECONDS.length - 1);
+  return BACKOFF_SECONDS[idx];
+}

--- a/client/lib/mail/classify.ts
+++ b/client/lib/mail/classify.ts
@@ -1,0 +1,39 @@
+// Decide whether an SMTP/transport error is permanent (mark `dead`,
+// stop retrying) or transient (keep retrying with backoff).
+//
+// Default-to-transient: on-playa, a misclassified transient (e.g. some
+// novel TLS hiccup) that we mark permanent costs a real email, while
+// a misclassified permanent just retries until 24h-cap forever — visible
+// in monitoring but not silently lost.
+
+interface MaybeSmtpError {
+  responseCode?: number;
+  code?: string;
+  message?: string;
+}
+
+// SMTP 5xx codes that mean "this message will never deliver":
+//   550 mailbox unavailable / user unknown
+//   551 user not local
+//   553 mailbox name not allowed
+//   554 transaction failed (often final reject)
+const PERMANENT_RESPONSE_CODES = new Set([550, 551, 553, 554]);
+
+export function classifyError(err: unknown): {
+  permanent: boolean;
+  reason: string;
+} {
+  const e = (err ?? {}) as MaybeSmtpError;
+  const reason = e.message ?? String(err);
+
+  if (typeof e.responseCode === "number") {
+    if (PERMANENT_RESPONSE_CODES.has(e.responseCode)) {
+      return { permanent: true, reason };
+    }
+    // 4xx and anything else: transient.
+    return { permanent: false, reason };
+  }
+
+  // No SMTP response code — connection-level or unknown. Always transient.
+  return { permanent: false, reason };
+}

--- a/client/lib/mail/index.ts
+++ b/client/lib/mail/index.ts
@@ -1,0 +1,61 @@
+import { pool } from "../database";
+
+import { enqueueEmail as enqueueEmailRaw } from "./queue";
+import { createMysqlStore } from "./store";
+import { selectTransport } from "./transport";
+import type { EnqueueArgs, MailConfig } from "./types";
+import { startWorker } from "./worker";
+
+function readConfig(): MailConfig {
+  const port = parseInt(process.env.SMTP_PORT ?? "25", 10);
+  return {
+    from: process.env.MAIL_FROM ?? "census@burningmail.burningman.org",
+    defaultReplyTo:
+      process.env.MAIL_DEFAULT_REPLY_TO ??
+      "Census Volunteer Coordinators <censusvc@burningman.org>",
+    smtpHost: process.env.SMTP_HOST ?? "127.0.0.1",
+    smtpPort: Number.isFinite(port) ? port : 25,
+    dryRun: process.env.MAIL_DRY_RUN === "1",
+    workerDisabled: process.env.MAIL_WORKER_DISABLED === "1",
+    ratePerMinute: parseIntEnv("MAIL_RATE_PER_MINUTE", 1),
+    ratePerDay: parseIntEnv("MAIL_RATE_PER_DAY", 100),
+    workerTickMs: parseIntEnv("MAIL_WORKER_TICK_MS", 30_000),
+  };
+}
+
+function parseIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+let workerStarted = false;
+let runtimeConfig: MailConfig | null = null;
+
+function config(): MailConfig {
+  if (!runtimeConfig) runtimeConfig = readConfig();
+  return runtimeConfig;
+}
+
+export async function enqueueEmail(args: EnqueueArgs): Promise<{ id: number }> {
+  return enqueueEmailRaw(pool, config(), args);
+}
+
+// Idempotent: instrumentation.ts calls this on cold start. Safe to call
+// repeatedly — extra calls no-op.
+export function bootstrapMailWorker(): void {
+  if (workerStarted) return;
+  const cfg = config();
+  if (cfg.workerDisabled) {
+    console.warn("[mail:worker] disabled via MAIL_WORKER_DISABLED=1");
+    return;
+  }
+  workerStarted = true;
+  const transport = selectTransport(cfg);
+  const store = createMysqlStore(pool);
+  startWorker(store, cfg, transport);
+  console.warn(
+    `[mail:worker] started — tickMs=${cfg.workerTickMs} ratePerMinute=${cfg.ratePerMinute} ratePerDay=${cfg.ratePerDay} dryRun=${cfg.dryRun} smtp=${cfg.smtpHost}:${cfg.smtpPort}`
+  );
+}

--- a/client/lib/mail/queue.ts
+++ b/client/lib/mail/queue.ts
@@ -1,0 +1,167 @@
+import type { Pool } from "mysql2/promise";
+import type { ResultSetHeader, RowDataPacket } from "mysql2";
+
+import { nextAttemptDelaySeconds } from "./backoff";
+import type { EmailRow, EnqueueArgs, MailConfig } from "./types";
+
+function joinAddrs(v: string | string[] | undefined): string | null {
+  if (v === undefined) return null;
+  if (Array.isArray(v)) return v.join(", ");
+  return v;
+}
+
+export async function enqueueEmail(
+  pool: Pool,
+  config: MailConfig,
+  args: EnqueueArgs
+): Promise<{ id: number }> {
+  const to = joinAddrs(args.to);
+  if (!to) throw new Error("enqueueEmail: `to` is required");
+
+  const [result] = await pool.execute<ResultSetHeader>(
+    `INSERT INTO op_email_queue
+      (\`to\`, cc, reply_to, \`from\`, subject, body_text, body_html,
+       ics_attachment, ics_filename, category)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      to,
+      joinAddrs(args.cc),
+      args.replyTo ?? config.defaultReplyTo,
+      config.from,
+      args.subject,
+      args.bodyText,
+      args.bodyHtml ?? null,
+      args.ics?.content ?? null,
+      args.ics?.filename ?? null,
+      args.category,
+    ]
+  );
+  return { id: result.insertId };
+}
+
+interface QueueRowPacket extends RowDataPacket {
+  id: number;
+  to: string;
+  cc: string | null;
+  reply_to: string;
+  from: string;
+  subject: string;
+  body_text: string;
+  body_html: string | null;
+  ics_attachment: Buffer | null;
+  ics_filename: string | null;
+  category: string;
+  attempts: number;
+  state: EmailRow["state"];
+}
+
+// Pick the oldest due `queued` row and atomically flip it to `sending`.
+// Returns null when nothing is due.
+//
+// Atomicity: relies on a transaction with FOR UPDATE so two worker ticks
+// (e.g. across multi-instance deployment, or overlapping ticks if a send
+// runs longer than the interval) can't grab the same row twice. The
+// per-tick lock window is tiny — just the SELECT + UPDATE round-trip.
+export async function claimNextDue(pool: Pool): Promise<EmailRow | null> {
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    const [rows] = await conn.execute<QueueRowPacket[]>(
+      `SELECT id, \`to\`, cc, reply_to, \`from\`, subject, body_text, body_html,
+              ics_attachment, ics_filename, category, attempts, state
+         FROM op_email_queue
+        WHERE state = 'queued' AND next_attempt_at <= NOW()
+        ORDER BY next_attempt_at ASC, id ASC
+        LIMIT 1
+        FOR UPDATE`
+    );
+    if (rows.length === 0) {
+      await conn.commit();
+      return null;
+    }
+    const r = rows[0];
+    await conn.execute(`UPDATE op_email_queue SET state='sending' WHERE id=?`, [
+      r.id,
+    ]);
+    await conn.commit();
+    return {
+      id: r.id,
+      to: r.to,
+      cc: r.cc,
+      replyTo: r.reply_to,
+      from: r.from,
+      subject: r.subject,
+      bodyText: r.body_text,
+      bodyHtml: r.body_html,
+      ics:
+        r.ics_attachment && r.ics_filename
+          ? { filename: r.ics_filename, content: r.ics_attachment }
+          : null,
+      category: r.category,
+      attempts: r.attempts,
+      state: r.state,
+    };
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+export async function markSent(pool: Pool, id: number): Promise<void> {
+  await pool.execute(
+    `UPDATE op_email_queue
+        SET state='sent', sent_at=NOW(), attempts=attempts+1, last_error=NULL
+      WHERE id=?`,
+    [id]
+  );
+}
+
+export async function markTransientFailure(
+  pool: Pool,
+  id: number,
+  attempts: number,
+  reason: string
+): Promise<void> {
+  const delay = nextAttemptDelaySeconds(attempts + 1);
+  await pool.execute(
+    `UPDATE op_email_queue
+        SET state='queued',
+            attempts=attempts+1,
+            next_attempt_at=DATE_ADD(NOW(), INTERVAL ? SECOND),
+            last_error=?
+      WHERE id=?`,
+    [delay, reason, id]
+  );
+}
+
+export async function markDead(
+  pool: Pool,
+  id: number,
+  reason: string
+): Promise<void> {
+  await pool.execute(
+    `UPDATE op_email_queue
+        SET state='dead', attempts=attempts+1, last_error=?
+      WHERE id=?`,
+    [reason, id]
+  );
+}
+
+interface CountPacket extends RowDataPacket {
+  n: number;
+}
+
+export async function recentSentCount(
+  pool: Pool,
+  withinSeconds: number
+): Promise<number> {
+  const [rows] = await pool.execute<CountPacket[]>(
+    `SELECT COUNT(*) AS n
+       FROM op_email_queue
+      WHERE state='sent' AND sent_at > DATE_SUB(NOW(), INTERVAL ? SECOND)`,
+    [withinSeconds]
+  );
+  return rows[0]?.n ?? 0;
+}

--- a/client/lib/mail/store.ts
+++ b/client/lib/mail/store.ts
@@ -1,0 +1,24 @@
+import type { Pool } from "mysql2/promise";
+
+import {
+  claimNextDue,
+  markDead,
+  markSent,
+  markTransientFailure,
+  recentSentCount,
+} from "./queue";
+import type { QueueStore } from "./types";
+
+// Production QueueStore backed by the shared MySQL pool. The worker
+// only knows about this interface, so tests can drop in an in-memory
+// store with no DB dependency.
+export function createMysqlStore(pool: Pool): QueueStore {
+  return {
+    claimNextDue: () => claimNextDue(pool),
+    markSent: (id) => markSent(pool, id),
+    markTransientFailure: (id, attempts, reason) =>
+      markTransientFailure(pool, id, attempts, reason),
+    markDead: (id, reason) => markDead(pool, id, reason),
+    recentSentCount: (s) => recentSentCount(pool, s),
+  };
+}

--- a/client/lib/mail/transport.ts
+++ b/client/lib/mail/transport.ts
@@ -1,0 +1,63 @@
+import nodemailer from "nodemailer";
+
+import { classifyError } from "./classify";
+import type { EmailRow, MailConfig, SendResult, Transport } from "./types";
+
+export function createSmtpTransport(config: MailConfig): Transport {
+  const transporter = nodemailer.createTransport({
+    host: config.smtpHost,
+    port: config.smtpPort,
+    secure: false,
+    // Local Exim on the prod EC2 box accepts unauthenticated submission
+    // from localhost. No TLS required for the localhost hop — the upstream
+    // SES relay handles TLS to the wider internet.
+    tls: { rejectUnauthorized: false },
+  });
+
+  return {
+    async send(row: EmailRow): Promise<SendResult> {
+      try {
+        await transporter.sendMail({
+          from: row.from,
+          to: row.to,
+          cc: row.cc ?? undefined,
+          replyTo: row.replyTo,
+          subject: row.subject,
+          text: row.bodyText,
+          html: row.bodyHtml ?? undefined,
+          attachments: row.ics
+            ? [
+                {
+                  filename: row.ics.filename,
+                  content: row.ics.content,
+                  contentType: "text/calendar; method=REQUEST; charset=UTF-8",
+                },
+              ]
+            : undefined,
+        });
+        return { ok: true };
+      } catch (err) {
+        const { permanent, reason } = classifyError(err);
+        return { ok: false, permanent, error: reason };
+      }
+    },
+  };
+}
+
+// Logs intent and reports success without touching the network.
+// Used in dev/CI and on hosts that have no SMTP relay configured.
+export function createDryRunTransport(): Transport {
+  return {
+    async send(row: EmailRow): Promise<SendResult> {
+      console.warn(
+        `[mail:dry-run] would send id=${row.id} to=<${row.to}> subject=${JSON.stringify(row.subject)} category=${row.category}`
+      );
+      return { ok: true };
+    },
+  };
+}
+
+export function selectTransport(config: MailConfig): Transport {
+  if (config.dryRun) return createDryRunTransport();
+  return createSmtpTransport(config);
+}

--- a/client/lib/mail/types.ts
+++ b/client/lib/mail/types.ts
@@ -1,0 +1,64 @@
+export type EmailState = "queued" | "sending" | "sent" | "failed" | "dead";
+
+export interface EnqueueArgs {
+  to: string | string[];
+  cc?: string | string[];
+  replyTo?: string;
+  subject: string;
+  bodyText: string;
+  bodyHtml?: string;
+  ics?: { filename: string; content: Buffer };
+  category: string;
+}
+
+export interface EmailRow {
+  id: number;
+  to: string;
+  cc: string | null;
+  replyTo: string;
+  from: string;
+  subject: string;
+  bodyText: string;
+  bodyHtml: string | null;
+  ics: { filename: string; content: Buffer } | null;
+  category: string;
+  attempts: number;
+  state: EmailState;
+}
+
+export interface SendResult {
+  ok: boolean;
+  permanent?: boolean;
+  error?: string;
+}
+
+export interface Transport {
+  send(row: EmailRow): Promise<SendResult>;
+}
+
+// What the worker needs from the queue. Lets us back the worker by either
+// the real MySQL queue (production) or an in-memory implementation (tests),
+// without the worker holding a reference to a `Pool`.
+export interface QueueStore {
+  claimNextDue(): Promise<EmailRow | null>;
+  markSent(id: number): Promise<void>;
+  markTransientFailure(
+    id: number,
+    attempts: number,
+    reason: string
+  ): Promise<void>;
+  markDead(id: number, reason: string): Promise<void>;
+  recentSentCount(withinSeconds: number): Promise<number>;
+}
+
+export interface MailConfig {
+  from: string;
+  defaultReplyTo: string;
+  smtpHost: string;
+  smtpPort: number;
+  dryRun: boolean;
+  workerDisabled: boolean;
+  ratePerMinute: number;
+  ratePerDay: number;
+  workerTickMs: number;
+}

--- a/client/lib/mail/worker.ts
+++ b/client/lib/mail/worker.ts
@@ -1,0 +1,84 @@
+import type { MailConfig, QueueStore, Transport } from "./types";
+
+// Run a single tick. Exported so a CLI smoke test (or future Lambda
+// trigger) can drive the worker manually without depending on the
+// in-process setInterval.
+//
+// Behavior:
+//   - Rate-limit check first; if exceeded, no-op.
+//   - Atomically claim the oldest due row (transitions to `sending`).
+//   - Hand to transport.
+//   - On success: mark sent.
+//   - On transient failure: requeue with backoff.
+//   - On permanent failure: mark dead.
+//
+// Returns true iff a row was processed (sent OR failed). The worker loop
+// uses this to drain quickly when the queue is backed up.
+export async function tickOnce(
+  store: QueueStore,
+  config: MailConfig,
+  transport: Transport
+): Promise<boolean> {
+  const sentLastMinute = await store.recentSentCount(60);
+  if (sentLastMinute >= config.ratePerMinute) return false;
+
+  const sentLast24h = await store.recentSentCount(24 * 3600);
+  if (sentLast24h >= config.ratePerDay) return false;
+
+  const row = await store.claimNextDue();
+  if (!row) return false;
+
+  const result = await transport.send(row);
+  if (result.ok) {
+    await store.markSent(row.id);
+    return true;
+  }
+
+  if (result.permanent) {
+    await store.markDead(row.id, result.error ?? "unknown permanent error");
+  } else {
+    await store.markTransientFailure(
+      row.id,
+      row.attempts,
+      result.error ?? "unknown transient error"
+    );
+  }
+  return true;
+}
+
+// Long-running drain loop. setTimeout-based so a slow tick can't stack;
+// each tick is awaited before the next is scheduled.
+export function startWorker(
+  store: QueueStore,
+  config: MailConfig,
+  transport: Transport
+): { stop: () => void } {
+  let stopped = false;
+  let timer: NodeJS.Timeout | null = null;
+
+  const run = async () => {
+    if (stopped) return;
+    try {
+      // Drain bursts: keep ticking while work is found, up to the
+      // rate-limit. tickOnce returns true while it has work to do.
+      let did = await tickOnce(store, config, transport);
+      while (did && !stopped) {
+        did = await tickOnce(store, config, transport);
+      }
+    } catch (err) {
+      console.error("[mail:worker] tick error:", err);
+    } finally {
+      if (!stopped) timer = setTimeout(run, config.workerTickMs);
+    }
+  };
+
+  // Defer the first tick so app boot doesn't block on it.
+  timer = setTimeout(run, config.workerTickMs);
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    },
+  };
+}

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint --fix",
     "test:e2e": "npx playwright test --config=e2e/playwright.config.ts",
     "test:e2e:ui": "npx playwright test --config=e2e/playwright.config.ts --ui",
-    "test:e2e:headed": "npx playwright test --config=e2e/playwright.config.ts --headed"
+    "test:e2e:headed": "npx playwright test --config=e2e/playwright.config.ts --headed",
+    "test:unit": "node --import tsx --test tests/unit/*.test.ts"
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",
@@ -25,6 +26,7 @@
     "mui-datatables": "^4.2.2",
     "mysql2": "^3.15.1",
     "next": "^16.1.1",
+    "nodemailer": "^8.0.10",
     "notistack": "^3.0.2",
     "react": "^19.2.3",
     "react-color": "^2.19.3",
@@ -40,6 +42,7 @@
     "@playwright/test": "^1.58.2",
     "@types/mui-datatables": "^4.3.13",
     "@types/node": "^24.5.2",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^19.1.13",
     "@types/react-color": "^3.0.13",
     "@types/react-dom": "^19.1.9",
@@ -54,6 +57,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.37.5",
     "prettier": "^3.6.2",
+    "tsx": "^4.22.3",
     "typescript": "^5.9.2"
   }
 }

--- a/client/tests/unit/mail-backoff.test.ts
+++ b/client/tests/unit/mail-backoff.test.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { nextAttemptDelaySeconds } from "../../lib/mail/backoff";
+
+test("backoff: schedule per attempt", () => {
+  assert.equal(nextAttemptDelaySeconds(1), 60);
+  assert.equal(nextAttemptDelaySeconds(2), 300);
+  assert.equal(nextAttemptDelaySeconds(3), 900);
+  assert.equal(nextAttemptDelaySeconds(4), 3_600);
+  assert.equal(nextAttemptDelaySeconds(5), 21_600);
+  assert.equal(nextAttemptDelaySeconds(6), 86_400);
+});
+
+test("backoff: caps at 24h forever (on-playa scenario)", () => {
+  // Even after a week of attempts, we keep retrying every 24h.
+  // Permanent failure is what should mark `dead`, not retry exhaustion.
+  for (const attempts of [7, 10, 50, 1000]) {
+    assert.equal(nextAttemptDelaySeconds(attempts), 86_400);
+  }
+});
+
+test("backoff: defensive on zero/negative input", () => {
+  assert.equal(nextAttemptDelaySeconds(0), 60);
+  assert.equal(nextAttemptDelaySeconds(-3), 60);
+});

--- a/client/tests/unit/mail-classify.test.ts
+++ b/client/tests/unit/mail-classify.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { classifyError } from "../../lib/mail/classify";
+
+test("classify: 550 → permanent", () => {
+  const out = classifyError({ responseCode: 550, message: "user unknown" });
+  assert.equal(out.permanent, true);
+  assert.equal(out.reason, "user unknown");
+});
+
+test("classify: 553, 554 → permanent", () => {
+  assert.equal(classifyError({ responseCode: 553 }).permanent, true);
+  assert.equal(classifyError({ responseCode: 554 }).permanent, true);
+});
+
+test("classify: 4xx → transient", () => {
+  assert.equal(classifyError({ responseCode: 421 }).permanent, false);
+  assert.equal(classifyError({ responseCode: 450 }).permanent, false);
+  assert.equal(classifyError({ responseCode: 451 }).permanent, false);
+});
+
+test("classify: connection-level / no SMTP code → transient", () => {
+  // On-playa default: when in doubt, retry. A misclassified permanent
+  // is irreversible; a misclassified transient just keeps retrying.
+  assert.equal(
+    classifyError({ code: "ECONNREFUSED", message: "no relay" }).permanent,
+    false
+  );
+  assert.equal(classifyError(new Error("timeout")).permanent, false);
+  assert.equal(classifyError(undefined).permanent, false);
+});

--- a/client/tests/unit/mail-worker.test.ts
+++ b/client/tests/unit/mail-worker.test.ts
@@ -1,0 +1,152 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import type {
+  EmailRow,
+  MailConfig,
+  QueueStore,
+  SendResult,
+  Transport,
+} from "../../lib/mail/types";
+import { tickOnce } from "../../lib/mail/worker";
+
+const baseConfig: MailConfig = {
+  from: "census@burningmail.burningman.org",
+  defaultReplyTo: "Census Volunteer Coordinators <censusvc@burningman.org>",
+  smtpHost: "127.0.0.1",
+  smtpPort: 25,
+  dryRun: false,
+  workerDisabled: false,
+  ratePerMinute: 1,
+  ratePerDay: 100,
+  workerTickMs: 30_000,
+};
+
+function makeRow(overrides: Partial<EmailRow> = {}): EmailRow {
+  return {
+    id: 1,
+    to: "mu@burningman.org",
+    cc: null,
+    replyTo: baseConfig.defaultReplyTo,
+    from: baseConfig.from,
+    subject: "Test",
+    bodyText: "hi",
+    bodyHtml: null,
+    ics: null,
+    category: "test",
+    attempts: 0,
+    state: "queued",
+    ...overrides,
+  };
+}
+
+function makeStore(opts: {
+  row?: EmailRow | null;
+  sentInLastMinute?: number;
+  sentInLastDay?: number;
+}): QueueStore & {
+  calls: { sent: number[]; dead: Array<[number, string]>; failed: Array<[number, number, string]> };
+} {
+  const calls = {
+    sent: [] as number[],
+    dead: [] as Array<[number, string]>,
+    failed: [] as Array<[number, number, string]>,
+  };
+  let row = opts.row ?? null;
+  return {
+    async claimNextDue() {
+      const r = row;
+      row = null;
+      return r;
+    },
+    async markSent(id) {
+      calls.sent.push(id);
+    },
+    async markTransientFailure(id, attempts, reason) {
+      calls.failed.push([id, attempts, reason]);
+    },
+    async markDead(id, reason) {
+      calls.dead.push([id, reason]);
+    },
+    async recentSentCount(within) {
+      return within <= 60 ? (opts.sentInLastMinute ?? 0) : (opts.sentInLastDay ?? 0);
+    },
+    calls,
+  };
+}
+
+function makeTransport(result: SendResult | (() => SendResult)): Transport {
+  return {
+    async send() {
+      return typeof result === "function" ? result() : result;
+    },
+  };
+}
+
+test("tickOnce: success path marks sent", async () => {
+  const store = makeStore({ row: makeRow() });
+  const t = makeTransport({ ok: true });
+  const did = await tickOnce(store, baseConfig, t);
+  assert.equal(did, true);
+  assert.deepEqual(store.calls.sent, [1]);
+  assert.equal(store.calls.failed.length, 0);
+  assert.equal(store.calls.dead.length, 0);
+});
+
+test("tickOnce: transient failure requeues", async () => {
+  const store = makeStore({ row: makeRow({ attempts: 2 }) });
+  const t = makeTransport({ ok: false, permanent: false, error: "timeout" });
+  await tickOnce(store, baseConfig, t);
+  assert.equal(store.calls.sent.length, 0);
+  assert.deepEqual(store.calls.failed, [[1, 2, "timeout"]]);
+  assert.equal(store.calls.dead.length, 0);
+});
+
+test("tickOnce: permanent failure marks dead", async () => {
+  const store = makeStore({ row: makeRow() });
+  const t = makeTransport({ ok: false, permanent: true, error: "550 user unknown" });
+  await tickOnce(store, baseConfig, t);
+  assert.equal(store.calls.sent.length, 0);
+  assert.deepEqual(store.calls.dead, [[1, "550 user unknown"]]);
+  assert.equal(store.calls.failed.length, 0);
+});
+
+test("tickOnce: per-minute cap skips work", async () => {
+  // Already sent 1 in the last 60s. Cap is 1/min → don't send.
+  const store = makeStore({ row: makeRow(), sentInLastMinute: 1 });
+  const t = makeTransport({ ok: true });
+  const did = await tickOnce(store, baseConfig, t);
+  assert.equal(did, false);
+  assert.equal(store.calls.sent.length, 0);
+});
+
+test("tickOnce: per-day cap skips work even when minute cap is fine", async () => {
+  const store = makeStore({
+    row: makeRow(),
+    sentInLastMinute: 0,
+    sentInLastDay: 100,
+  });
+  const t = makeTransport({ ok: true });
+  const did = await tickOnce(store, baseConfig, t);
+  assert.equal(did, false);
+  assert.equal(store.calls.sent.length, 0);
+});
+
+test("tickOnce: no work → returns false", async () => {
+  const store = makeStore({ row: null });
+  const t = makeTransport({ ok: true });
+  const did = await tickOnce(store, baseConfig, t);
+  assert.equal(did, false);
+});
+
+test("tickOnce: missing error string uses fallback reason", async () => {
+  const store = makeStore({ row: makeRow() });
+  const t = makeTransport({ ok: false, permanent: false });
+  await tickOnce(store, baseConfig, t);
+  assert.equal(store.calls.failed[0][2], "unknown transient error");
+
+  const store2 = makeStore({ row: makeRow({ id: 2 }) });
+  const t2 = makeTransport({ ok: false, permanent: true });
+  await tickOnce(store2, baseConfig, t2);
+  assert.equal(store2.calls.dead[0][1], "unknown permanent error");
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -154,6 +154,13 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@emnapi/runtime@^1.7.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz"
@@ -261,6 +268,136 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
+"@esbuild/aix-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz#7a289c158e29cbf59ea0afc83cc80f06d1c89402"
+  integrity sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==
+
+"@esbuild/android-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz#b8828d9edfa3a92660644eb8de6e4f3c203d7b17"
+  integrity sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==
+
+"@esbuild/android-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.0.tgz#5ec1847605e05b5dbe5df90db9ff7e3e4c58dca7"
+  integrity sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==
+
+"@esbuild/android-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.0.tgz#390642175b88ef82bad4cce03f8ab13fe9b1912e"
+  integrity sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==
+
+"@esbuild/darwin-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz#ae45325960d5950cd6951e4f97396f4e1ff7d8d3"
+  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
+
+"@esbuild/darwin-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz#c079247d589b6b99449659d94f06951b84bff2e4"
+  integrity sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==
+
+"@esbuild/freebsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz#45c456215a486593c94900297202dc11c880a37a"
+  integrity sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==
+
+"@esbuild/freebsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz#0399494c1c85e4388e9b7040bd60d48f2a5b0d2c"
+  integrity sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==
+
+"@esbuild/linux-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz#d6d9f09ef0de54116bf459a4d53cac7e0952fe39"
+  integrity sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==
+
+"@esbuild/linux-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz#7b42ffa84c288ae94fdc431c1b28a89e3c3b9278"
+  integrity sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==
+
+"@esbuild/linux-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz#deb15d112ed8dd605346b6b953d23a21ff81253f"
+  integrity sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==
+
+"@esbuild/linux-loong64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz#81fb89d07eecc79b157dea61033757726fce0ca4"
+  integrity sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==
+
+"@esbuild/linux-mips64el@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz#d0e42691b3ff7af9fb2217b70fc01f343bdb62bb"
+  integrity sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==
+
+"@esbuild/linux-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz#389f3e5e98f17d477c467cc87136e1a076eead87"
+  integrity sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==
+
+"@esbuild/linux-riscv64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz#763bd60d59b242be12da1e67d5729f3024c605fa"
+  integrity sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==
+
+"@esbuild/linux-s390x@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz#aac6061634872e4677de693bce8030d73b1fd055"
+  integrity sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==
+
+"@esbuild/linux-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz#4f2917747188fe77632bcec65b2d84b422419779"
+  integrity sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==
+
+"@esbuild/netbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz#814df0ae57a0c386814491b8397eeba82094a947"
+  integrity sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==
+
+"@esbuild/netbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz#e01bdf7e60fa1a08e46d46d960b0d9bb8ac210af"
+  integrity sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==
+
+"@esbuild/openbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz#4a15c36aacca68d2d5a4c90b710c06759f4c1ffa"
+  integrity sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==
+
+"@esbuild/openbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz#475e6101498a8ecce3008d7c388111d7a27c17bd"
+  integrity sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==
+
+"@esbuild/openharmony-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz#cfdc3957f0b7a69f1bde129aad17fcc2f6fa033e"
+  integrity sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==
+
+"@esbuild/sunos-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz#a013c856fecacd1c3aec985c8afe1d1cb017497d"
+  integrity sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==
+
+"@esbuild/win32-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz#eae05e0f35271cad3898b43168d3e9a3bbaf47e5"
+  integrity sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==
+
+"@esbuild/win32-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz#06161ebc5bf75c08d69feb3c6b22560515913998"
+  integrity sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==
+
+"@esbuild/win32-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
+  integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
+
 "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz"
@@ -365,15 +502,104 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz"
   integrity sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==
 
+"@img/sharp-darwin-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz#6e0732dcade126b6670af7aa17060b926835ea86"
+  integrity sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-arm64" "1.2.4"
+
+"@img/sharp-darwin-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz#19bc1dd6eba6d5a96283498b9c9f401180ee9c7b"
+  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
+
+"@img/sharp-libvips-darwin-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz#2894c0cb87d42276c3889942e8e2db517a492c43"
+  integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
+
+"@img/sharp-libvips-darwin-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz#e63681f4539a94af9cd17246ed8881734386f8cc"
+  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
+
+"@img/sharp-libvips-linux-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz#b1b288b36864b3bce545ad91fa6dadcf1a4ad318"
+  integrity sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==
+
+"@img/sharp-libvips-linux-arm@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz#b9260dd1ebe6f9e3bdbcbdcac9d2ac125f35852d"
+  integrity sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==
+
+"@img/sharp-libvips-linux-ppc64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz#4b83ecf2a829057222b38848c7b022e7b4d07aa7"
+  integrity sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==
+
+"@img/sharp-libvips-linux-riscv64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz#880b4678009e5a2080af192332b00b0aaf8a48de"
+  integrity sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==
+
+"@img/sharp-libvips-linux-s390x@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz#74f343c8e10fad821b38f75ced30488939dc59ec"
+  integrity sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==
+
 "@img/sharp-libvips-linux-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
   integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
 
+"@img/sharp-libvips-linuxmusl-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz#c8d6b48211df67137541007ee8d1b7b1f8ca8e06"
+  integrity sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==
+
 "@img/sharp-libvips-linuxmusl-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
   integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
+
+"@img/sharp-linux-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz#7aa7764ef9c001f15e610546d42fce56911790cc"
+  integrity sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.2.4"
+
+"@img/sharp-linux-arm@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz#5fb0c3695dd12522d39c3ff7a6bc816461780a0d"
+  integrity sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.2.4"
+
+"@img/sharp-linux-ppc64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz#9c213a81520a20caf66978f3d4c07456ff2e0813"
+  integrity sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.2.4"
+
+"@img/sharp-linux-riscv64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz#cdd28182774eadbe04f62675a16aabbccb833f60"
+  integrity sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-riscv64" "1.2.4"
+
+"@img/sharp-linux-s390x@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz#93eac601b9f329bb27917e0e19098c722d630df7"
+  integrity sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.2.4"
 
 "@img/sharp-linux-x64@0.34.5":
   version "0.34.5"
@@ -382,12 +608,41 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-x64" "1.2.4"
 
+"@img/sharp-linuxmusl-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz#d6515ee971bb62f73001a4829b9d865a11b77086"
+  integrity sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
+
 "@img/sharp-linuxmusl-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
   integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+
+"@img/sharp-wasm32@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz#2f15803aa626f8c59dd7c9d0bbc766f1ab52cfa0"
+  integrity sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==
+  dependencies:
+    "@emnapi/runtime" "^1.7.0"
+
+"@img/sharp-win32-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz#3706e9e3ac35fddfc1c87f94e849f1b75307ce0a"
+  integrity sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==
+
+"@img/sharp-win32-ia32@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz#0b71166599b049e032f085fb9263e02f4e4788de"
+  integrity sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==
+
+"@img/sharp-win32-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
+  integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -617,6 +872,26 @@
   dependencies:
     fast-glob "3.3.1"
 
+"@next/swc-darwin-arm64@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz#1e7e87fd21fcabce546dfb04fb946ecd9f866917"
+  integrity sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==
+
+"@next/swc-darwin-x64@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz#6617d03b96bdffad7bf4df50d4a699faea0d04c3"
+  integrity sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==
+
+"@next/swc-linux-arm64-gnu@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz#d8337e2f4881a80221a1f56ac3f979b665b7e574"
+  integrity sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==
+
+"@next/swc-linux-arm64-musl@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz#6c24392824406a50f27fb9cf4e49362d4666db1c"
+  integrity sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==
+
 "@next/swc-linux-x64-gnu@16.1.1":
   version "16.1.1"
   resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz"
@@ -627,6 +902,16 @@
   resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz"
   integrity sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==
 
+"@next/swc-win32-arm64-msvc@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz#9d66be9dc4ebc458d445a7f6ee804f416d5c2daf"
+  integrity sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==
+
+"@next/swc-win32-x64-msvc@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz#96e9e335e2577481dab6fc7a2af48f3e4a28fbdb"
+  integrity sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -635,7 +920,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -748,12 +1033,19 @@
     "@types/react" "*"
     csstype "^3.2.2"
 
-"@types/node@*", "@types/node@^24.5.2", "@types/node@>=10.0.0":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^24.5.2":
   version "24.5.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz"
   integrity sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==
   dependencies:
     undici-types "~7.12.0"
+
+"@types/nodemailer@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-8.0.0.tgz#ea189a9c151c04cc65c8a2a4c668c65d952a24e2"
+  integrity sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"
@@ -796,7 +1088,7 @@
   dependencies:
     "@types/react" "*"
 
-"@typescript-eslint/eslint-plugin@^8.44.1", "@typescript-eslint/eslint-plugin@8.50.1":
+"@typescript-eslint/eslint-plugin@8.50.1", "@typescript-eslint/eslint-plugin@^8.44.1":
   version "8.50.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz"
   integrity sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==
@@ -810,7 +1102,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@^8.44.1", "@typescript-eslint/parser@8.50.1":
+"@typescript-eslint/parser@8.50.1", "@typescript-eslint/parser@^8.44.1":
   version "8.50.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz"
   integrity sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==
@@ -838,7 +1130,7 @@
     "@typescript-eslint/types" "8.50.1"
     "@typescript-eslint/visitor-keys" "8.50.1"
 
-"@typescript-eslint/tsconfig-utils@^8.50.1", "@typescript-eslint/tsconfig-utils@8.50.1":
+"@typescript-eslint/tsconfig-utils@8.50.1", "@typescript-eslint/tsconfig-utils@^8.50.1":
   version "8.50.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz"
   integrity sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==
@@ -854,7 +1146,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@^8.50.1", "@typescript-eslint/types@8.50.1":
+"@typescript-eslint/types@8.50.1", "@typescript-eslint/types@^8.50.1":
   version "8.50.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz"
   integrity sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==
@@ -1083,7 +1375,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64id@~2.0.0, base64id@2.0.0:
+base64id@2.0.0, base64id@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
@@ -1175,17 +1467,7 @@ client-only@0.0.1:
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
-clsx@^1.0.4:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
-
-clsx@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
-
-clsx@^1.1.1:
+clsx@^1.0.4, clsx@^1.1.0, clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -1328,14 +1610,7 @@ debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@~4.4
   dependencies:
     ms "^2.1.3"
 
-debug@~4.3.1:
-  version "4.3.7"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
-  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
-  dependencies:
-    ms "^2.1.3"
-
-debug@~4.3.4:
+debug@~4.3.1, debug@~4.3.4:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -1599,6 +1874,38 @@ es-to-primitive@^1.3.0:
     is-callable "^1.2.7"
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
+
+esbuild@~0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.0.tgz#5dee347ffb3e3874212a35a69836b077b1ce6d96"
+  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.0"
+    "@esbuild/android-arm" "0.28.0"
+    "@esbuild/android-arm64" "0.28.0"
+    "@esbuild/android-x64" "0.28.0"
+    "@esbuild/darwin-arm64" "0.28.0"
+    "@esbuild/darwin-x64" "0.28.0"
+    "@esbuild/freebsd-arm64" "0.28.0"
+    "@esbuild/freebsd-x64" "0.28.0"
+    "@esbuild/linux-arm" "0.28.0"
+    "@esbuild/linux-arm64" "0.28.0"
+    "@esbuild/linux-ia32" "0.28.0"
+    "@esbuild/linux-loong64" "0.28.0"
+    "@esbuild/linux-mips64el" "0.28.0"
+    "@esbuild/linux-ppc64" "0.28.0"
+    "@esbuild/linux-riscv64" "0.28.0"
+    "@esbuild/linux-s390x" "0.28.0"
+    "@esbuild/linux-x64" "0.28.0"
+    "@esbuild/netbsd-arm64" "0.28.0"
+    "@esbuild/netbsd-x64" "0.28.0"
+    "@esbuild/openbsd-arm64" "0.28.0"
+    "@esbuild/openbsd-x64" "0.28.0"
+    "@esbuild/openharmony-arm64" "0.28.0"
+    "@esbuild/sunos-x64" "0.28.0"
+    "@esbuild/win32-arm64" "0.28.0"
+    "@esbuild/win32-ia32" "0.28.0"
+    "@esbuild/win32-x64" "0.28.0"
 
 escalade@^3.2.0:
   version "3.2.0"
@@ -1877,10 +2184,10 @@ fast-diff@^1.1.2:
   resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
-fast-glob@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+fast-glob@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1888,10 +2195,10 @@ fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz"
-  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+fast-glob@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1984,6 +2291,16 @@ form-data@^4.0.4:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -2072,15 +2389,15 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-globals@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
-  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
-
 globals@16.4.0:
   version "16.4.0"
   resolved "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz"
   integrity sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==
+
+globals@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
+  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -2759,6 +3076,11 @@ node-releases@^2.0.27:
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
+nodemailer@^8.0.10:
+  version "8.0.10"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.10.tgz#009d4deaa06f54b6bd7ddc6cac1bf78e3bcb0bf2"
+  integrity sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==
+
 notistack@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz"
@@ -3073,12 +3395,7 @@ react-idle-timer@5.7.2:
   resolved "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-5.7.2.tgz"
   integrity sha512-+BaPfc7XEUU5JFkwZCx6fO1bLVK+RBlFH+iY4X34urvIzZiZINP6v2orePx3E6pAztJGE7t4DzvL7if2SL/0GQ==
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3289,12 +3606,7 @@ scheduler@^0.27.0:
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
-semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -3645,7 +3957,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.8.0:
+tslib@^2.4.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -3658,6 +3970,15 @@ tss-react@^3.6.0:
     "@emotion/cache" "*"
     "@emotion/serialize" "*"
     "@emotion/utils" "*"
+
+tsx@^4.22.3:
+  version "4.22.3"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.22.3.tgz#7ca7cb34028e3e247f1fad300c157e42a90a1f50"
+  integrity sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/migrations/002_op_email_queue.sql
+++ b/migrations/002_op_email_queue.sql
@@ -1,0 +1,32 @@
+-- Email queue table. See #307.
+--
+-- All concrete email features (per-assignment, periodic digest, SAP-ready,
+-- contact-form send, critical-drop) enqueue rows here. A worker drains the
+-- queue with 1/min + 100/day rate limits and exponential backoff capped at
+-- 24h. On-playa internet outages may last days — transient failures keep
+-- retrying forever; only permanent SMTP errors mark the row `dead`.
+--
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS `op_email_queue` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `to` TEXT NOT NULL,
+  `cc` TEXT NULL,
+  `reply_to` TEXT NOT NULL,
+  `from` VARCHAR(255) NOT NULL,
+  `subject` VARCHAR(998) NOT NULL,
+  `body_text` MEDIUMTEXT NOT NULL,
+  `body_html` MEDIUMTEXT NULL,
+  `ics_attachment` MEDIUMBLOB NULL,
+  `ics_filename` VARCHAR(255) NULL,
+  `category` VARCHAR(64) NOT NULL,
+  `enqueued_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `next_attempt_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `sent_at` DATETIME NULL,
+  `attempts` INT NOT NULL DEFAULT 0,
+  `state` ENUM('queued','sending','sent','failed','dead') NOT NULL DEFAULT 'queued',
+  `last_error` TEXT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_state_next` (`state`, `next_attempt_at`),
+  KEY `idx_sent_at` (`sent_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Closes #307 (foundation only — no callers wired; per-feature PRs chain off this).

## Summary
- New table `op_email_queue` + worker that drains it with 1/min + 100/day rate limits
- Backoff schedule caps at 24h and **retries forever** for transient failures (on-playa internet may be out for days). Only permanent SMTP errors (550/551/553/554) mark the row `dead`
- Transport is pluggable via a `Transport` interface — SMTP via nodemailer in prod, dry-run for dev/CI/hosts with no relay, and the door is open for the on-playa Gmail OAuth swap mentioned by @mbhewitt
- Worker takes a `QueueStore` interface, so unit tests run against an in-memory store with zero DB dependency
- 14 unit tests via Node's built-in `node:test` (no Jest/Vitest added) — exercises backoff schedule, error classification, worker happy path, transient + permanent failures, both rate-limit gates

## Env vars (all optional, defaults are prod-ready)
```
SMTP_HOST=127.0.0.1
SMTP_PORT=25
MAIL_FROM=census@burningmail.burningman.org
MAIL_DEFAULT_REPLY_TO="Census Volunteer Coordinators <censusvc@burningman.org>"
MAIL_DRY_RUN=1                  # log instead of sending
MAIL_WORKER_DISABLED=1          # skip bootstrap (CI, tests)
MAIL_RATE_PER_MINUTE=1
MAIL_RATE_PER_DAY=100
MAIL_WORKER_TICK_MS=30000
```

## SMTP confirmation
Done end-to-end on prod 2026-05-29: Exim on `localhost:25` accepted `census@burningmail.burningman.org` (no local mailbox required) and delivered to `mu@burningman.org` via the SES relay.

## Test plan
- [ ] `yarn test:unit` — 14 pass locally
- [ ] `yarn build` — clean compile
- [ ] Apply migration on test server: `mysql census < migrations/002_op_email_queue.sql`
- [ ] On test server with `MAIL_DRY_RUN=1`: insert a row by hand, watch the worker log `[mail:dry-run] would send …`, verify state goes to `sent`
- [ ] On prod (after deploy): insert a real row, verify it delivers and `sent_at` is populated; verify a 2nd row enqueued <60s after the first is held back by rate limit

## Out of scope (separate PRs, each chains off this)
- #309 per-assignment email + .ics
- #310 periodic digest
- #311 SAP-ready email
- #312 contact-form send
- #313 critical-drop notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)