### PR TITLE
fix(mail): METHOD:PUBLISH + inline text/calendar

### DIFF
--- a/client/lib/mail/transport.ts
+++ b/client/lib/mail/transport.ts
@@ -3,6 +3,31 @@ import nodemailer from "nodemailer";
 import { classifyError } from "./classify";
 import type { EmailRow, MailConfig, SendResult, Transport } from "./types";
 
+// Pull the METHOD value out of an .ics payload so we can hand the
+// matching method to nodemailer's icalEvent (it goes into the
+// Content-Type parameter on the text/calendar part). Defaults to
+// PUBLISH for "I'm putting this on your calendar" — a safe fallback
+// that calendar clients will accept even if the file itself was
+// authored without an explicit METHOD line.
+function extractIcsMethod(
+  content: Buffer | string
+): "publish" | "cancel" | "request" | "reply" | "add" | "refresh" {
+  const s = Buffer.isBuffer(content) ? content.toString("utf8") : content;
+  const m = s.match(/^METHOD:(\S+)/m);
+  const v = (m?.[1] ?? "PUBLISH").toLowerCase();
+  switch (v) {
+    case "publish":
+    case "cancel":
+    case "request":
+    case "reply":
+    case "add":
+    case "refresh":
+      return v;
+    default:
+      return "publish";
+  }
+}
+
 // When MAIL_OVERRIDE_TO is set, prefix the body so the test recipient
 // can see at a glance what the real headers would have been.
 function applyOverride(
@@ -62,14 +87,17 @@ export function createSmtpTransport(config: MailConfig): Transport {
           subject: row.subject,
           text: headers.bodyText,
           html: headers.bodyHtml ?? undefined,
-          attachments: row.ics
-            ? [
-                {
-                  filename: row.ics.filename,
-                  content: row.ics.content,
-                  contentType: "text/calendar; method=REQUEST; charset=UTF-8",
-                },
-              ]
+          // Use nodemailer's `icalEvent` so the calendar payload lives
+          // inside a multipart/alternative as text/calendar. Outlook
+          // renders that as a native event banner ("Add to calendar")
+          // instead of a passive file attachment. Apple Mail / Gmail
+          // also recognize the inline part and surface the same UI.
+          icalEvent: row.ics
+            ? {
+                filename: row.ics.filename,
+                content: row.ics.content,
+                method: extractIcsMethod(row.ics.content),
+              }
             : undefined,
         });
         return { ok: true };

--- a/client/src/components/api/assignmentNotify.ts
+++ b/client/src/components/api/assignmentNotify.ts
@@ -74,12 +74,17 @@ function buildIcs(args: {
   date: string;
   startTime: string;
   endTime: string;
-  method: "REQUEST" | "CANCEL";
-  // Calendar clients match CANCEL to a prior REQUEST by UID and
+  // PUBLISH = "I'm publishing an event I think you want on your
+  // calendar; no RSVP expected." That matches our case better than
+  // REQUEST (which implies organizer/attendee with Accept/Decline
+  // exchange — we have neither, and our From domain is send-only).
+  // CANCEL is used by the removal path to drop the original.
+  method: "PUBLISH" | "CANCEL";
+  // Calendar clients match CANCEL to a prior PUBLISH by UID and
   // require a SEQUENCE strictly greater than the original to apply
-  // the update. We don't track per-event sequence, so for REQUEST
+  // the update. We don't track per-event sequence, so for PUBLISH
   // we use 0 and for CANCEL we use 1 — fine in practice because
-  // we don't re-issue REQUEST after a CANCEL.
+  // we don't re-issue PUBLISH after a CANCEL.
   sequence?: number;
 }): string {
   const escape = (s: string) =>
@@ -213,7 +218,7 @@ export async function notifyAssignment(
           date: icsDate,
           startTime: icsStart,
           endTime: icsEnd,
-          method: "REQUEST",
+          method: "PUBLISH",
         })
       : null;
 


### PR DESCRIPTION
Two .ics tightenings per Mew 2026-05-31:

1. **METHOD:PUBLISH instead of REQUEST** — REQUEST implies organizer + attendees with RSVP exchange; we have neither, and our From domain is send-only so a RSVP would have nowhere to go. PUBLISH is the right fit and calendar clients render it with a simple Add affordance.
2. **Inline via `icalEvent`** — nodemailer puts the calendar payload inside multipart/alternative as text/calendar. Outlook renders this as a native event banner with Add-to-calendar buttons rather than as a passive file attachment.

CANCEL semantics unchanged — calendar clients still match it to the prior PUBLISH by UID and drop the event.

`extractIcsMethod` parses the METHOD line out of the .ics so the Content-Type matches what's inside the file.