### PR TITLE
feat(contact): trim recipient list to 4 categories + default reply checkbox

### DIFF
--- a/client/src/app/contact/Contact.tsx
+++ b/client/src/app/contact/Contact.tsx
@@ -14,7 +14,6 @@ import {
   FormControlLabel,
   Grid,
   InputLabel,
-  ListSubheader,
   MenuItem,
   Select,
   TextField,
@@ -24,18 +23,14 @@ import { useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 import { useContext, useEffect } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
-import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 
-import { ErrorPage } from "@/components/general/ErrorPage";
-import { Loading } from "@/components/general/Loading";
 import { SnackbarText } from "@/components/general/SnackbarText";
 import { Hero } from "@/components/layout/Hero";
 import type { IReqContact } from "@/components/types/contact";
-import type { IResVolunteerDefaultItem } from "@/components/types/volunteers";
-import { GENERAL_ROLE_LIST } from "@/constants";
+import { CONTACT_RECIPIENT_LABELS } from "@/constants";
 import { SessionContext } from "@/state/session/context";
-import { fetcherGet, fetcherTrigger } from "@/utils/fetcher";
+import { fetcherTrigger } from "@/utils/fetcher";
 
 interface IFormValues {
   email: string;
@@ -47,7 +42,7 @@ interface IFormValues {
 
 const defaultValues: IFormValues = {
   email: "",
-  isReplyWanted: false,
+  isReplyWanted: true,
   message: "",
   name: "",
   to: "Volunteer Coordinator",
@@ -64,13 +59,6 @@ export const Contact = () => {
 
   // fetching, mutation, and revalidation
   // ------------------------------------------------------------
-  const {
-    data,
-    error,
-  }: {
-    data: IResVolunteerDefaultItem[];
-    error: Error | undefined;
-  } = useSWR("/api/volunteers/dropdown?filter=core", fetcherGet);
   const { isMutating, trigger } = useSWRMutation(
     "/api/contact",
     fetcherTrigger
@@ -104,11 +92,6 @@ export const Contact = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated]);
-
-  // logic
-  // ------------------------------------------------------------
-  if (error) return <ErrorPage />;
-  if (!data) return <Loading />;
 
   // form submission
   // ------------------------------------------------------------
@@ -233,28 +216,12 @@ export const Contact = () => {
                             <MenuItem
                               key="Send me a reminder"
                               value="Send me a reminder"
-                              sx={{ pl: 4 }}
                             >
                               Send me a reminder
                             </MenuItem>
-                            <ListSubheader>General roles</ListSubheader>
-                            {GENERAL_ROLE_LIST.map((generalRoleItem) => (
-                              <MenuItem
-                                key={`${generalRoleItem}`}
-                                value={generalRoleItem}
-                                sx={{ pl: 4 }}
-                              >
-                                {generalRoleItem}
-                              </MenuItem>
-                            ))}
-                            <ListSubheader>Core volunteers</ListSubheader>
-                            {data.map(({ playaName, worldName }) => (
-                              <MenuItem
-                                key={`${playaName}-${worldName}`}
-                                value={`${playaName} "${worldName}"`}
-                                sx={{ pl: 4 }}
-                              >
-                                {`${playaName} "${worldName}"`}
+                            {CONTACT_RECIPIENT_LABELS.map((label) => (
+                              <MenuItem key={label} value={label}>
+                                {label}
                               </MenuItem>
                             ))}
                           </Select>

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -4,17 +4,18 @@ export const HELPER_TEXT_EMERGENCY_CONTACT =
 export const HELPER_TEXT_LOCATION =
   "How to find you on playa and any other relevant info";
 
-// contact page form
-export const GENERAL_ROLE_LIST = [
-  "Census Lab Coordinator",
-  "Census Manager",
-  "Construction Lead",
-  "Data Analyst/Science",
-  "Sampling Coordinator",
-  "Scheduling Coordinator",
-  "Technology",
-  "Volunteer Coordinator",
-].sort();
+// contact page form — label → email recipients. The label is what
+// the user sees in the To dropdown and what we store in op_messages.to;
+// the email string (comma-separated, RFC-style) is what the email
+// actually goes to. Keep this list short — every entry is an inbox
+// that gets pinged for every routed message.
+export const CONTACT_RECIPIENTS: Record<string, string> = {
+  "Volunteer Coordinator": "censusvolunteercoordinators@burningman.org",
+  "Census Manager": "ann.norton@burningman.org, random@burningman.org",
+  Data: "aaronshev@gmail.com",
+  Technology: "mu@burningman.org, chipper@burningman.org, rqreyes@gmail.com",
+};
+export const CONTACT_RECIPIENT_LABELS = Object.keys(CONTACT_RECIPIENTS).sort();
 
 // review dialog - radio options
 export const legendList = [

--- a/client/src/pages/api/contact/index.ts
+++ b/client/src/pages/api/contact/index.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import type { ResultSetHeader } from "mysql2";
 
 import type { IReqContact } from "@/components/types/contact";
+import { CONTACT_RECIPIENTS } from "@/constants";
 import { enqueueEmail } from "lib/mail";
 import { pool } from "lib/database";
 
@@ -9,6 +10,13 @@ import { pool } from "lib/database";
 // sent. Now we also enqueue the email via #307. The DB write is still
 // the canonical "we got your message" — an enqueue failure logs but
 // does not fail the form submission.
+//
+// The "to" field arriving from the form is a recipient *label*
+// (e.g. "Volunteer Coordinator"), not an email address. We store the
+// label in op_messages.to (human-readable history) and map it through
+// CONTACT_RECIPIENTS to get the actual address list for the SMTP send.
+// "Send me a reminder" is a self-reminder marker with no SMTP target —
+// we skip the enqueue and just keep the op_messages row.
 const buildSubject = (name: string, wantsReply: boolean): string =>
   `[Census contact] from ${name || "Anonymous"} (${wantsReply ? "reply wanted" : "no reply needed"})`;
 
@@ -47,20 +55,28 @@ const contact = async (req: NextApiRequest, res: NextApiResponse) => {
       // canonical record. Headers per the domain-admin contract:
       // From locked to census@burningmail.burningman.org (default in
       // enqueueEmail), Reply-To = volunteer's email, Cc = VC list.
-      try {
-        await enqueueEmail({
-          to,
-          cc: "censusvc@burningman.org",
-          replyTo: email,
-          subject: buildSubject(name, isReplyWanted),
-          bodyText: buildBody(body, result.insertId),
-          category: "contact-form",
-        });
-      } catch (err) {
-        console.error(
-          `[contact] enqueueEmail failed for op_messages.id=${result.insertId}:`,
-          err
+      const recipientEmails = CONTACT_RECIPIENTS[to];
+      if (!recipientEmails) {
+        // "Send me a reminder" or an unknown label — no SMTP target.
+        console.warn(
+          `[contact] no email target for to=${JSON.stringify(to)} (op_messages.id=${result.insertId}); skipping enqueue`
         );
+      } else {
+        try {
+          await enqueueEmail({
+            to: recipientEmails,
+            cc: "censusvc@burningman.org",
+            replyTo: email,
+            subject: buildSubject(name, isReplyWanted),
+            bodyText: buildBody(body, result.insertId),
+            category: "contact-form",
+          });
+        } catch (err) {
+          console.error(
+            `[contact] enqueueEmail failed for op_messages.id=${result.insertId}:`,
+            err
+          );
+        }
       }
 
       return res.status(201).json({


### PR DESCRIPTION
## Summary
Per Mew 2026-05-29 — the contact form's "To" dropdown was sprawling. Cut to four categories, each backed by a concrete inbox or set of inboxes that someone actually monitors:

| Label | Address(es) |
|---|---|
| Volunteer Coordinator | censusvolunteercoordinators@burningman.org |
| Census Manager | ann.norton@burningman.org, random@burningman.org |
| Data | aaronshev@gmail.com |
| Technology | mu@burningman.org, chipper@burningman.org, rqreyes@gmail.com |

The label is still what shows in the dropdown and what gets stored in `op_messages.to` (preserves human-readable history); the address list is what the email actually goes to. `CONTACT_RECIPIENTS` in `constants.ts` is the one place to edit when extending or trimming.

Also:
- Default "Reply wanted after Burning Man" to checked
- Drop the unused `useSWR("/api/volunteers/dropdown?filter=core", ...)` fetch + its `Loading`/`ErrorPage` gating + the `IResVolunteerDefaultItem` import — the "Core volunteers" submenu is gone
- "Send me a reminder" stays as a self-reminder marker with no SMTP target — handler skips enqueue, still writes `op_messages`

## Test plan
- [ ] Open /contact: dropdown shows "Send me a reminder" then the 4 categories, alphabetized
- [ ] Reply checkbox is checked by default
- [ ] Submit with "Technology" selected: op_messages row with `to='Technology'`, op_email_queue row with `to='mu@burningman.org, chipper@burningman.org, rqreyes@gmail.com'`, delivered within 30s
- [ ] Submit with "Send me a reminder": op_messages row written, no op_email_queue row (warning in container log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)