### PR TITLE
ui(email): "About this shift type:" → "About this shift:"

### DIFF
--- a/client/src/components/api/assignmentNotify.ts
+++ b/client/src/components/api/assignmentNotify.ts
@@ -207,7 +207,7 @@ function renderShiftBody(
     );
   }
   if (notBlank(ctx.shift_details)) {
-    lines.push("", "About this shift type:", `  ${ctx.shift_details.trim()}`);
+    lines.push("", "About this shift:", `  ${ctx.shift_details.trim()}`);
   }
   if (notBlank(ctx.position_details)) {
     lines.push("", "About this position:", `  ${ctx.position_details.trim()}`);


### PR DESCRIPTION
Per Simcard via Mew (Discord, 2026-06-02). One label drop in renderShiftBody, applies to both assignment and removal emails since they share the renderer.