### PR TITLE
feat(okta): resolve canonical shiftboard_id via sb_pinfo before creating new account

### DIFF
--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -290,7 +290,7 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
       );
     }
 
-    // 2. check by email
+    // 2. check by email on op_volunteers
     if (!shiftboardId) {
       const [byEmail] = await pool.query<RowDataPacket[]>(
         "SELECT shiftboard_id FROM op_volunteers WHERE email=?",
@@ -309,7 +309,67 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
       }
     }
 
-    // 3. create new volunteer
+    // 3. check by email in sb_pinfo (Shiftboard email history, SCD2).
+    //    This catches the case where the BM volunteer record exists with
+    //    a canonical shiftboard_id but the row has never been imported
+    //    into op_volunteers yet (or never been linked to Okta). The lookup
+    //    matches any historical email -- it preferes the current row
+    //    (valid_to IS NULL) but falls back to the most recently valid
+    //    historical row if the user's Okta email is an older one.
+    //
+    //    Wrapped in try/catch so deployments that don't have sb_pinfo yet
+    //    (e.g. on-playa boxes) fall through to the create-new branch.
+    if (!shiftboardId) {
+      try {
+        const [bySbPinfo] = await pool.query<RowDataPacket[]>(
+          `SELECT shiftboard_id FROM sb_pinfo
+           WHERE email=?
+           ORDER BY (valid_to IS NULL) DESC, valid_from DESC
+           LIMIT 1`,
+          [email]
+        );
+        if (bySbPinfo.length > 0) {
+          const canonicalId = bySbPinfo[0].shiftboard_id;
+
+          // Does op_volunteers already have this canonical id (e.g. from
+          // a prior DB seed) but with no Okta link yet? Link and sync.
+          const [existingByCanonical] = await pool.query<RowDataPacket[]>(
+            "SELECT shiftboard_id FROM op_volunteers WHERE shiftboard_id=?",
+            [canonicalId]
+          );
+          if (existingByCanonical.length > 0) {
+            shiftboardId = canonicalId;
+            await pool.query(
+              `UPDATE op_volunteers
+              SET okta_id=?, playa_name=?, world_name=?, email=?
+              WHERE shiftboard_id=?`,
+              [oktaId, playaName, worldName, email, shiftboardId]
+            );
+          } else {
+            // Canonical id known from Shiftboard history but no row exists
+            // here yet -- create one using the canonical id (NOT a random
+            // generateId) so we stay consistent with the rest of the
+            // Census ecosystem.
+            await pool.query<RowDataPacket[]>(
+              `INSERT INTO op_volunteers (
+                shiftboard_id, playa_name, world_name, email, okta_id, create_volunteer
+              ) VALUES (?, ?, ?, ?, ?, true)`,
+              [canonicalId, playaName, worldName, email, oktaId]
+            );
+            shiftboardId = canonicalId;
+          }
+        }
+      } catch (sbErr) {
+        // sb_pinfo missing or query failed -- not fatal, fall through to
+        // creating a new volunteer with a generated id below.
+        console.warn(
+          "sb_pinfo lookup skipped:",
+          sbErr instanceof Error ? sbErr.message : sbErr
+        );
+      }
+    }
+
+    // 4. create new volunteer with a generated id
     if (!shiftboardId) {
       const newId = generateId(`
         SELECT shiftboard_id


### PR DESCRIPTION
This is the same change that's been running on the **test server** via PR #381 (merged into `deploy/test-bundle`) for the past day. It needs to land on `main` too so prod actually runs it — prod was redeployed off `main` after #381, so the sb_pinfo lookup isn't currently active on `volunteers.census.burningman.org`.

## What it does
Inserts a third lookup step in the Okta callback chain:
1. `op_volunteers` by `okta_id` *(existing)*
2. `op_volunteers` by `email` *(existing)*
3. **`sb_pinfo` by `email` — any historical match, current preferred *(this)***
4. `INSERT op_volunteers` with random `generateId()` *(existing fallback)*

When step 3 finds the canonical id, it either links an existing `op_volunteers` row (if one exists for that id) or INSERTs a new row using the canonical id directly — never a random one.

Wrapped in try/catch so deployments without `sb_pinfo` (test box, on-playa) silently fall through to step 4.

## Why now
- `sb_pinfo` table is live on prod RDS (4178 rows / 4069 distinct ids).
- Phase 2 ETL cron is updating it every 4h.
- Without this PR shipping to main, prod is keeping the table fresh but reading nothing from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)