### PR TITLE
feat(mail): collapse add+remove pair when the add hasn't shipped yet

### DIFF
--- a/client/lib/mail/index.ts
+++ b/client/lib/mail/index.ts
@@ -1,6 +1,9 @@
 import { pool } from "../database";
 
-import { enqueueEmail as enqueueEmailRaw } from "./queue";
+import {
+  enqueueEmail as enqueueEmailRaw,
+  supersedeQueuedByDedupeKey as supersedeQueuedByDedupeKeyRaw,
+} from "./queue";
 import { createMysqlStore } from "./store";
 import { selectTransport } from "./transport";
 import type { EnqueueArgs, MailConfig } from "./types";
@@ -43,6 +46,17 @@ export async function enqueueEmail(
   args: EnqueueArgs
 ): Promise<{ id: number; skipped?: boolean }> {
   return enqueueEmailRaw(pool, config(), args);
+}
+
+// Mark queued rows with this (dedupe_key, to) as superseded without
+// sending. Returns affected row count. Callers use this to collapse
+// add+remove pairs that resolved before the add actually shipped —
+// see queue.ts for the contract and #391 for the design.
+export async function supersedeQueuedByDedupeKey(
+  dedupeKey: string,
+  to: string
+): Promise<number> {
+  return supersedeQueuedByDedupeKeyRaw(pool, dedupeKey, to);
 }
 
 // Idempotent: instrumentation.ts calls this on cold start. Safe to call

--- a/client/lib/mail/queue.ts
+++ b/client/lib/mail/queue.ts
@@ -75,8 +75,8 @@ export async function enqueueEmail(
   const [result] = await pool.execute<ResultSetHeader>(
     `INSERT INTO op_email_queue
       (\`to\`, cc, reply_to, \`from\`, subject, body_text, body_html,
-       ics_attachment, ics_filename, category)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       ics_attachment, ics_filename, category, dedupe_key)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       to,
       joinAddrs(args.cc),
@@ -88,9 +88,42 @@ export async function enqueueEmail(
       args.ics?.content ?? null,
       args.ics?.filename ?? null,
       args.category,
+      args.dedupeKey ?? null,
     ]
   );
   return { id: result.insertId };
+}
+
+// Mark every still-queued row with this dedupe_key + recipient as
+// "sent" without actually sending. Returns the count of rows
+// superseded. Per Mew (#391): a volunteer adds-then-removes themselves
+// from a shift before the assignment email has actually shipped — both
+// the queued add (and the upcoming remove) are noise. The caller's
+// pattern is:
+//
+//   const superseded = await supersedeQueuedByDedupeKey(pool, key, to);
+//   if (superseded > 0) return;                  // collapsed pair
+//   await enqueueEmail({ ..., dedupeKey: key }); // ship removal
+//
+// Matching on (dedupe_key, `to`) so producers from different recipients
+// can't accidentally collide if they happen to pick the same key
+// scheme.
+export async function supersedeQueuedByDedupeKey(
+  pool: Pool,
+  dedupeKey: string,
+  to: string
+): Promise<number> {
+  const [result] = await pool.execute<ResultSetHeader>(
+    `UPDATE op_email_queue
+        SET state='sent',
+            sent_at=NOW(),
+            last_error='superseded by paired enqueue'
+      WHERE dedupe_key = ?
+        AND \`to\` = ?
+        AND state = 'queued'`,
+    [dedupeKey, to]
+  );
+  return result.affectedRows;
 }
 
 interface QueueRowPacket extends RowDataPacket {

--- a/client/lib/mail/types.ts
+++ b/client/lib/mail/types.ts
@@ -15,6 +15,13 @@ export interface EnqueueArgs {
   // mail (e.g. critical-drop notifications to the VC list, contact-form
   // sends) where opt-out doesn't apply.
   recipientShiftboardId?: number;
+  // Optional collapse key — paired enqueues (e.g. assignment + removal
+  // for the same volunteer × shift) can share a key. When the second
+  // enqueue arrives, callers can supersedeQueuedByDedupeKey first to
+  // wipe out the still-queued first email — keeps the inbox quiet for
+  // adds that the volunteer reversed before anything actually sent.
+  // See #391.
+  dedupeKey?: string;
 }
 
 export interface EmailRow {

--- a/client/src/components/api/assignmentNotify.ts
+++ b/client/src/components/api/assignmentNotify.ts
@@ -1,7 +1,15 @@
 import type { Pool } from "mysql2/promise";
 import type { RowDataPacket } from "mysql2";
 
-import { enqueueEmail } from "lib/mail";
+import { enqueueEmail, supersedeQueuedByDedupeKey } from "lib/mail";
+
+// Pair-key shared by the assignment + removal enqueues for one
+// volunteer × position assignment. When a removal arrives, the queue
+// uses this to find any still-queued assignment for the same key and
+// collapse the pair (mark them sent without actually sending) — see
+// #391.
+const assignmentDedupeKey = (shiftboardId: number, timePositionId: number) =>
+  `assign:${shiftboardId}:${timePositionId}`;
 
 // #309 — when a volunteer is assigned to a shift (admin or self),
 // email them with the details + an .ics so the event lands in their
@@ -311,6 +319,7 @@ export async function notifyAssignment(
         }
       : undefined,
     category: "assignment",
+    dedupeKey: assignmentDedupeKey(shiftboardId, timePositionId),
   });
 }
 
@@ -407,6 +416,20 @@ export async function notifyRemoval(
         })
       : null;
 
+  // Collapse with the paired assignment if it's still queued (#391).
+  // When the assignment never actually shipped, neither the calendar
+  // nor any inbox knows about it — so the removal email is noise.
+  // If the assignment already drained, supersedeQueuedByDedupeKey
+  // returns 0 and we fall through to enqueue the removal normally.
+  const dedupeKey = assignmentDedupeKey(shiftboardId, Number(timePositionId));
+  const superseded = await supersedeQueuedByDedupeKey(dedupeKey, ctx.email);
+  if (superseded > 0) {
+    console.warn(
+      `[assign-notify] collapsed pair: shiftboard_id=${shiftboardId} time_position_id=${timePositionId} (${superseded} row(s) superseded)`
+    );
+    return;
+  }
+
   await enqueueEmail({
     to: ctx.email,
     recipientShiftboardId: shiftboardId,
@@ -420,6 +443,7 @@ export async function notifyRemoval(
       : undefined,
     category:
       cause.kind === "shift-canceled" ? "shift-canceled" : "removal",
+    dedupeKey,
   });
 }
 

--- a/migrations/004_email_queue_dedupe_key.sql
+++ b/migrations/004_email_queue_dedupe_key.sql
@@ -1,0 +1,23 @@
+-- Adds dedupe_key to op_email_queue so an enqueueing producer can
+-- collapse its own already-queued-but-not-yet-sent rows. See #391.
+--
+-- Use case (initial): a volunteer adds themselves to a shift, then
+-- removes themselves before the "assignment" email has actually been
+-- sent. Both rows can be collapsed — no inbox noise for a state that
+-- resolved itself. If the assignment already sent, the removal still
+-- needs to ship so the volunteer's calendar drops the event.
+--
+-- Convention for assignment/removal dedupe_key:
+--   `${shiftboard_id}:${time_position_id}`
+-- (Generic free-form string; future callers can pick their own format
+-- as long as both sides of a pair use the same value.)
+--
+-- Idempotent: safe to re-run.
+
+ALTER TABLE `op_email_queue`
+  ADD COLUMN IF NOT EXISTS `dedupe_key` VARCHAR(128) NULL AFTER `category`;
+
+-- Index to make the lookup-and-supersede path cheap. Includes state so
+-- we only scan queued rows.
+ALTER TABLE `op_email_queue`
+  ADD KEY IF NOT EXISTS `idx_dedupe_state` (`dedupe_key`, `state`);


### PR DESCRIPTION
Closes #391. Per Mew (Discord, 2026-06-01).

When a volunteer adds themselves to a shift and removes themselves again before the assignment email actually drains the queue (rate cap is 100/day, so this happens often), both rows now collapse to `state='sent'` without firing — no inbox noise for a state that resolved itself. Once the assignment has actually shipped, the removal still goes out so the volunteer's calendar drops the event.

## Pieces

1. **migrations/004_email_queue_dedupe_key.sql** — adds `dedupe_key VARCHAR(128) NULL` + `idx_dedupe_state (dedupe_key, state)` to `op_email_queue`. Idempotent (`IF NOT EXISTS`).

2. **client/lib/mail/queue.ts** — new `supersedeQueuedByDedupeKey(pool, key, to)` helper. Flips matching `(dedupe_key, to, state='queued')` rows to `state='sent' / sent_at=NOW() / last_error='superseded by paired enqueue'`. Returns affected row count. `enqueueEmail` now persists the optional `dedupeKey`.

3. **client/lib/mail/index.ts** — re-exports `supersedeQueuedByDedupeKey` so callers don't pass the pool.

4. **client/lib/mail/types.ts** — `EnqueueArgs.dedupeKey?: string`.

5. **client/src/components/api/assignmentNotify.ts** — local `assignmentDedupeKey(shiftboard, timePosition)` helper. Assignment enqueues set it; removal enqueues call `supersedeQueuedByDedupeKey` first and bail if anything collapsed.

## Migration order
Run `004_email_queue_dedupe_key.sql` on prod **before** deploying. The new column appears in the assignment-INSERT column list, so deploying first would error.

```sql
ALTER TABLE op_email_queue
  ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(128) NULL AFTER category;
ALTER TABLE op_email_queue
  ADD KEY IF NOT EXISTS idx_dedupe_state (dedupe_key, state);
```

## Test plan
- Add self to a shift, immediately remove self → both rows land in state='sent' with `last_error='superseded by paired enqueue'`; no email actually ships.
- Add self, wait for the assignment to drain (worker sends), then remove → removal ships normally (no collapse since no queued add to find).
- Two different volunteers, same time position: each one's add+remove collapses independently — no cross-contamination.
- Existing single-direction assignment emails still send unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)