### PR TITLE
chore(etl): add prod Shiftboard -> sb_pinfo ETL scripts

### DIFF
--- a/etl/.gitignore
+++ b/etl/.gitignore
@@ -1,0 +1,4 @@
+secrets/
+venv/
+__pycache__/
+*.pyc

--- a/etl/README.md
+++ b/etl/README.md
@@ -1,0 +1,42 @@
+# Prod ETL scripts
+
+Python scripts that run on the prod EC2 box (under `mew` user) to keep the prod RDS in sync with Shiftboard.
+
+## Layout on prod
+```
+/home/mew/census-etl/
+  venv/                          # python 3.13 venv (httpx, pymysql, openpyxl, python-dotenv)
+  shiftboard_client.py           # standalone Shiftboard auth + profile download/parse
+  etl_sb_pinfo.py                # Phase 2: SCD2 upsert into prod RDS sb_pinfo
+  secrets/etl.env                # SHIFTBOARD_* + MYSQL_* (chmod 600, gitignored)
+```
+
+## Cron
+`crontab -l` (mew):
+```
+# Census prod RDS -> OnPlayaData snapshot (every 4 hours)
+0 */4 * * * cd $HOME/Census/OnPlayaData && server/update_server_v2.sh >> $HOME/onplayadata-dump.log 2>&1
+
+# Census prod RDS sb_pinfo upsert from Shiftboard (every 4h, offset 2h)
+0 2-22/4 * * * cd $HOME/census-etl && venv/bin/python etl_sb_pinfo.py >> $HOME/etl-sb-pinfo.log 2>&1
+```
+
+## What's done
+- **Phase 1**: `sb_pinfo` SCD2 table on prod RDS, seeded from `CensusData/data/sql/shiftboard_pinfohis.sql`. Okta callback looks up by email -> canonical `shiftboard_id` (see `client/src/pages/api/auth/okta/callback.ts`, step 3).
+- **Phase 2**: `etl_sb_pinfo.py` cron, every 4h. Pulls profiles for Active Census Team (597584) + Intake (602158), dedupes by `shiftboard_id`, SCD2-upserts into `sb_pinfo`.
+
+## What's not
+- **Phase 3** (intake / welcome workflow): not started. Needs:
+  - port of `Intake()` from `VCcensus/src/censusload.php`
+  - calls into `add_member_to_census()` / `remove_member_from_intake()` already stubbed in `shiftboard_client.py`
+  - welcome email send (decide on Gmail API vs SMTP first)
+  - integration with `op_volunteers` (currently legacy code wrote to `shiftboard_pinfo`)
+
+## Running manually
+```
+cd ~/census-etl
+source venv/bin/activate
+python etl_sb_pinfo.py --dry-run    # report changes, don't write
+python etl_sb_pinfo.py              # apply
+python etl_sb_pinfo.py --group 597584   # single-group only
+```

--- a/etl/etl_sb_pinfo.py
+++ b/etl/etl_sb_pinfo.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Phase 2 ETL: pull current Shiftboard profile data, upsert into sb_pinfo.
+
+What this does:
+    1. Authenticate with Shiftboard (read creds from env).
+    2. Download current profiles from the Active Census Team group (597584)
+       and the Intake group (602158). Both feed sb_pinfo so we capture
+       new arrivals' emails even before they're moved to the team.
+    3. For each (shiftboard_id, email):
+         - If no row exists for that shiftboard_id      -> INSERT new (current).
+         - If current row exists with same email        -> no-op.
+         - If current row exists with a different email -> close it out
+                                                           (valid_to=NOW())
+                                                           and INSERT a new
+                                                           current row.
+
+Idempotent. Safe to run repeatedly.
+
+Run:
+    cd ~/census-etl
+    source venv/bin/activate
+    python etl_sb_pinfo.py            # apply changes
+    python etl_sb_pinfo.py --dry-run  # report what would change, don't write
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import pymysql
+from dotenv import load_dotenv
+
+# When called from cron the cwd is $HOME, so anchor to this file's directory.
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+load_dotenv(HERE / "secrets" / "etl.env")
+
+from shiftboard_client import (  # noqa: E402
+    CENSUS_TEAM_GROUP,
+    INTAKE_GROUP,
+    ShiftboardClient,
+    ShiftboardError,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("etl_sb_pinfo")
+
+
+@dataclass
+class Counts:
+    fetched: int = 0
+    inserted: int = 0
+    closed_then_inserted: int = 0
+    unchanged: int = 0
+    skipped_no_email: int = 0
+    errors: int = 0
+
+    def __str__(self) -> str:
+        return (
+            f"fetched={self.fetched} inserted={self.inserted} "
+            f"changed={self.closed_then_inserted} unchanged={self.unchanged} "
+            f"skipped_no_email={self.skipped_no_email} errors={self.errors}"
+        )
+
+
+def get_db() -> pymysql.connections.Connection:
+    return pymysql.connect(
+        host=os.environ["MYSQL_HOST"],
+        user=os.environ["MYSQL_USER"],
+        password=os.environ["MYSQL_PASSWORD"],
+        database=os.environ["MYSQL_DATABASE"],
+        ssl={"ssl": {}},  # RDS requires TLS; empty dict = default verify
+        autocommit=False,
+        charset="utf8mb4",
+    )
+
+
+def upsert_sb_pinfo(
+    db: pymysql.connections.Connection,
+    shiftboard_id: int,
+    email: str,
+    dry_run: bool,
+    counts: Counts,
+) -> None:
+    """SCD2 upsert for a single (shiftboard_id, email) observation."""
+    with db.cursor(pymysql.cursors.DictCursor) as cur:
+        cur.execute(
+            "SELECT id, email FROM sb_pinfo "
+            "WHERE shiftboard_id=%s AND valid_to IS NULL "
+            "ORDER BY valid_from DESC LIMIT 1",
+            (shiftboard_id,),
+        )
+        current = cur.fetchone()
+
+        if current is None:
+            log.debug("INSERT new sb_pinfo id=%s email=%s", shiftboard_id, email)
+            if not dry_run:
+                cur.execute(
+                    "INSERT INTO sb_pinfo "
+                    "(shiftboard_id, email, valid_from, valid_to, source) "
+                    "VALUES (%s, %s, NOW(), NULL, 'shiftboard_etl')",
+                    (shiftboard_id, email),
+                )
+            counts.inserted += 1
+            return
+
+        if current["email"].lower() == email.lower():
+            counts.unchanged += 1
+            return
+
+        log.info(
+            "CHANGE shiftboard_id=%s: %s -> %s",
+            shiftboard_id, current["email"], email,
+        )
+        if not dry_run:
+            now = datetime.utcnow()
+            cur.execute(
+                "UPDATE sb_pinfo SET valid_to=%s WHERE id=%s",
+                (now, current["id"]),
+            )
+            cur.execute(
+                "INSERT INTO sb_pinfo "
+                "(shiftboard_id, email, valid_from, valid_to, source) "
+                "VALUES (%s, %s, %s, NULL, 'shiftboard_etl')",
+                (shiftboard_id, email, now),
+            )
+        counts.closed_then_inserted += 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Shiftboard -> sb_pinfo ETL")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change, do not write to RDS",
+    )
+    parser.add_argument(
+        "--group",
+        type=int,
+        default=None,
+        help="single group ID to pull; default = both Census Team + Intake",
+    )
+    args = parser.parse_args()
+
+    counts = Counts()
+
+    user = os.environ.get("SHIFTBOARD_USER")
+    pw = os.environ.get("SHIFTBOARD_PASSWORD")
+    ss = os.environ.get("SHIFTBOARD_SESSION_ID", "534228")
+    if not user or not pw:
+        log.error("SHIFTBOARD_USER / SHIFTBOARD_PASSWORD missing from env")
+        return 2
+
+    client = ShiftboardClient(user, pw, ss)
+    log.info("authenticating to Shiftboard as %s", user)
+    if not client.authenticate():
+        log.error("Shiftboard authentication failed")
+        return 3
+
+    group_ids = [args.group] if args.group else [CENSUS_TEAM_GROUP, INTAKE_GROUP]
+
+    # Collect first, dedupe by shiftboard_id (last write wins, so a person
+    # who appears in both Census Team and Intake takes the Intake row --
+    # intake tends to have the newer profile data).
+    pairs: dict[int, str] = {}
+    for gid in group_ids:
+        log.info("downloading profiles for group %s", gid)
+        try:
+            profiles = client.download_profiles(gid)
+        except ShiftboardError as e:
+            log.error("download failed for group %s: %s", gid, e)
+            counts.errors += 1
+            continue
+        log.info("group %s returned %d profile rows", gid, len(profiles))
+        for p in profiles:
+            counts.fetched += 1
+            if not p.get("email"):
+                counts.skipped_no_email += 1
+                continue
+            pairs[p["shiftboard_id"]] = p["email"]
+    log.info("after dedupe: %d distinct shiftboard_ids to upsert", len(pairs))
+
+    db = get_db()
+    try:
+        for sb_id, email in pairs.items():
+            try:
+                upsert_sb_pinfo(db, sb_id, email, args.dry_run, counts)
+            except Exception as e:
+                log.exception(
+                    "upsert failed for shiftboard_id=%s email=%s: %s",
+                    sb_id, email, e,
+                )
+                counts.errors += 1
+
+        if not args.dry_run:
+            db.commit()
+            log.info("committed: %s", counts)
+        else:
+            db.rollback()
+            log.info("DRY RUN, rolled back: %s", counts)
+    finally:
+        db.close()
+
+    return 0 if counts.errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/etl/shiftboard_client.py
+++ b/etl/shiftboard_client.py
@@ -1,0 +1,245 @@
+"""Minimal standalone Shiftboard client.
+
+Extracted from census-python/app/services/shiftboard_service.py for use by
+the prod ETL scripts. Drops the SQLAlchemy and app.core dependencies; this
+file only does HTTP I/O + TSV parsing.
+
+Public surface:
+    ShiftboardClient(user, password, session_id)
+        .authenticate()                -> bool
+        .download_profiles(group_id)   -> list[dict]   # parsed TSV rows
+        .add_member_to_census(id)      -> bool         # move to group 597584
+        .remove_member_from_intake(id) -> bool         # remove from group 602158
+
+Groups:
+    CENSUS_TEAM_GROUP = 597584   # Active Census Team
+    INTAKE_GROUP      = 602158   # Pending intake
+
+The TSV response uses Shiftboard's report.cgi `format=new_excel` endpoint,
+which despite the name returns tab-delimited text.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+import httpx
+import openpyxl
+
+logger = logging.getLogger(__name__)
+
+CENSUS_TEAM_GROUP = 597584
+INTAKE_GROUP = 602158
+DEFAULT_SS = "534228"
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.5",
+    "Origin": "https://www.shiftboard.com",
+    "Referer": "https://www.shiftboard.com/BurningMan/",
+}
+
+
+class ShiftboardError(RuntimeError):
+    pass
+
+
+class ShiftboardClient:
+    def __init__(
+        self,
+        user: str,
+        password: str,
+        session_id: str = DEFAULT_SS,
+        timeout: float = 60.0,
+    ):
+        self._user = user
+        self._password = password
+        self._ss = session_id
+        self._timeout = timeout
+        self._cookies: dict[str, str] | None = None
+
+    # ---------------------------------------------------------------- auth
+
+    def authenticate(self) -> bool:
+        """POST credentials, capture SB2Session cookie."""
+        headers = {**_HEADERS, "Content-Type": "application/x-www-form-urlencoded"}
+        with httpx.Client(
+            follow_redirects=True, timeout=self._timeout, headers=headers
+        ) as client:
+            client.get("https://www.shiftboard.com/BurningMan/")
+            resp = client.post(
+                "https://app.shiftboard.com/servola/auth.cgi",
+                data={
+                    "ss": self._ss,
+                    "auth_user": self._user,
+                    "auth_password": self._password,
+                },
+            )
+            if "/errors/" in str(resp.url) or resp.status_code >= 400:
+                logger.error(
+                    "Shiftboard login landed at error page: %s (status %s)",
+                    resp.url, resp.status_code,
+                )
+                return False
+            if "SB2Session" not in client.cookies:
+                logger.error(
+                    "Shiftboard login: no SB2Session cookie returned; cookies=%s",
+                    list(client.cookies.keys()),
+                )
+                return False
+            self._cookies = dict(client.cookies)
+            logger.info("Shiftboard auth OK (SB2Session captured)")
+            return True
+
+    # ------------------------------------------------------------- download
+
+    def _get_bytes(self, url: str) -> bytes | None:
+        if not self._cookies:
+            raise ShiftboardError("not authenticated; call authenticate() first")
+        with httpx.Client(
+            headers=_HEADERS, cookies=self._cookies, timeout=self._timeout,
+        ) as client:
+            resp = client.get(url, follow_redirects=True)
+            final_url = str(resp.url)
+            if "/errors/" in final_url or resp.status_code >= 400:
+                logger.error("GET %s -> %s (final %s)", url, resp.status_code, final_url)
+                return None
+            return resp.content
+
+    def _post(self, url: str, data: dict) -> bool:
+        if not self._cookies:
+            raise ShiftboardError("not authenticated; call authenticate() first")
+        with httpx.Client(
+            headers=_HEADERS, cookies=self._cookies, timeout=self._timeout,
+            follow_redirects=False,
+        ) as client:
+            resp = client.post(url, data=data)
+            if resp.status_code in (301, 302, 303, 307, 308):
+                location = resp.headers.get("location", "")
+                if any(s in location for s in ("/errors/", "403", "404", "login")):
+                    logger.error("POST %s -> redirect to %s", url, location)
+                    return False
+                # Following redirect counts as success; Shiftboard form actions
+                # typically redirect to the same admin page on success.
+                return True
+            if resp.status_code < 400:
+                return True
+            logger.error("POST %s -> status %s", url, resp.status_code)
+            return False
+
+    def download_profiles(self, group_id: int = CENSUS_TEAM_GROUP) -> list[dict[str, Any]]:
+        """Download + parse the profile XLSX for a given group.
+
+        Despite the URL implying an "Excel" download, the response is a real
+        binary xlsx (ZIP archive starting with PK\\x03\\x04), not TSV.
+        """
+        url = (
+            "https://www.shiftboard.com/servola/reporting/report.cgi"
+            f"?download=1&type=profile&uncrypt=1&profile_type_id=1"
+            f"&group={group_id}&ss={self._ss}"
+        )
+        content = self._get_bytes(url)
+        if not content:
+            raise ShiftboardError(f"download_profiles({group_id}) returned empty content")
+        return _parse_profile_xlsx(content)
+
+    # ----------------------------------------------------- group membership
+
+    def add_member_to_census(self, shiftboard_id: int) -> bool:
+        """Move a volunteer into the Active Census Team group."""
+        # Shiftboard's group-membership admin endpoint POSTs to security.cgi
+        # with form fields matching the admin UI. See censusload.php
+        # addmembers() for the original PHP version.
+        url = "https://www.shiftboard.com/servola/admin/security.cgi"
+        return self._post(url, {
+            "group": str(CENSUS_TEAM_GROUP),
+            "memnum": str(shiftboard_id),
+            "ss": self._ss,
+            "action": "add_member",
+        })
+
+    def remove_member_from_intake(self, shiftboard_id: int) -> bool:
+        """Remove a volunteer from the Intake group."""
+        url = "https://www.shiftboard.com/servola/admin/security.cgi"
+        return self._post(url, {
+            "group": str(INTAKE_GROUP),
+            "memnum": str(shiftboard_id),
+            "ss": self._ss,
+            "action": "remove_member",
+        })
+
+
+# --------------------------------------------------------- TSV parsing
+
+def _parse_profile_xlsx(content: bytes) -> list[dict[str, Any]]:
+    """Parse Shiftboard's xlsx-formatted profile export.
+
+    Column names from Shiftboard's standard "profile" report. If they
+    change upstream, normalize_keys() is where to look.
+    """
+    profiles: list[dict[str, Any]] = []
+    wb = openpyxl.load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+    ws = wb.active
+    rows_iter = ws.iter_rows(values_only=True)
+    try:
+        header = [str(c).strip() if c is not None else "" for c in next(rows_iter)]
+    except StopIteration:
+        return profiles
+    for raw in rows_iter:
+        row = {header[i]: raw[i] for i in range(min(len(header), len(raw)))}
+        sb_id = _to_int(row.get("Shiftboard ID"))
+        if not sb_id:
+            continue
+        email = _to_str(
+            row.get("Email") or row.get("Receives Email") or ""
+        ).strip().lower()
+        if not email:
+            continue
+        playaname = _to_str(
+            row.get("Playa Name/AKA")
+            or row.get("Playa Name")
+            or row.get("AKA")
+            or ""
+        )
+        profiles.append({
+            "shiftboard_id": sb_id,
+            "playaname": playaname,
+            "first": _to_str(row.get("First Name")),
+            "last": _to_str(row.get("Last Name")),
+            "standing": _to_str(row.get("Standing")),
+            "email": email,
+            "phone_mobile": _to_str(row.get("Mobile Phone")),
+            "phone_home": _to_str(row.get("Home Phone")),
+            "address": _to_str(row.get("Address")),
+            "city": _to_str(row.get("City")),
+            "state": _to_str(row.get("State")),
+            "country": _to_str(row.get("Country")),
+            "zip": _to_str(row.get("Zip")),
+            "last_updated": _to_str(row.get("Last Updated")) or None,
+        })
+    wb.close()
+    return profiles
+
+
+def _to_int(v: Any) -> int:
+    if v is None:
+        return 0
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _to_str(v: Any) -> str:
+    if v is None:
+        return ""
+    return str(v).strip()


### PR DESCRIPTION
Code that's already running on the prod EC2 box (`~mew/census-etl/`, every 4h via cron). Committing it here so it lives in source control next to the deploy runbook.

## Contents
- `etl/shiftboard_client.py` — standalone Shiftboard client (auth + xlsx profile download/parse). Lifted from `census-python/app/services/shiftboard_service.py` minus the SQLAlchemy/FastAPI dependencies.
- `etl/etl_sb_pinfo.py` — Phase 2 ETL: pulls Active Census Team + Intake group profiles, dedupes, SCD2-upserts into `sb_pinfo`.
- `etl/secrets/etl.env.example` — env template (real creds gitignored).
- `etl/README.md` — layout, cron schedule, what's deployed, Phase 3 (intake/welcome) is pending.

## Verified
- First real run on 2026-05-31: 1926 profiles fetched, deduped to 1862, 65 new ids inserted, 9 historical email changes closed out, 0 errors.
- Cron scheduled: every 4h at `02,06,10,14,18,22 :00 UTC` (offset 2h from OnPlayaData dump).
- Logs to `~/etl-sb-pinfo.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)