### PR TITLE
feat(okta): resolve canonical shiftboard_id via sb_pinfo before creating new account

### DIFF
--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -290,7 +290,7 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
       );
     }
 
-    // 2. check by email
+    // 2. check by email on op_volunteers
     if (!shiftboardId) {
       const [byEmail] = await pool.query<RowDataPacket[]>(
         "SELECT shiftboard_id FROM op_volunteers WHERE email=?",
@@ -309,7 +309,67 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
       }
     }
 
-    // 3. create new volunteer
+    // 3. check by email in sb_pinfo (Shiftboard email history, SCD2).
+    //    This catches the case where the BM volunteer record exists with
+    //    a canonical shiftboard_id but the row has never been imported
+    //    into op_volunteers yet (or never been linked to Okta). The lookup
+    //    matches any historical email -- it preferes the current row
+    //    (valid_to IS NULL) but falls back to the most recently valid
+    //    historical row if the user's Okta email is an older one.
+    //
+    //    Wrapped in try/catch so deployments that don't have sb_pinfo yet
+    //    (e.g. on-playa boxes) fall through to the create-new branch.
+    if (!shiftboardId) {
+      try {
+        const [bySbPinfo] = await pool.query<RowDataPacket[]>(
+          `SELECT shiftboard_id FROM sb_pinfo
+           WHERE email=?
+           ORDER BY (valid_to IS NULL) DESC, valid_from DESC
+           LIMIT 1`,
+          [email]
+        );
+        if (bySbPinfo.length > 0) {
+          const canonicalId = bySbPinfo[0].shiftboard_id;
+
+          // Does op_volunteers already have this canonical id (e.g. from
+          // a prior DB seed) but with no Okta link yet? Link and sync.
+          const [existingByCanonical] = await pool.query<RowDataPacket[]>(
+            "SELECT shiftboard_id FROM op_volunteers WHERE shiftboard_id=?",
+            [canonicalId]
+          );
+          if (existingByCanonical.length > 0) {
+            shiftboardId = canonicalId;
+            await pool.query(
+              `UPDATE op_volunteers
+              SET okta_id=?, playa_name=?, world_name=?, email=?
+              WHERE shiftboard_id=?`,
+              [oktaId, playaName, worldName, email, shiftboardId]
+            );
+          } else {
+            // Canonical id known from Shiftboard history but no row exists
+            // here yet -- create one using the canonical id (NOT a random
+            // generateId) so we stay consistent with the rest of the
+            // Census ecosystem.
+            await pool.query<RowDataPacket[]>(
+              `INSERT INTO op_volunteers (
+                shiftboard_id, playa_name, world_name, email, okta_id, create_volunteer
+              ) VALUES (?, ?, ?, ?, ?, true)`,
+              [canonicalId, playaName, worldName, email, oktaId]
+            );
+            shiftboardId = canonicalId;
+          }
+        }
+      } catch (sbErr) {
+        // sb_pinfo missing or query failed -- not fatal, fall through to
+        // creating a new volunteer with a generated id below.
+        console.warn(
+          "sb_pinfo lookup skipped:",
+          sbErr instanceof Error ? sbErr.message : sbErr
+        );
+      }
+    }
+
+    // 4. create new volunteer with a generated id
     if (!shiftboardId) {
       const newId = generateId(`
         SELECT shiftboard_id


### PR DESCRIPTION
## Why
We just stood up `sb_pinfo` on prod RDS — a SCD2 table seeded from `shiftboard_pinfohis` (the Shiftboard email history from `CensusData/data/sql/shiftboard_pinfohis.sql`). It contains 4104 rows mapping every email Shiftboard has ever known for a volunteer to the canonical `shiftboard_id` (4004 distinct ids, 100 of which have email-change history).

Without using it, an Okta sign-in for an existing BM volunteer who isn't already in `op_volunteers` gets a random generated `shiftboard_id`, divorcing the prod app's record from the rest of the Census ecosystem (and producing the kind of duplicates we cleaned up by hand yesterday).

## What
Insert a third lookup step in the OAuth callback chain. New chain:

1. `op_volunteers` by `okta_id` *(existing)*
2. `op_volunteers` by `email` *(existing)*
3. **`sb_pinfo` by `email` — any historical match, current preferred *(new)***
   - If match → either link existing `op_volunteers` row with that canonical id, OR `INSERT` a new `op_volunteers` row with the canonical id directly (no `generateId`)
4. `INSERT op_volunteers` with random `generateId()` *(existing fallback)*

The `sb_pinfo` query is wrapped in `try/catch` so deployments that don't have the table (test box, on-playa) silently fall through to step 4 unchanged.

## SQL the new step runs
```sql
SELECT shiftboard_id FROM sb_pinfo
WHERE email = ?
ORDER BY (valid_to IS NULL) DESC, valid_from DESC
LIMIT 1
```
`ORDER BY (valid_to IS NULL) DESC` puts the current row first if one exists; otherwise we get the most recently valid historical row. This way an Okta login with someone's old email still resolves to the right id.

## Test plan
- [ ] On prod, deleting a keep-list row then re-signing in via Okta resolves to the same canonical `shiftboard_id` (e.g. 3234 for `mu@burningman.org`) instead of a random one
- [ ] On test (no `sb_pinfo` table), sign-in continues to work via the existing flow
- [ ] Schema and seed verified out-of-band:
  - 4104 rows / 4004 distinct ids / 100 historical email changes
  - All 7 prod keep-list emails resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)