### PR TITLE
fix(session): clear stale client state when census-session cookie is gone

### DIFF
--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -3,6 +3,7 @@ import { ReactNode, useContext } from "react";
 import { DeveloperCard } from "@/components/layout/developer-card";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
+import { useSessionValidation } from "@/hooks/useSessionValidation";
 import { DeveloperModeContext } from "@/state/developer-mode/context";
 
 interface ILayoutProps {
@@ -18,6 +19,10 @@ export const Layout = ({ children }: ILayoutProps) => {
       dateTime: { isEnabled: isDateTimeEnabled },
     },
   } = useContext(DeveloperModeContext);
+
+  // One-shot stale-session detector — runs once per app mount, clears
+  // client state if the cookie has expired (issue #389).
+  useSessionValidation();
 
   // render
   // ------------------------------------------------------------

--- a/client/src/hooks/useSessionValidation.ts
+++ b/client/src/hooks/useSessionValidation.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useContext, useEffect } from "react";
+
+import { SESSION_SIGN_OUT } from "@/constants";
+import { SessionContext } from "@/state/session/context";
+
+// Detect a stale client-side session: SessionContext / localStorage says
+// the user is authenticated, but the actual HMAC-signed cookie has
+// expired or been cleared. Without this, the UI keeps rendering the
+// authenticated branch (e.g. Home's "Welcome — view your account"
+// button) and the user gets stuck in a spinner when they click anything
+// that needs the cookie.
+//
+// Approach: on mount, when client state claims authenticated, fire one
+// quiet GET to /api/auth/session. If 401, silently sign out client-side
+// (no snackbar, no redirect) so the next render picks the unauth UI
+// branch. If 200 / network error, do nothing — false positives here
+// would log healthy users out.
+//
+// One-shot per mount; not a heartbeat. The bug only manifests when
+// state is already stale at first render, and a heartbeat opens up
+// false-positive risk (transient API errors logging users out).
+//
+// See issue #389.
+export const useSessionValidation = () => {
+  const {
+    sessionDispatch,
+    sessionState: {
+      settings: { isAuthenticated },
+    },
+  } = useContext(SessionContext);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    fetch("/api/auth/session", { credentials: "same-origin" })
+      .then((res) => {
+        if (cancelled) return;
+        if (res.status === 401) {
+          sessionDispatch({ type: SESSION_SIGN_OUT });
+        }
+      })
+      .catch(() => {
+        // Network errors: leave client state alone. Better to keep a
+        // healthy user signed in than to bounce them on a transient
+        // blip.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, sessionDispatch]);
+};

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -31,6 +31,12 @@ const ALLOWLIST = [
   "/api/auth/okta",
   "/api/auth/okta/callback",
   "/api/auth/sign-out",
+  // /api/auth/session is the cookie-validity probe used by
+  // useSessionValidation to keep client SessionContext in sync with
+  // the actual cookie. Must reach the handler (which returns 401 on
+  // missing/bad cookie) — middleware can't 401 first or the client
+  // can't distinguish stale state from genuinely-no-cookie.
+  "/api/auth/session",
   "/auth/complete",
 
   // Public information pages (per Mew, 2026-05-06)

--- a/client/src/pages/api/auth/session.ts
+++ b/client/src/pages/api/auth/session.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withAuth } from "@/lib/withAuth";
+
+// GET /api/auth/session — returns 200 + shiftboardId if the
+// census-session cookie is currently valid, 401 otherwise.
+//
+// Purpose: let the client cheaply detect "client state thinks signed in
+// but the server-side cookie is gone" so it can clear stale React /
+// localStorage state and stop rendering the authenticated branch of
+// the UI. See issue #389.
+//
+// No database hit — withAuth already verified the HMAC, so we can
+// return the session shape immediately.
+const sessionHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
+  if (req.method !== "GET") {
+    return res.status(404).json({ statusCode: 404, message: "Not found" });
+  }
+  return res.status(200).json({
+    statusCode: 200,
+    shiftboardId: session.shiftboardId,
+  });
+};
+
+export default withAuth(sessionHandler);


### PR DESCRIPTION
Closes #389.

## Bug
Surfaced by Mew 2026-06-01 after PR #352 made Home auth-state-aware. When `SessionContext` (persisted in localStorage) outlives the server-side `census-session` cookie, the UI gets stuck in a half-state:
1. Home renders the "Welcome — view your account" branch (client state says authenticated).
2. Click routes to `/volunteers/<id>/info`.
3. Middleware sees no cookie → 307 → `/sign-in?returnTo=/info`.
4. `/sign-in` reads SessionContext (still "authenticated"), enters a loading branch → spinner that never resolves.

## Fix
Three pieces:

1. **New endpoint `GET /api/auth/session`** — `withAuth`-wrapped, returns `200 { shiftboardId }` if cookie valid, `401` otherwise. Cheap probe — no DB hit, withAuth already verified the HMAC.
2. **Middleware** allowlists `/api/auth/session` so middleware's 401 doesn't preempt the cookie-validity check.
3. **New hook `useSessionValidation`** runs once at `Layout.tsx` mount. If client claims authenticated AND probe returns 401, silently `SESSION_SIGN_OUT` to bring client state in sync. No snackbar, no redirect — next render of auth-aware components picks the unauth branch automatically.

One-shot per mount, deliberately not a heartbeat — the bug only manifests when state is already stale at first render; a periodic re-check would open false-positive risk (transient API blips logging users out).

## Test plan
- Reproduce: sign in, then in DevTools delete the `census-session` cookie but leave localStorage intact. Reload Home → renders the unauth branch (login button), not "Welcome —".
- Cookie still valid → no spurious sign-outs, no extra request noise after the first mount.
- Network error to /api/auth/session → user stays signed in (don't bounce healthy users on transient errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)