### PR TITLE
fix(db): wire cacheable-lookup via global dns.lookup override

### DIFF
--- a/client/lib/database.ts
+++ b/client/lib/database.ts
@@ -1,3 +1,7 @@
+import dns from "node:dns";
+import http from "node:http";
+import https from "node:https";
+
 import CacheableLookup from "cacheable-lookup";
 import mysql from "mysql2";
 
@@ -18,7 +22,19 @@ const sslOption = process.env.MYSQL_SSL ? { ssl: "Amazon RDS" } : {};
 // cacheable-lookup honors the DNS record's TTL (default RDS endpoints
 // are ~5 s on the CNAME). 60 s maxTtl is a belt — even if the upstream
 // TTL is mis-advertised we still re-resolve every minute.
+//
+// mysql2 v3.x dropped support for the per-connection `lookup` option
+// (it logs "Ignoring invalid configuration option"), so we replace the
+// global `dns.lookup` symbol that net.createConnection falls back to
+// when no per-connection lookup is provided. This is process-wide and
+// affects every outbound resolver, which is the desired behavior —
+// same DNS caching for Okta callbacks, SMTP relay, and the mysql pool.
+// http(s) globalAgent gets the official install() path too.
 const dnsLookup = new CacheableLookup({ maxTtl: 60, errorTtl: 5 });
+dnsLookup.install(http.globalAgent);
+dnsLookup.install(https.globalAgent);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(dns as any).lookup = dnsLookup.lookup.bind(dnsLookup);
 
 // dateStrings: return DATE/DATETIME columns as "YYYY-MM-DD" strings instead of
 // JS Date objects pinned to UTC midnight. Without this, a DATE value like
@@ -48,10 +64,9 @@ const dnsLookup = new CacheableLookup({ maxTtl: 60, errorTtl: 5 });
 // 0s of idle time AND the reaper missed it within 60s". Not zero, hence
 // the retry wrapper below.
 
-// mysql2's typings don't expose `lookup`, but it forwards unknown
-// options to the underlying net.createConnection / tls.connect, both
-// of which honor `lookup` per Node's docs. Type assertion is local
-// to this construction.
+// DNS caching reaches mysql2 via the global `dns.lookup` override
+// above — mysql2 v3.x rejects the per-connection `lookup` option
+// outright. The pool config below is back to plain mysql2.PoolOptions.
 const basePool = mysql
   .createPool({
     connectionLimit: 10,
@@ -61,12 +76,11 @@ const basePool = mysql
     host: process.env.MYSQL_HOST,
     idleTimeout: 60_000,
     keepAliveInitialDelay: 10_000,
-    lookup: dnsLookup.lookup,
     maxIdle: 5,
     password: process.env.MYSQL_PASSWORD,
     user: process.env.MYSQL_USER,
     ...sslOption,
-  } as unknown as mysql.PoolOptions)
+  })
   .promise();
 
 // Retry-once-on-ETIMEDOUT wrapper for pool.query / pool.execute.
@@ -133,11 +147,10 @@ export function createFreshConnection() {
     database: process.env.MYSQL_DATABASE,
     dateStrings: true,
     host: process.env.MYSQL_HOST,
-    lookup: dnsLookup.lookup,
     password: process.env.MYSQL_PASSWORD,
     user: process.env.MYSQL_USER,
     ...sslOption,
-  } as unknown as mysql.ConnectionOptions);
+  });
 }
 
 // Force every idle connection in the pool to be destroyed. The pool


### PR DESCRIPTION
Follow-up to #376 caught at first deploy:

PR #376 wired `cacheable-lookup` into the mysql2 pool via the per-connection `lookup` option, but mysql2 v3.x explicitly rejects unknown options — the container booted with `Ignoring invalid configuration option passed to Connection: lookup` in the logs. The DNS caching layer never actually engaged.

Switching strategy: replace the global `dns.lookup` symbol that `net.createConnection` falls back to. This is process-wide and applies to mysql2, nodemailer's SMTP relay socket, Okta callback fetch, anything else that resolves a name. Same intent, different mechanism. The heartbeat + drain from #376 stays as the detect-and-react belt.

## Test plan
- [ ] Deploy; verify no "Ignoring invalid configuration option" warning in container logs
- [ ] Healthcheck still transitions from `boot` to `healthy`
- [ ] Spot-check that DB queries work (already do; this isn't a behavior change for healthy state)
