### PR TITLE
feat(mail): email unsubscribe — role-based flag + footer + info-page checkbox

### DIFF
--- a/client/lib/mail/index.ts
+++ b/client/lib/mail/index.ts
@@ -39,7 +39,9 @@ function config(): MailConfig {
   return runtimeConfig;
 }
 
-export async function enqueueEmail(args: EnqueueArgs): Promise<{ id: number }> {
+export async function enqueueEmail(
+  args: EnqueueArgs
+): Promise<{ id: number; skipped?: boolean }> {
   return enqueueEmailRaw(pool, config(), args);
 }
 

--- a/client/lib/mail/queue.ts
+++ b/client/lib/mail/queue.ts
@@ -4,19 +4,73 @@ import type { ResultSetHeader, RowDataPacket } from "mysql2";
 import { nextAttemptDelaySeconds } from "./backoff";
 import type { EmailRow, EnqueueArgs, MailConfig } from "./types";
 
+// Kept local to the mail layer so queue.ts has no dep on src/constants.ts
+// (which is React-side). Must stay in sync with
+// ROLE_EMAIL_UNSUBSCRIBED_ID in client/src/constants.ts and the seed in
+// migrations/003_email_unsubscribed_role.sql.
+const ROLE_EMAIL_UNSUBSCRIBED_ID = 2000020;
+
+const APP_BASE_URL =
+  process.env.APP_BASE_URL ?? "https://volunteers.census.burningman.org";
+
 function joinAddrs(v: string | string[] | undefined): string | null {
   if (v === undefined) return null;
   if (Array.isArray(v)) return v.join(", ");
   return v;
 }
 
+async function isUnsubscribed(
+  pool: Pool,
+  shiftboardId: number
+): Promise<boolean> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT 1
+       FROM op_volunteer_roles
+      WHERE shiftboard_id = ?
+        AND role_id = ?
+        AND add_role = true
+        AND remove_role = false
+      LIMIT 1`,
+    [shiftboardId, ROLE_EMAIL_UNSUBSCRIBED_ID]
+  );
+  return rows.length > 0;
+}
+
+function appendUnsubscribeFooter(
+  bodyText: string,
+  bodyHtml: string | undefined,
+  unsubscribeUrl: string
+): { bodyText: string; bodyHtml: string | undefined } {
+  const text = `${bodyText}\n\n— — —\nDon't want these emails? Click here to unsubscribe:\n${unsubscribeUrl}\n`;
+  const html =
+    bodyHtml === undefined
+      ? undefined
+      : `${bodyHtml}\n<hr>\n<p style="color:#666;font-size:12px;">Don't want these emails? <a href="${unsubscribeUrl}">Click here to unsubscribe</a>.</p>`;
+  return { bodyText: text, bodyHtml: html };
+}
+
 export async function enqueueEmail(
   pool: Pool,
   config: MailConfig,
   args: EnqueueArgs
-): Promise<{ id: number }> {
+): Promise<{ id: number; skipped?: boolean }> {
   const to = joinAddrs(args.to);
   if (!to) throw new Error("enqueueEmail: `to` is required");
+
+  let bodyText = args.bodyText;
+  let bodyHtml = args.bodyHtml;
+
+  if (args.recipientShiftboardId != null) {
+    if (await isUnsubscribed(pool, args.recipientShiftboardId)) {
+      return { id: 0, skipped: true };
+    }
+    const unsubUrl = `${APP_BASE_URL}/unsubscribe`;
+    ({ bodyText, bodyHtml } = appendUnsubscribeFooter(
+      bodyText,
+      bodyHtml,
+      unsubUrl
+    ));
+  }
 
   const [result] = await pool.execute<ResultSetHeader>(
     `INSERT INTO op_email_queue
@@ -29,8 +83,8 @@ export async function enqueueEmail(
       args.replyTo ?? config.defaultReplyTo,
       config.from,
       args.subject,
-      args.bodyText,
-      args.bodyHtml ?? null,
+      bodyText,
+      bodyHtml ?? null,
       args.ics?.content ?? null,
       args.ics?.filename ?? null,
       args.category,

--- a/client/lib/mail/types.ts
+++ b/client/lib/mail/types.ts
@@ -9,6 +9,12 @@ export interface EnqueueArgs {
   bodyHtml?: string;
   ics?: { filename: string; content: Buffer };
   category: string;
+  // When set, enqueueEmail checks op_volunteer_roles for the
+  // EmailUnsubscribed role and skips the send if found. Also enables the
+  // unsubscribe footer so the recipient can opt back in. Omit for system
+  // mail (e.g. critical-drop notifications to the VC list, contact-form
+  // sends) where opt-out doesn't apply.
+  recipientShiftboardId?: number;
 }
 
 export interface EmailRow {

--- a/client/src/app/unsubscribe/Unsubscribe.tsx
+++ b/client/src/app/unsubscribe/Unsubscribe.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Container } from "@mui/material";
+import { useRouter } from "next/navigation";
+import { useSnackbar } from "notistack";
+import { useContext, useEffect, useRef } from "react";
+import useSWRMutation from "swr/mutation";
+
+import { Loading } from "@/components/general/Loading";
+import { SnackbarText } from "@/components/general/SnackbarText";
+import type { IReqToggleEmailUnsubscribed } from "@/components/types/volunteer-info";
+import {
+  ROLE_EMAIL_UNSUBSCRIBED_ID,
+  SESSION_ROLE_ITEM_ADD,
+} from "@/constants";
+import { SessionContext } from "@/state/session/context";
+import { fetcherTrigger } from "@/utils/fetcher";
+
+// Email-footer "Click here to unsubscribe" target. AuthGate on the page
+// wrapper forces Okta sign-in first (with /sign-in?returnTo=/unsubscribe),
+// so by the time this component mounts we have the authenticated
+// shiftboardId from session. We auto-fire the POST exactly like the
+// training-confirmation flow — visiting the page IS the action — then
+// redirect to the info page's Settings section so the volunteer can see
+// the result and re-subscribe if they want.
+export const Unsubscribe = () => {
+  const {
+    sessionDispatch,
+    sessionState: {
+      user: { shiftboardId },
+    },
+  } = useContext(SessionContext);
+
+  const { trigger } = useSWRMutation(
+    shiftboardId
+      ? `/api/volunteers/${shiftboardId}/info/email-preference`
+      : null,
+    fetcherTrigger
+  );
+
+  const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+
+  // Guard against React-strict-mode double-mount. The POST is idempotent
+  // server-side (SELECT-then-branch UPDATE/INSERT) but no need to round-trip
+  // twice.
+  const autoFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (!shiftboardId) return;
+    if (autoFiredRef.current) return;
+    autoFiredRef.current = true;
+
+    (async () => {
+      try {
+        const body: IReqToggleEmailUnsubscribed = { unsubscribed: true };
+        await trigger({ body, method: "POST" });
+        sessionDispatch({
+          type: SESSION_ROLE_ITEM_ADD,
+          payload: {
+            id: ROLE_EMAIL_UNSUBSCRIBED_ID,
+            name: "EmailUnsubscribed",
+          },
+        });
+        enqueueSnackbar(
+          <SnackbarText>
+            You have been <strong>unsubscribed</strong> from Census emails. You
+            can re-subscribe from your info page.
+          </SnackbarText>,
+          { variant: "success" }
+        );
+        router.replace(`/volunteers/${shiftboardId}/info#settings`);
+      } catch (e) {
+        autoFiredRef.current = false;
+        if (e instanceof Error) {
+          enqueueSnackbar(
+            <SnackbarText>
+              <strong>{e.message}</strong>
+            </SnackbarText>,
+            { persist: true, variant: "error" }
+          );
+        }
+      }
+    })();
+  }, [shiftboardId, trigger, sessionDispatch, enqueueSnackbar, router]);
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Loading />
+    </Container>
+  );
+};

--- a/client/src/app/unsubscribe/page.tsx
+++ b/client/src/app/unsubscribe/page.tsx
@@ -1,0 +1,17 @@
+import { Unsubscribe } from "@/app/unsubscribe/Unsubscribe";
+import { AuthGate } from "@/components/general/AuthGate";
+import { ACCOUNT_TYPE_AUTHENTICATED } from "@/constants";
+
+export const metadata = {
+  title: "Census | Unsubscribe",
+};
+
+const UnsubscribePage = () => {
+  return (
+    <AuthGate accountTypeToCheck={ACCOUNT_TYPE_AUTHENTICATED}>
+      <Unsubscribe />
+    </AuthGate>
+  );
+};
+
+export default UnsubscribePage;

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -186,6 +186,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     `/api/volunteers/${shiftboardId}/info/profile-updated`,
     fetcherTrigger
   );
+  const { trigger: triggerEmailPreference } = useSWRMutation(
+    `/api/volunteers/${shiftboardId}/info/email-preference`,
+    fetcherTrigger
+  );
 
   // account data (for admin sections: roles, notes, security)
   const {
@@ -281,6 +285,34 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
       }
     },
     [triggerOtherSap, mutate, enqueueSnackbar]
+  );
+
+  const handleEmailUnsubscribedToggle = useCallback(
+    async (unsubscribed: boolean) => {
+      try {
+        await triggerEmailPreference({
+          body: { unsubscribed },
+          method: "POST",
+        });
+        mutate();
+        enqueueSnackbar(
+          <SnackbarText>
+            Email preference <strong>updated</strong>
+          </SnackbarText>,
+          { variant: "success" }
+        );
+      } catch (error) {
+        if (error instanceof Error) {
+          enqueueSnackbar(
+            <SnackbarText>
+              <strong>{error.message}</strong>
+            </SnackbarText>,
+            { persist: true, variant: "error" }
+          );
+        }
+      }
+    },
+    [triggerEmailPreference, mutate, enqueueSnackbar]
   );
 
   const handleLocationChange = useCallback(
@@ -416,6 +448,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     behavioralStandardsSigned,
     burnerProfileUpdated,
     dates,
+    emailUnsubscribed,
     roles,
     roleThresholds,
     sapStatus,
@@ -1079,6 +1112,44 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                   </Stack>
                 </Grid>
               </Grid>
+            </CardContent>
+          </Card>
+        </Box>
+
+        {/* settings — available to all users (email-footer #settings anchor) */}
+        <Box component="section" id="settings" sx={{ mt: 3 }}>
+          <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
+            Settings
+          </Typography>
+          <Card>
+            <CardContent>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={!emailUnsubscribed}
+                    onChange={(e) =>
+                      handleEmailUnsubscribedToggle(!e.target.checked)
+                    }
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography component="span" variant="body1">
+                      Receive emails from Census
+                    </Typography>
+                    <Typography
+                      color="text.secondary"
+                      component="div"
+                      variant="body2"
+                    >
+                      Uncheck to stop receiving automated emails (shift
+                      assignments, cancellations, calendar invites). You can
+                      re-subscribe here at any time.
+                    </Typography>
+                  </Box>
+                }
+                sx={{ alignItems: "flex-start", m: 0 }}
+              />
             </CardContent>
           </Card>
         </Box>

--- a/client/src/components/api/assignmentNotify.ts
+++ b/client/src/components/api/assignmentNotify.ts
@@ -301,6 +301,7 @@ export async function notifyAssignment(
 
   await enqueueEmail({
     to: ctx.email,
+    recipientShiftboardId: shiftboardId,
     subject: `Census: assigned to ${ctx.position} on ${dayLabel}`,
     bodyText,
     ics: icsContent
@@ -408,6 +409,7 @@ export async function notifyRemoval(
 
   await enqueueEmail({
     to: ctx.email,
+    recipientShiftboardId: shiftboardId,
     subject,
     bodyText,
     ics: icsContent
@@ -485,6 +487,7 @@ export async function notifyRestoration(
 
   await enqueueEmail({
     to: ctx.email,
+    recipientShiftboardId: shiftboardId,
     subject: `Census: ${ctx.shift_name} on ${dayLabel} is back on`,
     bodyText,
     ics: icsContent

--- a/client/src/components/types/volunteer-info.ts
+++ b/client/src/components/types/volunteer-info.ts
@@ -12,6 +12,9 @@ export interface IReqToggleOtherSap {
 export interface IReqToggleProfileUpdated {
   updated: boolean;
 }
+export interface IReqToggleEmailUnsubscribed {
+  unsubscribed: boolean;
+}
 
 // response
 export interface IResVolunteerInfo {
@@ -74,4 +77,5 @@ export interface IResVolunteerInfo {
   }[];
   burnerProfileUpdated: boolean;
   behavioralStandardsSigned: boolean;
+  emailUnsubscribed: boolean;
 }

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -91,6 +91,7 @@ export const COLOR_CENSUS_PINK = "#ea008b";
 export const ROLE_ADMIN_ID = 2;
 export const ROLE_BEHAVIORAL_STANDARDS_ID = 1000012;
 export const ROLE_CORE_CREW_ID = 13184;
+export const ROLE_EMAIL_UNSUBSCRIBED_ID = 2000020;
 export const ROLE_SUPER_ADMIN_ID = 1;
 
 // sockets

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/email-preference/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/email-preference/index.ts
@@ -1,0 +1,83 @@
+import { RowDataPacket } from "mysql2";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { IReqToggleEmailUnsubscribed } from "@/components/types/volunteer-info";
+import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
+
+// Toggles the EmailUnsubscribed role on op_volunteer_roles. Mirrors the
+// other-sap endpoint pattern: SELECT-then-branch into UPDATE or INSERT.
+// The mail layer (client/lib/mail/queue.ts) checks this role at enqueue
+// time and skips the send.
+const ROLE_EMAIL_UNSUBSCRIBED_ID = 2000020;
+
+const emailPreference = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
+  const { shiftboardId } = req.query;
+
+  // Self-only: prevents an admin or anyone else from flipping this for
+  // another volunteer. Admins can already manage roles directly on the
+  // Roles page if they need to unsubscribe someone on their behalf.
+  if (Number(shiftboardId) !== session.shiftboardId) {
+    return res.status(403).json({
+      statusCode: 403,
+      message: "Forbidden",
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const { unsubscribed }: IReqToggleEmailUnsubscribed = JSON.parse(
+        req.body
+      );
+      const [addRole, removeRole] = [unsubscribed === true, unsubscribed === false];
+
+      const [dbVolunteerRoleList] = await pool.query<RowDataPacket[]>(
+        `SELECT shiftboard_id
+        FROM op_volunteer_roles
+        WHERE role_id=?
+        AND shiftboard_id=?`,
+        [ROLE_EMAIL_UNSUBSCRIBED_ID, shiftboardId]
+      );
+      const [dbVolunteerRoleFirst] = dbVolunteerRoleList;
+
+      if (dbVolunteerRoleFirst) {
+        await pool.query(
+          `UPDATE op_volunteer_roles
+          SET add_role=?, remove_role=?
+          WHERE role_id=?
+          AND shiftboard_id=?`,
+          [addRole, removeRole, ROLE_EMAIL_UNSUBSCRIBED_ID, shiftboardId]
+        );
+      } else {
+        await pool.query(
+          `INSERT INTO op_volunteer_roles (
+            add_role,
+            remove_role,
+            role_id,
+            shiftboard_id
+          )
+          VALUES (?, ?, ?, ?)`,
+          [addRole, removeRole, ROLE_EMAIL_UNSUBSCRIBED_ID, shiftboardId]
+        );
+      }
+
+      return res.status(201).json({
+        statusCode: 201,
+        message: "Created",
+      });
+    }
+
+    default: {
+      return res.status(404).json({
+        statusCode: 404,
+        message: "Not found",
+      });
+    }
+  }
+};
+
+export default withAuth(emailPreference);

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -36,6 +36,7 @@ const ROLE_STAFF_ID = 2000006;
 const ROLE_OTHER_SAP_ID = 2000007;
 const ROLE_BURNER_PROFILE_UPDATED_ID = 2000010;
 const ROLE_BEHAVIORAL_STANDARDS_ID = 1000012;
+const ROLE_EMAIL_UNSUBSCRIBED_ID = 2000020;
 
 // Datenames that are before or on opening (eligible for SAP)
 const PRE_OPEN_DATENAMES = [
@@ -302,6 +303,7 @@ const volunteerInfo = async (req: NextApiRequest, res: NextApiResponse) => {
       const behavioralStandardsSigned = roleIdSet.has(
         ROLE_BEHAVIORAL_STANDARDS_ID
       );
+      const emailUnsubscribed = roleIdSet.has(ROLE_EMAIL_UNSUBSCRIBED_ID);
 
       // build response
       const resVolunteerInfo: IResVolunteerInfo = {
@@ -341,6 +343,7 @@ const volunteerInfo = async (req: NextApiRequest, res: NextApiResponse) => {
         })),
         burnerProfileUpdated,
         behavioralStandardsSigned,
+        emailUnsubscribed,
       };
 
       return res.status(200).json(resVolunteerInfo);

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -303,7 +303,22 @@ const volunteerInfo = async (req: NextApiRequest, res: NextApiResponse) => {
       const behavioralStandardsSigned = roleIdSet.has(
         ROLE_BEHAVIORAL_STANDARDS_ID
       );
-      const emailUnsubscribed = roleIdSet.has(ROLE_EMAIL_UNSUBSCRIBED_ID);
+      // Strict (add_role=true AND remove_role=false) so the checkbox state
+       // matches the queue's send-time filter in client/lib/mail/queue.ts
+      // exactly. The bulk role-list query above is intentionally looser to
+       // keep parity with the rest of this endpoint (other-sap, profile-updated,
+       // behavioral-standards, etc.).
+      const [dbUnsubRow] = await pool.query<RowDataPacket[]>(
+        `SELECT 1
+        FROM op_volunteer_roles
+        WHERE shiftboard_id=?
+          AND role_id=?
+          AND add_role=true
+          AND remove_role=false
+        LIMIT 1`,
+        [shiftboardId, ROLE_EMAIL_UNSUBSCRIBED_ID]
+      );
+      const emailUnsubscribed = dbUnsubRow.length > 0;
 
       // build response
       const resVolunteerInfo: IResVolunteerInfo = {

--- a/migrations/003_email_unsubscribed_role.sql
+++ b/migrations/003_email_unsubscribed_role.sql
@@ -1,0 +1,22 @@
+-- Migration: seed the EmailUnsubscribed role.
+--
+-- Stored as a regular volunteer role (op_volunteer_roles) so the flag
+-- lives next to every other per-volunteer flag — OtherSAP, BurnerProfileUpdated,
+-- BehavioralStandards, etc. — and so admins/the role admin UI can audit it the
+-- same way.
+--
+-- role_id 2000020 is hand-picked in the 2000xxx status-flag range
+-- (ROLE_BURNER_PROFILE_UPDATED_ID=2000010, ROLE_OTHER_SAP_ID=2000007,
+-- ROLE_STAFF_ID=2000006) so the constant in client/src/constants.ts is stable
+-- across environments.
+--
+-- display=0: this is a self-managed preference, not something admins flip from
+-- the Roles list.
+--
+-- Idempotent: safe to re-run.
+
+INSERT INTO op_roles (role_id, role, display, role_src)
+VALUES (2000020, 'EmailUnsubscribed', 0, 'system')
+ON DUPLICATE KEY UPDATE role = VALUES(role),
+                        display = VALUES(display),
+                        role_src = VALUES(role_src);


### PR DESCRIPTION
## Summary

Adds the email unsubscribe loop now that the queue is sending automated mail.

- **Storage**: an `EmailUnsubscribed` role on `op_volunteer_roles` (role_id 2000020, seeded in [migrations/003](migrations/003_email_unsubscribed_role.sql)). Lives next to every other per-volunteer flag (`OtherSAP`, `BurnerProfileUpdated`, `BehavioralStandards`). No schema change.
- **Enforcement**: `enqueueEmail` gets an optional `recipientShiftboardId`. When set, [queue.ts](client/lib/mail/queue.ts) checks the role and skip-returns `{ id: 0, skipped: true }`; otherwise it appends a text + HTML footer linking to `${APP_BASE_URL}/unsubscribe`. Threaded through `notifyAssignment` / `notifyRemoval` / `notifyRestoration`. Critical-drop (VC list) and contact-form sends intentionally don't pass it — opt-out doesn't apply to those.
- **One-click unsub**: [`/unsubscribe`](client/src/app/unsubscribe/page.tsx) is wrapped in `AuthGate` so unauthenticated clicks land on `/sign-in?returnTo=/unsubscribe` (Okta) and come back. Auto-fires the POST exactly like `/training/confirmation/[code]`, then `router.replace` to `/volunteers/[id]/info#settings`.
- **Checkbox**: `GET /api/volunteers/[id]/info` returns `emailUnsubscribed`; new `POST .../info/email-preference` (self-only, mirrors `other-sap`) toggles the role. `VolunteerInfo.tsx` adds a `<Box id="settings">` Settings section at the bottom with a "Receive emails from Census" checkbox — `#settings` is the redirect anchor.

## Test plan

- [ ] Apply `migrations/003_email_unsubscribed_role.sql` on test DB; confirm role_id=2000020 row in `op_roles`
- [ ] Sign in, visit `/volunteers/<self-id>/info`, scroll to Settings, uncheck the box → snackbar "Email preference updated"
- [ ] Trigger an assignment email (add a shift) → footer present, link goes to `/unsubscribe`
- [ ] Trigger another assignment to a still-subscribed account → footer present
- [ ] Re-check the Settings box → next assignment notify enqueues normally
- [ ] Uncheck again, then trigger an assignment → check `op_email_queue` shows no new row (returned `skipped: true`)
- [ ] Click the unsubscribe link while signed out → Okta sign-in, then auto-unsub, lands on `/volunteers/<id>/info#settings` with checkbox unchecked
- [ ] Click the unsubscribe link while signed in → no sign-in detour
- [ ] Verify critical-drop email (drop a critical shift) → no footer, sends to VC list normally
- [ ] Verify contact form email → no footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)