### PR TITLE
ui(shifts): rename Shifts → Assigned Shifts on /info + Census Shifts on /shifts

### DIFF
--- a/client/src/app/shifts/Shifts.tsx
+++ b/client/src/app/shifts/Shifts.tsx
@@ -373,7 +373,7 @@ export const Shifts = () => {
           backgroundImage: "url(/banners/databeast-volunteers-exiting.jpg)",
           backgroundSize: "cover",
         }}
-        text="Shifts"
+        text="Census Shifts"
       />
       <Container component="main">
         <Box component="section">

--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
@@ -238,7 +238,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     return (
       <>
         <Typography component="h2" sx={{ mb: 1 }} variant="h4">
-          Shifts
+          Assigned Shifts
         </Typography>
         <ErrorAlert />
       </>
@@ -247,7 +247,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     return (
       <>
         <Typography component="h2" sx={{ mb: 1 }} variant="h4">
-          Shifts
+          Assigned Shifts
         </Typography>
         <Loading />
       </>
@@ -573,7 +573,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
         sx={{ mb: 2 }}
       >
         <Typography component="h2" variant="h4">
-          Shifts
+          Assigned Shifts
         </Typography>
         <Button
           onClick={() => {
@@ -583,7 +583,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
           type="button"
           variant="contained"
         >
-          Add shift
+          View Census Shifts
         </Button>
       </Stack>
       <DataTable


### PR DESCRIPTION
Per Simcard via Mew (Discord, 2026-06-02). "Shifts" is too generic now that other departments are adopting this system.

- `VolunteerShifts.tsx` × 3 sites: heading "Shifts" → "Assigned Shifts"
- `VolunteerShifts.tsx`: button "Add shift" → "View Census Shifts"
- `Shifts.tsx` Hero: `text="Shifts"` → `text="Census Shifts"`

Drawer menu label "Shifts" left alone — separate decision since on-playa walk-up flow also uses it.