### PR TITLE
feat(mail): un-cancel a shift sends a restoration email + re-PUBLISH .ics

### DIFF
--- a/client/src/components/api/assignmentNotify.ts
+++ b/client/src/components/api/assignmentNotify.ts
@@ -413,3 +413,79 @@ export async function notifyRemoval(
       cause.kind === "shift-canceled" ? "shift-canceled" : "removal",
   });
 }
+
+// Fires when a whole shift's `canceled` flag flips 1→0 (the user
+// unchecked the Cancel checkbox in the Update Time dialog and saved).
+// Sends every still-assigned volunteer a "your shift is back on"
+// email + a PUBLISH .ics with SEQUENCE bumped above the prior
+// CANCEL's SEQUENCE so calendar clients re-add the event in place.
+// Per Mew 2026-05-31.
+//
+// SEQUENCE note: buildIcs defaults are PUBLISH=0 / CANCEL=1. We
+// pass `sequence: 2` here so the restoration overrides the most
+// recent CANCEL. Repeated cancel→restore cycles would need
+// further bumps; out of scope until/unless that becomes a real
+// workflow (in practice an un-cancel is the end of the story).
+export async function notifyRestoration(
+  pool: Pool,
+  shiftboardId: number,
+  timePositionId: number | string
+): Promise<void> {
+  const [rows] = await pool.query<ShiftContext[]>(SHIFT_CONTEXT_QUERY, [
+    shiftboardId,
+    timePositionId,
+  ]);
+  const ctx = rows[0];
+  if (!ctx) return;
+  if (!ctx.email) {
+    console.warn(
+      `[restore-notify] skip: shiftboard_id=${shiftboardId} time_position_id=${timePositionId} — no email on file`
+    );
+    return;
+  }
+
+  const dayLabel = ctx.datename ? `${ctx.datename} ${ctx.date}` : ctx.date;
+  const timeLabel = timeLabelFor(ctx);
+
+  const bodyText = [
+    greetingFor(ctx),
+    "",
+    "Good news — a Census shift you were on has been un-canceled. Your assignment is back on:",
+    "",
+    renderShiftBody(ctx, dayLabel, timeLabel),
+    "",
+    "A calendar invite is attached — your calendar should pick the event back up automatically.",
+    "",
+    `Manage your shifts: ${APP_BASE_URL}/`,
+  ].join("\n");
+
+  const icsDate = dateToIcs(ctx.date);
+  const icsStart = timeToIcs(ctx.start_time);
+  const icsEnd = timeToIcs(ctx.end_time);
+  const icsContent =
+    icsDate && icsStart && icsEnd
+      ? buildIcs({
+          uid: shiftIcsUid(shiftboardId, timePositionId),
+          summary: `Census: ${ctx.position}`,
+          description: bodyText,
+          date: icsDate,
+          startTime: icsStart,
+          endTime: icsEnd,
+          method: "PUBLISH",
+          sequence: 2,
+        })
+      : null;
+
+  await enqueueEmail({
+    to: ctx.email,
+    subject: `Census: ${ctx.shift_name} on ${dayLabel} is back on`,
+    bodyText,
+    ics: icsContent
+      ? {
+          filename: `census-${ctx.position.replace(/\s+/g, "-").toLowerCase()}-restored.ics`,
+          content: Buffer.from(icsContent, "utf8"),
+        }
+      : undefined,
+    category: "shift-restored",
+  });
+}

--- a/client/src/pages/api/shifts/types/[typeId]/index.ts
+++ b/client/src/pages/api/shifts/types/[typeId]/index.ts
@@ -10,7 +10,10 @@ import {
 } from "@/components/types/shifts/types";
 import { generateId } from "@/utils/generateId";
 import { pool } from "lib/database";
-import { notifyRemoval } from "@/components/api/assignmentNotify";
+import {
+  notifyRemoval,
+  notifyRestoration,
+} from "@/components/api/assignmentNotify";
 import { handleTimeListAdd } from "@/pages/api/shifts/types";
 
 const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -314,13 +317,15 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
         )
       );
 
-      // For each shift_times_id that just flipped 0→1, fetch every
-      // currently-assigned volunteer position and enqueue a
-      // shift-canceled email per (volunteer, time_position). Best-effort:
-      // an enqueue failure is logged and the route still 201s.
+      // For each shift_times_id that flipped 0→1 (newly canceled) or
+      // 1→0 (un-canceled), fan out the appropriate email per still-
+      // assigned volunteer. Best-effort: enqueue failures log and the
+      // route still 201s.
       for (const t of timeListUpdate) {
-        if (!t.canceled) continue;
-        if (wasCanceledMap.get(t.timeId)) continue;
+        const wasCanceled = wasCanceledMap.get(t.timeId) ?? false;
+        const isCanceled = Boolean(t.canceled);
+        if (wasCanceled === isCanceled) continue;
+        const tag = isCanceled ? "shift-canceled" : "shift-restored";
         try {
           const [rows] = await pool.query<RowDataPacket[]>(
             `SELECT DISTINCT vs.shiftboard_id, vs.time_position_id
@@ -333,22 +338,30 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
           );
           for (const v of rows) {
             try {
-              await notifyRemoval(
-                pool,
-                v.shiftboard_id,
-                v.time_position_id,
-                { kind: "shift-canceled" }
-              );
+              if (isCanceled) {
+                await notifyRemoval(
+                  pool,
+                  v.shiftboard_id,
+                  v.time_position_id,
+                  { kind: "shift-canceled" }
+                );
+              } else {
+                await notifyRestoration(
+                  pool,
+                  v.shiftboard_id,
+                  v.time_position_id
+                );
+              }
             } catch (err) {
               console.error(
-                `[shift-canceled-notify] enqueue failed for shiftboard_id=${v.shiftboard_id} time_position_id=${v.time_position_id}:`,
+                `[${tag}-notify] enqueue failed for shiftboard_id=${v.shiftboard_id} time_position_id=${v.time_position_id}:`,
                 err
               );
             }
           }
         } catch (err) {
           console.error(
-            `[shift-canceled-notify] fan-out failed for shift_times_id=${t.timeId}:`,
+            `[${tag}-notify] fan-out failed for shift_times_id=${t.timeId}:`,
             err
           );
         }


### PR DESCRIPTION
Per Mew. Inverse of #378: when canceled flips 1→0, fan out a 'your shift is back on' email per still-assigned volunteer with a PUBLISH .ics at SEQUENCE:2 so the prior CANCEL is overridden in their calendar.

## Test plan
With MAIL_OVERRIDE_TO active:
- [ ] Cancel a shift in Update Time → mu gets the cancel emails (existing #378 behavior)
- [ ] In the same dialog, uncheck Cancel and save → mu gets a 'restored' email per assigned volunteer; opens the .ics — the prior canceled event re-appears in the calendar