### PR TITLE
hotfix(contact): drop dangling reminderParam ref

### DIFF
--- a/client/src/app/contact/Contact.tsx
+++ b/client/src/app/contact/Contact.tsx
@@ -103,7 +103,6 @@ export const Contact = () => {
           ...defaultValues,
           email,
           name: `${playaName} "${worldName}"`,
-          to: reminderParam ? "Send me a reminder" : "Volunteer Coordinator",
         });
       } else {
         reset(defaultValues);


### PR DESCRIPTION
Followup to PR #366 — that one removed the useSearchParams import + the reminderParam variable but missed one reference inside the post-submit reset block. One-line fix.