### PR TITLE
fix(middleware): allowlist /api/contact so the form actually posts

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -35,6 +35,11 @@ const ALLOWLIST = [
 
   // Public information pages (per Mew, 2026-05-06)
   "/contact",
+  // /api/contact accepts the form POST. Must be unauthenticated so
+  // walk-up visitors with no session can actually send a message —
+  // the /contact page was already allowlisted but its API was not,
+  // so the form silently 401'd for everyone signed-out (#312).
+  "/api/contact",
   "/help",
   "/reports",
 


### PR DESCRIPTION
The /contact page is in the public allowlist but the API endpoint it POSTs to wasn't, so the form silently 401'd for any signed-out visitor — which is the form's primary audience.

Caught smoke-testing #312 against prod: a curl POST to https://volunteers.census.burningman.org/api/contact returned 401 from the middleware before reaching the handler.

One-line fix: add /api/contact to the allowlist.

## Test plan
- [ ] After deploy, signed-out curl POST to /api/contact returns 201
- [ ] op_messages row written and op_email_queue row enqueued + sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)