### PR TITLE
feat(contact): actually send the message (#312)

### DIFF
--- a/client/src/pages/api/contact/index.ts
+++ b/client/src/pages/api/contact/index.ts
@@ -1,7 +1,31 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import type { ResultSetHeader } from "mysql2";
 
 import type { IReqContact } from "@/components/types/contact";
+import { enqueueEmail } from "lib/mail";
 import { pool } from "lib/database";
+
+// #312: the form was a black hole — `op_messages` row written, no email
+// sent. Now we also enqueue the email via #307. The DB write is still
+// the canonical "we got your message" — an enqueue failure logs but
+// does not fail the form submission.
+const buildSubject = (name: string, wantsReply: boolean): string =>
+  `[Census contact] from ${name || "Anonymous"} (${wantsReply ? "reply wanted" : "no reply needed"})`;
+
+const buildBody = (
+  { email, isReplyWanted, message, name, to }: IReqContact,
+  messageId: number
+): string =>
+  [
+    `From: ${name || "Anonymous"} <${email}>`,
+    `Routed to category: ${to}`,
+    `Wants reply: ${isReplyWanted ? "yes" : "no"}`,
+    "",
+    "--- Message ---",
+    message,
+    "",
+    `Stored as op_messages.id = ${messageId}`,
+  ].join("\n");
 
 const contact = async (req: NextApiRequest, res: NextApiResponse) => {
   switch (req.method) {
@@ -9,14 +33,35 @@ const contact = async (req: NextApiRequest, res: NextApiResponse) => {
     // ------------------------------------------------------------
     case "POST": {
       // store message
-      const { email, isReplyWanted, message, name, to }: IReqContact =
-        JSON.parse(req.body);
+      const body: IReqContact = JSON.parse(req.body);
+      const { email, isReplyWanted, message, name, to } = body;
 
-      await pool.query(
+      const [result] = await pool.query<ResultSetHeader>(
         // must use backticks for "to" keyword
         "INSERT INTO op_messages (email, message, name, `to`, wants_reply) VALUES (?, ?, ?, ?, ?)",
         [email, message, name, to, isReplyWanted]
       );
+
+      // Best-effort send. Per #312 acceptance: enqueue failure does
+      // NOT fail the form submission — the row write above is the
+      // canonical record. Headers per the domain-admin contract:
+      // From locked to census@burningmail.burningman.org (default in
+      // enqueueEmail), Reply-To = volunteer's email, Cc = VC list.
+      try {
+        await enqueueEmail({
+          to,
+          cc: "censusvc@burningman.org",
+          replyTo: email,
+          subject: buildSubject(name, isReplyWanted),
+          bodyText: buildBody(body, result.insertId),
+          category: "contact-form",
+        });
+      } catch (err) {
+        console.error(
+          `[contact] enqueueEmail failed for op_messages.id=${result.insertId}:`,
+          err
+        );
+      }
 
       return res.status(201).json({
         statusCode: 201,


### PR DESCRIPTION
Closes #312. Builds on the email queue foundation merged via #361.

## Summary
The contact form already wrote to \`op_messages\` but never sent anything. This PR also enqueues an email via \`lib/mail.enqueueEmail\` after the row write, with the special header pattern from the domain-admin contract:

| Header | Value |
|---|---|
| From | \`census@burningmail.burningman.org\` (default in \`enqueueEmail\` — only allowed sender domain) |
| To | the form's \`to\` field (recipient category) |
| Reply-To | the volunteer's email — so coordinators reply directly to the submitter |
| Cc | \`censusvc@burningman.org\` — VC list always sees the message |
| Subject | \`[Census contact] from {Name} (reply wanted\|no reply needed)\` |
| Body | name+email, routing category, wants-reply flag, message verbatim, \`op_messages.id\` |

## Failure semantics
Per #312 acceptance: enqueue failure does NOT fail the form submission. The \`op_messages\` row is the canonical "we got your message" record; the email is best-effort on top.

## Test plan
- [ ] Foundation #361 deployed first (see #361 test plan)
- [ ] Submit the Contact form once on test/prod, verify an \`op_messages\` row was written (existing behavior — regression check)
- [ ] Verify a new \`op_email_queue\` row appears with the correct headers, then transitions to \`sent\` within ~30s
- [ ] In the inbox: clicking Reply addresses the volunteer, not censusvc; censusvc is on the Cc line

🤖 Generated with [Claude Code](https://claude.com/claude-code)