### PR TITLE
feat(shifts): display canceled shifts struck-through + block adds (allow self-remove)

### DIFF
--- a/client/src/app/shifts/Shifts.tsx
+++ b/client/src/app/shifts/Shifts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Chip, Container, lighten } from "@mui/material";
+import { Box, Chip, Container, lighten, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import dayjs from "dayjs";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
@@ -274,6 +274,7 @@ export const Shifts = () => {
   const colorMapDisplay = getColorMap(data);
   const dataTable = data.map(
     ({
+      canceled,
       cspMax,
       cspMin,
       date,
@@ -288,6 +289,32 @@ export const Shifts = () => {
     }) => {
       const cspDisplay =
         cspMin === cspMax ? `${cspMin}` : `${cspMin}-${cspMax}`;
+      const typeCell = canceled ? (
+        <Box
+          key={`${id}-type`}
+          sx={{ alignItems: "center", display: "flex", gap: 1 }}
+        >
+          <Chip
+            label={type}
+            sx={{
+              backgroundColor: colorMapDisplay[departmentName],
+              textDecoration: "line-through",
+            }}
+          />
+          <Typography
+            component="span"
+            sx={{ color: "error.main", fontWeight: 700 }}
+          >
+            CANCELED
+          </Typography>
+        </Box>
+      ) : (
+        <Chip
+          key={`${id}-chip`}
+          label={type}
+          sx={{ backgroundColor: colorMapDisplay[departmentName] }}
+        />
+      );
       return [
         id, // hide for row click
         date, // hide for filter dialog (Present/Future vs Past)
@@ -295,11 +322,7 @@ export const Shifts = () => {
         formatTime(startTime, endTime),
         cspDisplay,
         type, // hide for filter dialog
-        <Chip
-          key={`${id}-chip`}
-          label={type}
-          sx={{ backgroundColor: colorMapDisplay[departmentName] }}
-        />,
+        typeCell,
         `${slotsFilled} / ${slotsTotal}`,
       ];
     }

--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -10,6 +10,7 @@ import {
   WorkHistory as WorkHistoryIcon,
 } from "@mui/icons-material";
 import {
+  Alert,
   Box,
   Button,
   Card,
@@ -337,6 +338,7 @@ export const ShiftVolunteers = ({
     endTime: dayjs(dataShiftVolunteersItem.shift.endTime),
     startTime: dayjs(dataShiftVolunteersItem.shift.startTime),
   });
+  const isShiftCanceled = Boolean(dataShiftVolunteersItem.shift.canceled);
   let isVolunteerAddAvailable = false;
   let isCheckInAvailable = false;
 
@@ -364,6 +366,16 @@ export const ShiftVolunteers = ({
     default: {
       throw new Error(`Unknown check-in type: ${checkInType}`);
     }
+  }
+  // Canceled shifts: no one (including admins) can add volunteers
+  // via this page — they have to flip the canceled flag back off
+  // in the Update Time dialog first. Self-removes (the DataTable's
+  // row-level remove buttons) are intentionally still available so
+  // already-assigned volunteers can drop themselves, which fires
+  // the cancellation .ics if they hadn't already gotten one.
+  if (isShiftCanceled) {
+    isVolunteerAddAvailable = false;
+    isCheckInAvailable = false;
   }
 
   // prepare datatable positions
@@ -604,8 +616,28 @@ export const ShiftVolunteers = ({
           </BreadcrumbsNav>
         </Box>
         <Box component="section">
+          {isShiftCanceled && (
+            <Alert
+              severity="error"
+              sx={{ mb: 2, "& .MuiAlert-message": { fontWeight: 700 } }}
+            >
+              CANCELED — this shift has been canceled. New assignments are
+              disabled. Volunteers already on the shift can still remove
+              themselves.
+            </Alert>
+          )}
           <Box>
-            <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
+            <Typography
+              component="h2"
+              variant="h4"
+              sx={{
+                mb: 2,
+                ...(isShiftCanceled && {
+                  color: "text.disabled",
+                  textDecoration: "line-through",
+                }),
+              }}
+            >
               {formatDateName(
                 dataShiftVolunteersItem.shift.date,
                 dataShiftVolunteersItem.shift.dateName

--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
@@ -6,6 +6,7 @@ import {
   MoreHoriz as MoreHorizIcon,
 } from "@mui/icons-material";
 import {
+  Box,
   Button,
   Chip,
   IconButton,
@@ -363,6 +364,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     ({
       department: { name: departmentName },
       shift: {
+        canceled,
         date,
         dateName,
         endTime,
@@ -448,15 +450,38 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
         />
       );
 
-      return [
-        formatDateName(date, dateName),
-        formatTime(startTime, endTime),
-        positionName,
+      const positionCell = canceled ? (
+        <Box
+          key={`${timePositionId}-position`}
+          sx={{ alignItems: "center", display: "flex", gap: 1 }}
+        >
+          <Chip
+            label={positionName}
+            sx={{
+              backgroundColor: colorMapDisplay[departmentName],
+              textDecoration: "line-through",
+            }}
+          />
+          <Typography
+            component="span"
+            sx={{ color: "error.main", fontWeight: 700 }}
+          >
+            CANCELED
+          </Typography>
+        </Box>
+      ) : (
         <Chip
           key={`${timePositionId}-chip`}
           label={positionName}
           sx={{ backgroundColor: colorMapDisplay[departmentName] }}
-        />,
+        />
+      );
+
+      return [
+        formatDateName(date, dateName),
+        formatTime(startTime, endTime),
+        positionName,
+        positionCell,
         <Switch
           checked={noShow === ""}
           disabled={!isCheckInAvailable}

--- a/client/src/components/types/shifts/index.ts
+++ b/client/src/components/types/shifts/index.ts
@@ -1,6 +1,7 @@
 // shifts
 // ------------------------------------------------------------
 export interface IResShiftRowItem {
+  canceled: boolean;
   category: {
     id: number;
   };
@@ -55,6 +56,7 @@ export interface IResShiftVolunteerRowItem {
 export interface IResShiftVolunteerInformation {
   positionList: IResShiftPositionCountItem[];
   shift: {
+    canceled: boolean;
     date: string;
     dateName: string;
     details: string;

--- a/client/src/components/types/volunteers/index.ts
+++ b/client/src/components/types/volunteers/index.ts
@@ -54,6 +54,7 @@ export interface IResVolunteerShiftItem {
     name: string;
   };
   shift: {
+    canceled: boolean;
     date: string;
     dateName: string;
     endTime: string;

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -26,6 +26,10 @@ const shiftVolunteers = async (
     case "GET": {
       // get all shift volunteers
       const { timeId } = req.query;
+      // Include canceled shifts in the detail response — the page
+      // shows them with a banner and disables Add, but volunteers
+      // still need to reach the page so they can self-remove and
+      // admins can flip the canceled state back via Update Time.
       const [dbShiftPositionList] = await pool.query<RowDataPacket[]>(
         `SELECT
           d.date,
@@ -36,6 +40,7 @@ const shiftVolunteers = async (
           pt.role_id,
           sn.shift_details,
           sn.shift_name,
+          st.canceled,
           st.end_time,
           st.end_time_text,
           st.meal,
@@ -59,7 +64,6 @@ const shiftVolunteers = async (
         ON pt.delete_position=false
         AND pt.position_type_id=stp.position_type_id
         WHERE st.remove_shift_time=false
-        AND st.canceled=false
         AND st.shift_times_id=?
         ORDER BY pt.position COLLATE utf8mb4_general_ci`,
         [timeId]
@@ -156,6 +160,7 @@ const shiftVolunteers = async (
       const resShiftVolunteerDetails: IResShiftVolunteerInformation = {
         positionList: resShiftPositionList,
         shift: {
+          canceled: Boolean(resShiftPositionFirst.canceled),
           date: resShiftPositionFirst.date,
           dateName: resShiftPositionFirst.datename ?? "",
           details: resShiftPositionFirst.shift_details,
@@ -177,6 +182,27 @@ const shiftVolunteers = async (
       // add volunteer to shift
       const { noShow, shiftboardId, timePositionId }: IReqShiftVolunteerItem =
         JSON.parse(req.body);
+
+      // Block adds on canceled shifts. Server-side enforcement —
+      // the UI hides the Add button but a stale tab / forged request
+      // would still reach this handler. Self-removes (DELETE) are
+      // intentionally NOT blocked: an already-assigned volunteer
+      // can still drop themselves and trigger the cancellation .ics.
+      const [dbShiftCanceledCheck] = await pool.query<RowDataPacket[]>(
+        `SELECT st.canceled
+         FROM op_shift_time_position stp
+         JOIN op_shift_times st ON st.shift_times_id = stp.shift_times_id
+         WHERE stp.time_position_id = ?
+         LIMIT 1`,
+        [timePositionId]
+      );
+      if (dbShiftCanceledCheck[0]?.canceled) {
+        return res.status(409).json({
+          statusCode: 409,
+          message: "Shift is canceled; cannot add volunteers.",
+        });
+      }
+
       const [dbShiftVolunteerList] = await pool.query<RowDataPacket[]>(
         `SELECT *
         FROM op_volunteer_shifts

--- a/client/src/pages/api/shifts/index.ts
+++ b/client/src/pages/api/shifts/index.ts
@@ -54,7 +54,9 @@ const shifts = async (req: NextApiRequest, res: NextApiResponse) => {
           ORDER BY d.date, st.start_time_text`
         );
       } else {
-        // get all shifts
+        // get all shifts (including canceled — UI strikes them through
+        // and prevents adds; volunteers still need to see them so they
+        // know they were canceled and can self-remove)
         [dbShiftList] = await pool.query<RowDataPacket[]>(
           `SELECT
             d.date,
@@ -62,6 +64,7 @@ const shifts = async (req: NextApiRequest, res: NextApiResponse) => {
             sc.department,
             sc.shift_category_id,
             sn.shift_name,
+            st.canceled,
             st.end_time,
             st.end_time_text,
             st.shift_times_id,
@@ -88,7 +91,6 @@ const shifts = async (req: NextApiRequest, res: NextApiResponse) => {
           ON vs.remove_shift=false
           AND vs.time_position_id=stp.time_position_id
           WHERE st.remove_shift_time=false
-          AND st.canceled=false
           ORDER BY d.date, st.start_time_text`
         );
       }

--- a/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
@@ -26,6 +26,7 @@ const volunteerShifts = async (
           d.datename,
           pt.position,
           sc.department,
+          st.canceled,
           st.end_time,
           st.end_time_text,
           st.start_time,
@@ -55,6 +56,7 @@ const volunteerShifts = async (
       );
       const resVolunteerShiftList = dbVolunteerShiftList.map(
         ({
+          canceled,
           date,
           datename,
           department,
@@ -74,6 +76,7 @@ const volunteerShifts = async (
               name: department ?? "",
             },
             shift: {
+              canceled: Boolean(canceled),
               date: date,
               dateName: datename ?? "",
               endTime: end_time ?? end_time_text,

--- a/client/src/utils/getShiftList.ts
+++ b/client/src/utils/getShiftList.ts
@@ -19,6 +19,7 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
 
   dbShiftList.forEach((row: RowDataPacket) => {
     const {
+      canceled,
       date,
       datename,
       department,
@@ -38,6 +39,7 @@ export const getShiftList = (dbShiftList: RowDataPacket[]) => {
     let shift = shiftMap.get(shift_times_id);
     if (!shift) {
       shift = {
+        canceled: Boolean(canceled),
         category: { id: shift_category_id },
         cspMin: Number.POSITIVE_INFINITY,
         cspMax: Number.NEGATIVE_INFINITY,


### PR DESCRIPTION
Per Mew. Canceled shifts now show up in the lists and detail pages with strikethrough + bold-red 'CANCELED', and the API rejects new assignments at the handler level. Self-removes are still allowed so assigned volunteers can drop themselves and pick up the cancellation .ics.

## Test plan
- [ ] Cancel a shift via Update Time (PR #378). /shifts list shows the row with a struck-through Chip + 'CANCELED' label
- [ ] Click the row — detail page renders with the red Alert banner; date/time/title struck through; 'Add volunteer' disabled
- [ ] As an already-assigned volunteer, the row-level remove menu still works
- [ ] Curl POST to /api/shifts/[timeId]/volunteers on the canceled shift returns 409
- [ ] /volunteers/[id]/info shifts table shows the volunteer's canceled assignments with the same CANCELED label