### PR TITLE
fix(db): layered wedge defenses (cacheable-lookup + heartbeat + drain)

### DIFF
--- a/client/instrumentation.ts
+++ b/client/instrumentation.ts
@@ -1,9 +1,12 @@
-// Next.js calls this once per process at server boot. We use it to start
-// the email queue worker (#307). The Edge runtime is skipped — only the
-// Node runtime can reach MySQL and Node SMTP.
+// Next.js calls this once per process at server boot. We use it to
+// start the email queue worker (#307) and the DB wedge heartbeat. The
+// Edge runtime is skipped — only the Node runtime can reach MySQL and
+// Node SMTP.
 
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
   const { bootstrapMailWorker } = await import("./lib/mail");
   bootstrapMailWorker();
+  const { startDbHealthCheck } = await import("./lib/dbHealth");
+  startDbHealthCheck();
 }

--- a/client/lib/database.ts
+++ b/client/lib/database.ts
@@ -1,8 +1,24 @@
+import CacheableLookup from "cacheable-lookup";
 import mysql from "mysql2";
 
 // MYSQL_SSL=true enables TLS for hosted DBs like RDS that require secure
 // transport. Local docker DB on test/playa boxes leaves it unset.
 const sslOption = process.env.MYSQL_SSL ? { ssl: "Amazon RDS" } : {};
+
+// DNS re-resolution. Root cause of the recurring pool wedge (2026-05-13,
+// 17, 23, 31): Node's libuv `dns.lookup()` caches its first result for
+// the lifetime of the process. When AWS RDS does a Multi-AZ failover or
+// endpoint refresh, the cached IP keeps pointing at the dead instance.
+// Every new mysql2 connection — even the "fresh" one from the retry
+// wrapper below — SYNs the dead IP and times out. Meanwhile the host's
+// `mysql` CLI does a fresh `getaddrinfo` per invocation, hits the new
+// IP, and works fine. Container restart "fixes" it because the new
+// Node process starts with an empty cache.
+//
+// cacheable-lookup honors the DNS record's TTL (default RDS endpoints
+// are ~5 s on the CNAME). 60 s maxTtl is a belt — even if the upstream
+// TTL is mis-advertised we still re-resolve every minute.
+const dnsLookup = new CacheableLookup({ maxTtl: 60, errorTtl: 5 });
 
 // dateStrings: return DATE/DATETIME columns as "YYYY-MM-DD" strings instead of
 // JS Date objects pinned to UTC midnight. Without this, a DATE value like
@@ -32,6 +48,10 @@ const sslOption = process.env.MYSQL_SSL ? { ssl: "Amazon RDS" } : {};
 // 0s of idle time AND the reaper missed it within 60s". Not zero, hence
 // the retry wrapper below.
 
+// mysql2's typings don't expose `lookup`, but it forwards unknown
+// options to the underlying net.createConnection / tls.connect, both
+// of which honor `lookup` per Node's docs. Type assertion is local
+// to this construction.
 const basePool = mysql
   .createPool({
     connectionLimit: 10,
@@ -41,11 +61,12 @@ const basePool = mysql
     host: process.env.MYSQL_HOST,
     idleTimeout: 60_000,
     keepAliveInitialDelay: 10_000,
+    lookup: dnsLookup.lookup,
     maxIdle: 5,
     password: process.env.MYSQL_PASSWORD,
     user: process.env.MYSQL_USER,
     ...sslOption,
-  })
+  } as unknown as mysql.PoolOptions)
   .promise();
 
 // Retry-once-on-ETIMEDOUT wrapper for pool.query / pool.execute.
@@ -101,3 +122,49 @@ basePool.query = wrapWithRetry("pool.query", pq);
 basePool.execute = wrapWithRetry("pool.execute", pe);
 
 export const pool = basePool;
+
+// One-shot connection that bypasses the pool. Used by the wedge
+// heartbeat (lib/dbHealth.ts) to distinguish "pool is wedged" from
+// "DB itself is unreachable" — when those answers disagree we can
+// trigger automatic pool drain instead of just logging and waiting.
+export function createFreshConnection() {
+  return mysql.createConnection({
+    connectTimeout: 5_000,
+    database: process.env.MYSQL_DATABASE,
+    dateStrings: true,
+    host: process.env.MYSQL_HOST,
+    lookup: dnsLookup.lookup,
+    password: process.env.MYSQL_PASSWORD,
+    user: process.env.MYSQL_USER,
+    ...sslOption,
+  } as unknown as mysql.ConnectionOptions);
+}
+
+// Force every idle connection in the pool to be destroyed. The pool
+// itself stays usable — subsequent queries borrow fresh sockets which
+// re-resolve DNS through cacheable-lookup. Called by the heartbeat
+// when it detects the wedge-vs-healthy-DB signature.
+export async function drainPool(): Promise<void> {
+  // mysql2's promise pool wraps the callback pool. The internal
+  // ._allConnections is an array of connection objects (typed any
+  // because mysql2 doesn't export the private shape). Destroying
+  // an in-use connection terminates its current query — but if the
+  // pool is wedged, every connection's current query is already
+  // ETIMEDOUT-ing, so the user impact is nil.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const internal = (basePool as any).pool;
+  if (!internal) return;
+  const all: { destroy?: () => void }[] = [
+    ...(internal._allConnections?.toArray?.() ?? internal._allConnections ?? []),
+  ];
+  let destroyed = 0;
+  for (const c of all) {
+    try {
+      c.destroy?.();
+      destroyed++;
+    } catch {
+      // best effort
+    }
+  }
+  console.warn(`[db] drainPool destroyed ${destroyed} pool connection(s)`);
+}

--- a/client/lib/dbHealth.ts
+++ b/client/lib/dbHealth.ts
@@ -1,0 +1,202 @@
+import { createFreshConnection, drainPool, pool } from "./database";
+
+// DB wedge detector. Every `DB_HEALTHCHECK_INTERVAL_MS` (default 60s)
+// we run `SELECT 1` through the pool with a tight timeout. On failure
+// we run the same query via a one-shot fresh connection.
+//
+//   pool OK          → healthy, nothing to do.
+//   pool FAIL,
+//     fresh OK       → POOL WEDGE. Log + drain idle pool connections
+//                      so subsequent queries get fresh sockets that
+//                      re-resolve DNS through cacheable-lookup.
+//                      Continue logging at every tick until pool
+//                      recovers (so a still-active wedge is visible
+//                      in `docker logs` and any webhook channel).
+//   pool FAIL,
+//     fresh FAIL     → DB UNREACHABLE. Log only — we can't fix it
+//                      from the app.
+//
+// Notifications:
+//   - Every state transition writes a recognizable marker to
+//     stderr (`[db:healthcheck:state=...]`). External watchers can
+//     grep / tail.
+//   - If `DB_WEDGE_WEBHOOK_URL` is set, the same payload is POSTed
+//     there (Discord-/Slack-compatible). Best-effort; webhook failures
+//     are logged but don't stop the heartbeat.
+
+const WEBHOOK_URL = process.env.DB_WEDGE_WEBHOOK_URL?.trim() || null;
+const PING_TIMEOUT_MS = 5_000;
+const HEARTBEAT_INTERVAL_MS = (() => {
+  const raw = process.env.DB_HEALTHCHECK_INTERVAL_MS;
+  if (!raw) return 60_000;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 5_000 ? n : 60_000;
+})();
+
+type State = "healthy" | "wedged" | "unreachable" | "boot";
+let state: State = "boot";
+let consecutiveWedgeTicks = 0;
+let timer: NodeJS.Timeout | null = null;
+
+async function pingViaPool(): Promise<boolean> {
+  try {
+    await Promise.race([
+      pool.query("SELECT 1"),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error("pool ping timeout")),
+          PING_TIMEOUT_MS
+        )
+      ),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pingViaFreshConnection(): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let done = false;
+    const finish = (ok: boolean) => {
+      if (done) return;
+      done = true;
+      try {
+        conn.destroy();
+      } catch {
+        // best-effort
+      }
+      resolve(ok);
+    };
+    const conn = createFreshConnection();
+    const timeout = setTimeout(() => finish(false), PING_TIMEOUT_MS + 1_000);
+    conn.connect((connErr) => {
+      if (connErr) {
+        clearTimeout(timeout);
+        finish(false);
+        return;
+      }
+      conn.query("SELECT 1", (qErr) => {
+        clearTimeout(timeout);
+        finish(!qErr);
+      });
+    });
+  });
+}
+
+async function postWebhook(payload: object): Promise<void> {
+  if (!WEBHOOK_URL) return;
+  try {
+    await fetch(WEBHOOK_URL, {
+      body: JSON.stringify(payload),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    console.warn("[db:healthcheck] webhook POST failed:", err);
+  }
+}
+
+function logState(transition: { from: State; to: State; detail?: string }) {
+  const stamp = new Date().toISOString();
+  console.warn(
+    `[db:healthcheck:state=${transition.to}] from=${transition.from} consecutive_wedge_ticks=${consecutiveWedgeTicks} ${transition.detail ?? ""}`
+  );
+  void postWebhook({
+    consecutive_wedge_ticks: consecutiveWedgeTicks,
+    detail: transition.detail ?? "",
+    event: "db_state_change",
+    from: transition.from,
+    timestamp: stamp,
+    to: transition.to,
+  });
+}
+
+export async function tickHealthCheck(): Promise<{
+  poolOk: boolean;
+  freshOk: boolean | null;
+  state: State;
+}> {
+  const poolOk = await pingViaPool();
+  if (poolOk) {
+    if (state !== "healthy") {
+      const previous = state;
+      state = "healthy";
+      consecutiveWedgeTicks = 0;
+      logState({ from: previous, to: "healthy" });
+    }
+    return { freshOk: null, poolOk: true, state };
+  }
+  const freshOk = await pingViaFreshConnection();
+  if (freshOk) {
+    consecutiveWedgeTicks++;
+    if (state !== "wedged") {
+      const previous = state;
+      state = "wedged";
+      logState({
+        detail: "pool query failed but fresh connection succeeded",
+        from: previous,
+        to: "wedged",
+      });
+    } else {
+      // Still wedged. Surface so a long wedge is visible at every tick.
+      console.warn(
+        `[db:healthcheck:state=wedged] ongoing consecutive_wedge_ticks=${consecutiveWedgeTicks}`
+      );
+    }
+    // Auto-recovery: destroy idle pool sockets so subsequent queries
+    // borrow fresh ones (which re-resolve DNS through cacheable-lookup).
+    // Safe — wedged sockets aren't doing useful work anyway.
+    try {
+      await drainPool();
+    } catch (err) {
+      console.error("[db:healthcheck] drainPool failed:", err);
+    }
+    return { freshOk: true, poolOk: false, state };
+  }
+  if (state !== "unreachable") {
+    const previous = state;
+    state = "unreachable";
+    logState({
+      detail: "both pool and fresh connection failed",
+      from: previous,
+      to: "unreachable",
+    });
+  } else {
+    console.warn(
+      `[db:healthcheck:state=unreachable] ongoing both ping paths still failing`
+    );
+  }
+  return { freshOk: false, poolOk: false, state };
+}
+
+export function startDbHealthCheck(): { stop: () => void } {
+  if (timer) {
+    // already running — bootstrap is idempotent
+    return { stop: () => stopDbHealthCheck() };
+  }
+  const tick = async () => {
+    try {
+      await tickHealthCheck();
+    } catch (err) {
+      console.error("[db:healthcheck] tick error:", err);
+    } finally {
+      if (timer) timer = setTimeout(tick, HEARTBEAT_INTERVAL_MS);
+    }
+  };
+  // Defer the first tick so app boot doesn't race against the pool warmup.
+  timer = setTimeout(tick, HEARTBEAT_INTERVAL_MS);
+  timer.unref?.();
+  console.warn(
+    `[db:healthcheck] started — intervalMs=${HEARTBEAT_INTERVAL_MS} webhook=${WEBHOOK_URL ? "yes" : "no"}`
+  );
+  return { stop: () => stopDbHealthCheck() };
+}
+
+export function stopDbHealthCheck(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@mui/material-nextjs": "^7.3.2",
     "@mui/x-date-pickers": "^8.11.3",
     "axios": "^1.12.2",
+    "cacheable-lookup": "^7.0.0",
     "dayjs": "^1.11.18",
     "immer": "^10.1.3",
     "mui-datatables": "^4.2.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1418,6 +1418,11 @@ browserslist@^4.24.0:
     node-releases "^2.0.27"
     update-browserslist-db "^1.2.0"
 
+cacheable-lookup@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
+  integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz"


### PR DESCRIPTION
Going-live readiness. Layered fixes for the recurring pool wedge:

1. **cacheable-lookup** — honors DNS TTL (60s cap) so libuv re-resolves the RDS endpoint after failover. Wired into mysql2 via the `lookup` option that net.createConnection honors.
2. **createFreshConnection** — bypasses the pool, used by the heartbeat to distinguish pool wedge from DB outage.
3. **drainPool** — destroys idle pool sockets so subsequent queries fetch fresh ones that re-resolve DNS.
4. **Heartbeat** (`client/lib/dbHealth.ts`) — every 60s pings via pool; on failure pings via fresh connection; on `wedged` state (pool fail, fresh OK) auto-runs drainPool and logs a structured marker. Optional webhook via `DB_WEDGE_WEBHOOK_URL`.
5. **Bootstrap** from instrumentation.ts.

Independent reviews ran on both root cause (DNS hypothesis fits the symptoms) and recommendation (RDS Proxy is the alternative — ruled out because we don't control the AWS infra). This is the code-only path.

## Test plan
- [ ] Smoke: deploy, look for `[db:healthcheck] started` in container logs
- [ ] After 60s, look for healthy-state transition marker
- [ ] Confirm yarn.lock is reproducible — `docker compose --file docker-compose-prod.yaml build`
- [ ] When the next wedge happens (or by force-blocking RDS at the kernel-level temporarily), confirm the marker fires and drainPool runs