### PR TITLE
feat(mail): MAIL_OVERRIDE_TO env to redirect all sends to one address

### DIFF
--- a/client/lib/mail/index.ts
+++ b/client/lib/mail/index.ts
@@ -16,6 +16,7 @@ function readConfig(): MailConfig {
     smtpHost: process.env.SMTP_HOST ?? "127.0.0.1",
     smtpPort: Number.isFinite(port) ? port : 25,
     dryRun: process.env.MAIL_DRY_RUN === "1",
+    overrideTo: process.env.MAIL_OVERRIDE_TO?.trim() || null,
     workerDisabled: process.env.MAIL_WORKER_DISABLED === "1",
     ratePerMinute: parseIntEnv("MAIL_RATE_PER_MINUTE", 1),
     ratePerDay: parseIntEnv("MAIL_RATE_PER_DAY", 100),
@@ -56,6 +57,6 @@ export function bootstrapMailWorker(): void {
   const store = createMysqlStore(pool);
   startWorker(store, cfg, transport);
   console.warn(
-    `[mail:worker] started — tickMs=${cfg.workerTickMs} ratePerMinute=${cfg.ratePerMinute} ratePerDay=${cfg.ratePerDay} dryRun=${cfg.dryRun} smtp=${cfg.smtpHost}:${cfg.smtpPort}`
+    `[mail:worker] started — tickMs=${cfg.workerTickMs} ratePerMinute=${cfg.ratePerMinute} ratePerDay=${cfg.ratePerDay} dryRun=${cfg.dryRun} smtp=${cfg.smtpHost}:${cfg.smtpPort}${cfg.overrideTo ? ` overrideTo=${cfg.overrideTo}` : ""}`
   );
 }

--- a/client/lib/mail/transport.ts
+++ b/client/lib/mail/transport.ts
@@ -3,6 +3,35 @@ import nodemailer from "nodemailer";
 import { classifyError } from "./classify";
 import type { EmailRow, MailConfig, SendResult, Transport } from "./types";
 
+// When MAIL_OVERRIDE_TO is set, prefix the body so the test recipient
+// can see at a glance what the real headers would have been.
+function applyOverride(
+  row: EmailRow,
+  override: string
+): {
+  to: string;
+  cc: string | null;
+  bodyText: string;
+  bodyHtml: string | null;
+} {
+  const banner = [
+    "*** MAIL_OVERRIDE_TO is active — this would have gone to:",
+    `***   To: ${row.to}`,
+    ...(row.cc ? [`***   Cc: ${row.cc}`] : []),
+    `***   Reply-To: ${row.replyTo}`,
+    "*** Delivered to the override address instead.",
+    "",
+  ].join("\n");
+  return {
+    to: override,
+    cc: null,
+    bodyText: banner + row.bodyText,
+    bodyHtml: row.bodyHtml
+      ? `<pre style="background:#fff4cc;border:1px solid #d4a017;padding:8px;color:#5b3a00;">${banner.replace(/\n/g, "<br>")}</pre>${row.bodyHtml}`
+      : null,
+  };
+}
+
 export function createSmtpTransport(config: MailConfig): Transport {
   const transporter = nodemailer.createTransport({
     host: config.smtpHost,
@@ -17,14 +46,22 @@ export function createSmtpTransport(config: MailConfig): Transport {
   return {
     async send(row: EmailRow): Promise<SendResult> {
       try {
+        const headers = config.overrideTo
+          ? applyOverride(row, config.overrideTo)
+          : {
+              to: row.to,
+              cc: row.cc,
+              bodyText: row.bodyText,
+              bodyHtml: row.bodyHtml,
+            };
         await transporter.sendMail({
           from: row.from,
-          to: row.to,
-          cc: row.cc ?? undefined,
+          to: headers.to,
+          cc: headers.cc ?? undefined,
           replyTo: row.replyTo,
           subject: row.subject,
-          text: row.bodyText,
-          html: row.bodyHtml ?? undefined,
+          text: headers.bodyText,
+          html: headers.bodyHtml ?? undefined,
           attachments: row.ics
             ? [
                 {

--- a/client/lib/mail/types.ts
+++ b/client/lib/mail/types.ts
@@ -57,6 +57,13 @@ export interface MailConfig {
   smtpHost: string;
   smtpPort: number;
   dryRun: boolean;
+  // When set: SMTP envelope + To header are rewritten to this single
+  // address; Cc is dropped; the body is prepended with a banner showing
+  // what the real recipients would have been. The queue row is NOT
+  // modified — `op_email_queue.to` / `cc` still record the intended
+  // recipients so routing logic stays observable. Unsetting the env
+  // (and recreating the container) flips traffic back to live.
+  overrideTo: string | null;
   workerDisabled: boolean;
   ratePerMinute: number;
   ratePerDay: number;

--- a/client/tests/unit/mail-worker.test.ts
+++ b/client/tests/unit/mail-worker.test.ts
@@ -16,6 +16,7 @@ const baseConfig: MailConfig = {
   smtpHost: "127.0.0.1",
   smtpPort: 25,
   dryRun: false,
+  overrideTo: null,
   workerDisabled: false,
   ratePerMinute: 1,
   ratePerDay: 100,


### PR DESCRIPTION
Test-mode safety net for the next round of email features (#309, #313). When MAIL_OVERRIDE_TO is set, the SMTP transport rewrites To→override, drops Cc, and prepends a banner showing what the real headers would have been. The queue row is NOT modified — original recipients stay observable. Flip back to live = unset the env var + container recreate.