### PR TITLE
feat(shifts): cancel-shift checkbox in Update Time dialog + bulk cancel emails

### DIFF
--- a/client/src/app/shifts/types/type/ShiftTypesForm.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesForm.tsx
@@ -128,6 +128,7 @@ export const processInformation = (
 export const processTimeList = (formValues: IFormValues) => {
   return formValues.timeList.map(
     ({
+      canceled,
       date,
       endTime,
       instance,
@@ -138,6 +139,7 @@ export const processTimeList = (formValues: IFormValues) => {
       timeId,
     }) => {
       return {
+        canceled: Boolean(canceled),
         endTime: `${dayjs(date).format("YYYY-MM-DD")} ${dayjs(endTime).format("HH:mm")}`,
         instance,
         meal,
@@ -174,6 +176,7 @@ export const defaultValues: IFormValues = {
   },
   positionList: [],
   timeAdd: {
+    canceled: false,
     date: "",
     endTime: "",
     instance: "",
@@ -226,6 +229,7 @@ export const ShiftTypesForm = ({
       startTimeOffset: "",
     },
     timeItem: {
+      canceled: false,
       date: "",
       endTime: "",
       instance: "",
@@ -317,6 +321,7 @@ export const ShiftTypesForm = ({
     const endTimeNew = dayjs(endTime).format("HH:mm");
     const startTimeNew = dayjs(startTime).format("HH:mm");
     const timeNew = {
+      canceled: false,
       date: dateNew,
       endTime: `${dateNew} ${endTimeNew}`,
       id: "",

--- a/client/src/app/shifts/types/type/ShiftTypesTimeDialogAdd.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesTimeDialogAdd.tsx
@@ -135,6 +135,7 @@ export const ShiftTypesTimeDialogAdd = ({
               );
 
               handleTimeAdd({
+                canceled: false,
                 date: getValues("timeAdd.date"),
                 endTime: getValues("timeAdd.endTime"),
                 instance: getValues("timeAdd.instance"),

--- a/client/src/app/shifts/types/type/ShiftTypesTimeDialogForm.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesTimeDialogForm.tsx
@@ -1,5 +1,7 @@
 import {
+  Checkbox,
   FormControl,
+  FormControlLabel,
   Grid,
   InputLabel,
   MenuItem,
@@ -34,6 +36,10 @@ interface IShiftTypesTimeDialogFormProps {
   errors: FieldErrors<IFormValues>;
   getValues: UseFormGetValues<IFormValues>;
   setError: UseFormSetError<IFormValues>;
+  // When true (Update dialog only), the "Cancel this shift" checkbox
+  // renders at the bottom of the form. The Add dialog leaves it off
+  // — a brand-new time should never start in the canceled state.
+  showCanceledCheckbox?: boolean;
   timePositionListAddFields: FieldArrayWithId<
     IFormValues,
     "timeAdd.positionList",
@@ -47,6 +53,7 @@ export const ShiftTypesTimeDialogForm = ({
   errors,
   getValues,
   setError,
+  showCanceledCheckbox = false,
   timePositionListAddFields,
 }: IShiftTypesTimeDialogFormProps) => {
   // render
@@ -274,6 +281,22 @@ export const ShiftTypesTimeDialogForm = ({
           )}
         />
       </Grid>
+      {showCanceledCheckbox && (
+        <Grid size={12}>
+          <Controller
+            control={control}
+            name="timeAdd.canceled"
+            render={({ field: { value, ...field } }) => (
+              <FormControlLabel
+                control={
+                  <Checkbox {...field} checked={Boolean(value)} color="secondary" />
+                }
+                label="Cancel this shift (notifies all assigned volunteers)"
+              />
+            )}
+          />
+        </Grid>
+      )}
       {timePositionListAddFields && (
         <Grid size={12}>
           <Typography component="h3" variant="h6">

--- a/client/src/app/shifts/types/type/ShiftTypesTimeDialogUpdate.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesTimeDialogUpdate.tsx
@@ -71,6 +71,7 @@ export const ShiftTypesTimeDialogUpdate = ({
         errors={errors}
         getValues={getValues}
         setError={setError}
+        showCanceledCheckbox
         timePositionListAddFields={timePositionListAddFields}
       />
       <DialogActions>

--- a/client/src/app/shifts/types/type/index.ts
+++ b/client/src/app/shifts/types/type/index.ts
@@ -13,6 +13,7 @@ export interface IPositionAddValues {
   startTimeOffset: string;
 }
 export interface ITimeAddValues {
+  canceled: boolean;
   date: string;
   endTime: string;
   instance: string;

--- a/client/src/components/types/shifts/types/index.ts
+++ b/client/src/components/types/shifts/types/index.ts
@@ -50,6 +50,7 @@ export interface IResShiftTypePositionItem {
   wapPoints?: string;
 }
 export interface IResShiftTypeTimeItem {
+  canceled: boolean;
   date: string;
   endTime: string;
   instance: string;
@@ -88,6 +89,7 @@ export interface IReqShiftTypeTimePositionItem {
   timePositionId: number;
 }
 export interface IReqShiftTypeTimeItem {
+  canceled: boolean;
   endTime: string;
   instance: string;
   meal: string;

--- a/client/src/pages/api/shifts/types/[typeId]/index.ts
+++ b/client/src/pages/api/shifts/types/[typeId]/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@/components/types/shifts/types";
 import { generateId } from "@/utils/generateId";
 import { pool } from "lib/database";
+import { notifyRemoval } from "@/components/api/assignmentNotify";
 import { handleTimeListAdd } from "@/pages/api/shifts/types";
 
 const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -111,6 +112,7 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
           d.date,
           pt.position,
           pt.position_type_id,
+          st.canceled,
           st.end_time_text,
           st.meal,
           st.notes,
@@ -143,6 +145,7 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
 
       dbTimeList.forEach(
         ({
+          canceled,
           date,
           end_time_text,
           meal,
@@ -173,6 +176,7 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
           } else {
             resTimeMap[shift_times_id] = true;
             resTimeList.push({
+              canceled: Boolean(canceled),
               date: date,
               endTime: end_time_text,
               instance: shift_instance,
@@ -256,36 +260,99 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
         return !timeList.some(({ timeId }) => timeId === shift_times_id);
       });
 
-      timeListUpdate.forEach(
-        async ({ endTime, timeId, instance, meal, notes, startTime }) => {
-          // Refresh start_date_id / end_date_id alongside the start_time /
-          // end_time change — a date edit must update the FK or downstream
-          // joins keep pointing at the old date row. See [[fix-handleTimeListAdd]].
-          await pool.query<RowDataPacket[]>(
-            `UPDATE op_shift_times
-            SET
-              end_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
-              end_time=?,
-              meal=?,
-              notes=?,
-              update_shift_time=true,
-              shift_instance=?,
-              start_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
-              start_time=?
-            WHERE shift_times_id=?`,
-            [
-              endTime,
-              endTime,
-              meal === "None" ? "" : meal,
-              notes,
-              instance,
-              startTime,
-              startTime,
-              timeId,
-            ]
+      // Capture the prior `canceled` state for every row we're about to
+      // touch so we can detect the 0→1 transition and notify the
+      // assigned volunteers exactly once per cancellation. Done before
+      // the UPDATEs fire.
+      const wasCanceledMap = new Map<number, boolean>();
+      if (timeListUpdate.length > 0) {
+        const [priorStates] = await pool.query<RowDataPacket[]>(
+          `SELECT shift_times_id, canceled FROM op_shift_times
+           WHERE shift_times_id IN (?)`,
+          [timeListUpdate.map(({ timeId }) => timeId)]
+        );
+        for (const row of priorStates) {
+          wasCanceledMap.set(row.shift_times_id, Boolean(row.canceled));
+        }
+      }
+
+      // Await the UPDATEs so transition detection / notify happens
+      // after the writes land (the previous forEach(async) pattern
+      // raced the route's response).
+      await Promise.all(
+        timeListUpdate.map(
+          async ({ canceled, endTime, timeId, instance, meal, notes, startTime }) => {
+            // Refresh start_date_id / end_date_id alongside the start_time /
+            // end_time change — a date edit must update the FK or downstream
+            // joins keep pointing at the old date row. See [[fix-handleTimeListAdd]].
+            await pool.query<RowDataPacket[]>(
+              `UPDATE op_shift_times
+              SET
+                canceled=?,
+                end_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
+                end_time=?,
+                meal=?,
+                notes=?,
+                update_shift_time=true,
+                shift_instance=?,
+                start_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
+                start_time=?
+              WHERE shift_times_id=?`,
+              [
+                Boolean(canceled),
+                endTime,
+                endTime,
+                meal === "None" ? "" : meal,
+                notes,
+                instance,
+                startTime,
+                startTime,
+                timeId,
+              ]
+            );
+          }
+        )
+      );
+
+      // For each shift_times_id that just flipped 0→1, fetch every
+      // currently-assigned volunteer position and enqueue a
+      // shift-canceled email per (volunteer, time_position). Best-effort:
+      // an enqueue failure is logged and the route still 201s.
+      for (const t of timeListUpdate) {
+        if (!t.canceled) continue;
+        if (wasCanceledMap.get(t.timeId)) continue;
+        try {
+          const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT DISTINCT vs.shiftboard_id, vs.time_position_id
+             FROM op_volunteer_shifts vs
+             JOIN op_shift_time_position stp
+               ON stp.time_position_id = vs.time_position_id
+             WHERE stp.shift_times_id = ?
+               AND vs.remove_shift = false`,
+            [t.timeId]
+          );
+          for (const v of rows) {
+            try {
+              await notifyRemoval(
+                pool,
+                v.shiftboard_id,
+                v.time_position_id,
+                { kind: "shift-canceled" }
+              );
+            } catch (err) {
+              console.error(
+                `[shift-canceled-notify] enqueue failed for shiftboard_id=${v.shiftboard_id} time_position_id=${v.time_position_id}:`,
+                err
+              );
+            }
+          }
+        } catch (err) {
+          console.error(
+            `[shift-canceled-notify] fan-out failed for shift_times_id=${t.timeId}:`,
+            err
           );
         }
-      );
+      }
       timeListAdd.forEach(
         async ({ endTime, instance, meal, notes, startTime }) => {
           const [dbTime] = await pool.query<RowDataPacket[]>(


### PR DESCRIPTION
Per Mew. Adds a 'Cancel this shift' checkbox to the **Update Time** dialog. Flipping it true and saving:

1. Persists `op_shift_times.canceled = 1` for that time row.
2. Looks up every currently-assigned volunteer on that shift_times_id and enqueues a CANCEL `.ics` email per (volunteer, time_position) with the `shift-canceled` RemovalCause from #373 — uses the canceled-specific subject + opener ("The following Census shift has been canceled:") rather than the self/admin removal copy.

## Test plan
- [ ] Open Update Time dialog on an existing shift; checkbox renders (Add Time does NOT show it)
- [ ] Checking it + Save → DB row's canceled = 1
- [ ] With MAIL_OVERRIDE_TO active: assign 2+ volunteers to a shift, then check + save Cancel → 2 emails enqueued to mu (one per volunteer), each with shift-canceled opener
- [ ] Saving the dialog again without changes does NOT re-send (0→1 transition only)
- [ ] Unchecking + saving sets canceled = 0; no email goes out (1→0 case is out of scope)