### PR TITLE
fix(shifts): write time_text columns on save + event-day dropdown in time dialog

### DIFF
--- a/client/src/app/shifts/types/type/ShiftTypesForm.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesForm.tsx
@@ -266,8 +266,6 @@ export const ShiftTypesForm = ({
     dateNameMap[dayjs(date).format("YYYY-MM-DD")] = name;
   });
 
-  // logic
-  // ------------------------------------------------------------
   const handlePositionAdd = ({
     alias,
     name,

--- a/client/src/app/shifts/types/type/ShiftTypesForm.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesForm.tsx
@@ -24,7 +24,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { DatePicker, TimePicker } from "@mui/x-date-pickers";
+import { TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import dayjs from "dayjs";
@@ -44,6 +44,7 @@ import {
   UseFormSetValue,
   UseFormWatch,
 } from "react-hook-form";
+import useSWR from "swr";
 
 import {
   IFormValues,
@@ -54,12 +55,14 @@ import { ShiftTypesPositionDialogAdd } from "@/app/shifts/types/type/ShiftTypesP
 import { ShiftTypesTimeDialogAdd } from "@/app/shifts/types/type/ShiftTypesTimeDialogAdd";
 import { ShiftTypesTimeDialogUpdate } from "@/app/shifts/types/type/ShiftTypesTimeDialogUpdate";
 import { SnackbarText } from "@/components/general/SnackbarText";
+import { IResDateRowItem } from "@/components/types/dates";
 import type {
   IResShiftTypeCategoryItem,
   IResShiftTypeDefaults,
 } from "@/components/types/shifts/types";
 import { COLOR_BURNING_MAN_BROWN, MEAL_LIST } from "@/constants";
 import { ensure } from "@/utils/ensure";
+import { fetcherGet } from "@/utils/fetcher";
 import { formatDateName, formatTime } from "@/utils/formatDateTime";
 
 dayjs.extend(utc);
@@ -242,9 +245,26 @@ export const ShiftTypesForm = ({
   });
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
+  // fetcher
+  // ------------------------------------------------------------
+  // event days from the Dates table — used to label saved time rows with
+  // the day name (e.g. "Aug 30 - OpenSun"); the time dialog offers these
+  // same days as a dropdown
+  const { data: dateList }: { data: IResDateRowItem[] | undefined } = useSWR(
+    "/api/dates",
+    fetcherGet
+  );
+
   // other hooks
   // ------------------------------------------------------------
   const { enqueueSnackbar } = useSnackbar();
+
+  // logic
+  // ------------------------------------------------------------
+  const dateNameMap: { [date: string]: string } = {};
+  (dateList ?? []).forEach(({ date, name }) => {
+    dateNameMap[dayjs(date).format("YYYY-MM-DD")] = name;
+  });
 
   // logic
   // ------------------------------------------------------------
@@ -771,20 +791,23 @@ export const ShiftTypesForm = ({
                         control={control}
                         name={`timeList.${timeIndex}.date`}
                         render={({ field: { value } }) => (
-                          <LocalizationProvider dateAdapter={AdapterDayjs}>
-                            <DatePicker
-                              disabled
-                              label="Date"
-                              slotProps={{
-                                textField: {
-                                  fullWidth: true,
-                                  required: true,
-                                  variant: "standard",
-                                },
-                              }}
-                              value={dayjs(value)}
-                            />
-                          </LocalizationProvider>
+                          <TextField
+                            disabled
+                            fullWidth
+                            label="Day"
+                            required
+                            value={
+                              value
+                                ? formatDateName(
+                                    value,
+                                    dateNameMap[
+                                      dayjs(value).format("YYYY-MM-DD")
+                                    ]
+                                  )
+                                : ""
+                            }
+                            variant="standard"
+                          />
                         )}
                       />
                     </Grid>

--- a/client/src/app/shifts/types/type/ShiftTypesTimeDialogAdd.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesTimeDialogAdd.tsx
@@ -91,7 +91,7 @@ export const ShiftTypesTimeDialogAdd = ({
             if (getValues("timeAdd.date") === "") {
               setError("timeAdd.date", {
                 type: "required",
-                message: "Date is required",
+                message: "Day is required",
               });
             }
             if (getValues("timeAdd.startTime") === "") {

--- a/client/src/app/shifts/types/type/ShiftTypesTimeDialogForm.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesTimeDialogForm.tsx
@@ -2,6 +2,7 @@ import {
   Checkbox,
   FormControl,
   FormControlLabel,
+  FormHelperText,
   Grid,
   InputLabel,
   MenuItem,
@@ -9,11 +10,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import {
-  DatePicker,
-  LocalizationProvider,
-  TimePicker,
-} from "@mui/x-date-pickers";
+import { LocalizationProvider, TimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import {
@@ -25,9 +22,13 @@ import {
   UseFormGetValues,
   UseFormSetError,
 } from "react-hook-form";
+import useSWR from "swr";
 
 import { IFormValues } from "@/app/shifts/types/type";
+import { IResDateRowItem } from "@/components/types/dates";
 import { MEAL_LIST } from "@/constants";
+import { fetcherGet } from "@/utils/fetcher";
+import { formatDateName } from "@/utils/formatDateTime";
 
 interface IShiftTypesTimeDialogFormProps {
   clearErrors: UseFormClearErrors<IFormValues>;
@@ -56,6 +57,26 @@ export const ShiftTypesTimeDialogForm = ({
   showCanceledCheckbox = false,
   timePositionListAddFields,
 }: IShiftTypesTimeDialogFormProps) => {
+  // fetcher
+  // ------------------------------------------------------------
+  // event days from the Dates table — the day field is a dropdown of these
+  // instead of a free date picker, so a shift time can only land on a date
+  // that exists in op_dates (anything else orphans the date FKs)
+  const { data: dateList }: { data: IResDateRowItem[] | undefined } = useSWR(
+    "/api/dates",
+    fetcherGet
+  );
+
+  // logic
+  // ------------------------------------------------------------
+  const dateListDisplay = (dateList ?? [])
+    .map(({ date, id, name }) => ({
+      date: dayjs(date).format("YYYY-MM-DD"),
+      id,
+      name,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
   // render
   // ------------------------------------------------------------
   return (
@@ -64,43 +85,49 @@ export const ShiftTypesTimeDialogForm = ({
         <Controller
           control={control}
           name="timeAdd.date"
-          render={({ field: { onChange, value } }) => (
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
-              <DatePicker
-                label="Date"
-                onChange={(event) => {
-                  // update field
-                  onChange(event);
+          render={({ field: { onChange, value } }) => {
+            const valueDisplay = value ? dayjs(value).format("YYYY-MM-DD") : "";
+            const isValueListed = dateListDisplay.some(
+              ({ date }) => date === valueDisplay
+            );
 
-                  if (event) {
+            return (
+              <FormControl
+                error={Boolean(errors.timeAdd?.date)}
+                fullWidth
+                required
+                variant="standard"
+              >
+                <InputLabel id="timeAddDate">Day</InputLabel>
+                <Select
+                  label="Day *"
+                  labelId="timeAddDate"
+                  onChange={(event) => {
+                    // update field
+                    onChange(event.target.value);
                     clearErrors("timeAdd.date");
-                  }
-                }}
-                slotProps={{
-                  textField: {
-                    error: Boolean(errors.timeAdd?.date),
-                    fullWidth: true,
-                    helperText: errors.timeAdd?.date?.message,
-                    onBlur: (
-                      event: React.FocusEvent<
-                        HTMLInputElement | HTMLTextAreaElement
-                      >
-                    ) => {
-                      if (event.target.value === "MM/DD/YYYY") {
-                        setError("timeAdd.date", {
-                          type: "required",
-                          message: "Date is required",
-                        });
-                      }
-                    },
-                    required: true,
-                    variant: "standard",
-                  },
-                }}
-                value={dayjs(value)}
-              />
-            </LocalizationProvider>
-          )}
+                  }}
+                  value={valueDisplay}
+                >
+                  {/* keep a stored date visible even if its op_dates row
+                      has since been removed from the Dates table */}
+                  {!isValueListed && valueDisplay !== "" && (
+                    <MenuItem key={valueDisplay} value={valueDisplay}>
+                      {formatDateName(valueDisplay)}
+                    </MenuItem>
+                  )}
+                  {dateListDisplay.map(({ date, id, name }) => (
+                    <MenuItem key={id} value={date}>
+                      {formatDateName(date, name)}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {errors.timeAdd?.date && (
+                  <FormHelperText>{errors.timeAdd.date.message}</FormHelperText>
+                )}
+              </FormControl>
+            );
+          }}
         />
       </Grid>
       <Grid size={3}>

--- a/client/src/app/shifts/types/type/ShiftTypesTimeDialogUpdate.tsx
+++ b/client/src/app/shifts/types/type/ShiftTypesTimeDialogUpdate.tsx
@@ -89,7 +89,7 @@ export const ShiftTypesTimeDialogUpdate = ({
             if (getValues("timeAdd.date") === "") {
               setError("timeAdd.date", {
                 type: "required",
-                message: "Date is required",
+                message: "Day is required",
               });
             }
             if (getValues("timeAdd.startTime") === "") {

--- a/client/src/pages/api/shifts/types/[typeId]/index.ts
+++ b/client/src/pages/api/shifts/types/[typeId]/index.ts
@@ -288,26 +288,33 @@ const shiftTypeUpdate = async (req: NextApiRequest, res: NextApiResponse) => {
             // Refresh start_date_id / end_date_id alongside the start_time /
             // end_time change — a date edit must update the FK or downstream
             // joins keep pointing at the old date row. See [[fix-handleTimeListAdd]].
+            // start_time_text / end_time_text ("HH:mm") must be written too:
+            // the Shift Types form GET reads ONLY the _text columns, so
+            // skipping them leaves the form's time fields blank/red (#395).
             await pool.query<RowDataPacket[]>(
               `UPDATE op_shift_times
               SET
                 canceled=?,
                 end_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
                 end_time=?,
+                end_time_text=DATE_FORMAT(?, '%H:%i'),
                 meal=?,
                 notes=?,
                 update_shift_time=true,
                 shift_instance=?,
                 start_date_id=(SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
-                start_time=?
+                start_time=?,
+                start_time_text=DATE_FORMAT(?, '%H:%i')
               WHERE shift_times_id=?`,
               [
                 Boolean(canceled),
                 endTime,
                 endTime,
+                endTime,
                 meal === "None" ? "" : meal,
                 notes,
                 instance,
+                startTime,
                 startTime,
                 startTime,
                 timeId,

--- a/client/src/pages/api/shifts/types/index.ts
+++ b/client/src/pages/api/shifts/types/index.ts
@@ -32,27 +32,45 @@ export const handleTimeListAdd = async ({
       // volunteers, etc.) JOINs op_dates via these FKs to get the date label,
       // so a row without them shows up as an orphan with NULL date/datename.
       // Missing date matches resolve to NULL — same as the old behavior.
+      //
+      // start_time_text / end_time_text hold the bare "HH:mm" — the Shift
+      // Types form GET reads ONLY these (not start_time/end_time), so a row
+      // without them renders as blank/red time fields in the form (#395).
       await pool.query(
         `INSERT INTO op_shift_times (
           add_shift_time,
           end_date_id,
           end_time,
+          end_time_text,
           meal,
           notes,
           shift_instance,
           shift_name_id,
           shift_times_id,
           start_date_id,
-          start_time
+          start_time,
+          start_time_text
         )
         VALUES (
           true,
           (SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
-          ?, ?, ?, ?, ?, ?,
+          ?, DATE_FORMAT(?, '%H:%i'), ?, ?, ?, ?, ?,
           (SELECT date_id FROM op_dates WHERE date = DATE(?) AND delete_date = false LIMIT 1),
-          ?
+          ?, DATE_FORMAT(?, '%H:%i')
         )`,
-        [endTime, endTime, meal, notes, instance, typeId, timeIdNew, startTime, startTime]
+        [
+          endTime,
+          endTime,
+          endTime,
+          meal,
+          notes,
+          instance,
+          typeId,
+          timeIdNew,
+          startTime,
+          startTime,
+          startTime,
+        ]
       );
 
       positionList.forEach(async ({ alias, positionId, sapPoints, slots }) => {

--- a/migrations/004_backfill_shift_time_text.sql
+++ b/migrations/004_backfill_shift_time_text.sql
@@ -1,0 +1,26 @@
+-- Migration: backfill start_time_text / end_time_text on op_shift_times (#395).
+--
+-- The Shift Types form GET reads ONLY the _text columns ("HH:mm") since the
+-- date-ID refactor, but the UI save paths (handleTimeListAdd INSERT and the
+-- PATCH timeListUpdate) only wrote the start_time / end_time DATETIME-shaped
+-- varchars. Every shift time created or edited through the UI therefore came
+-- back with blank/red time fields in the form, even though the data was
+-- saved (the /shifts page falls back to start_time, so it looked fine there).
+--
+-- The code fix makes both save paths write the _text columns; this backfills
+-- rows that were created/edited before the fix. start_time / end_time hold
+-- "YYYY-MM-DD HH:mm" strings, so DATE_FORMAT extracts the time portion.
+--
+-- Idempotent: only touches rows where the _text column is NULL or empty.
+
+UPDATE op_shift_times
+SET start_time_text = DATE_FORMAT(start_time, '%H:%i')
+WHERE (start_time_text IS NULL OR start_time_text = '')
+  AND start_time IS NOT NULL
+  AND start_time != '';
+
+UPDATE op_shift_times
+SET end_time_text = DATE_FORMAT(end_time, '%H:%i')
+WHERE (end_time_text IS NULL OR end_time_text = '')
+  AND end_time IS NOT NULL
+  AND end_time != '';


### PR DESCRIPTION
Fixes #395, fixes #397.

## What

**1. Shift Types times no longer come back blank/red (#395)**

Since the date-ID refactor, the Shift Types form GET reads only `start_time_text` / `end_time_text` ("HH:mm") — but the save paths (`handleTimeListAdd` INSERT and the `[typeId]` PATCH `timeListUpdate`) only wrote the DATETIME-shaped `start_time` / `end_time`. Nothing the UI did ever populated the `_text` columns (only the Shiftboard ETL does), so every UI-created/edited time row re-opened as blank/red. The `/shifts` page masked it by falling back to `start_time` (`getShiftList.ts`).

Both save paths now also write the `_text` columns via `DATE_FORMAT(?, '%H:%i')`.

**2. Time dialog: free DatePicker → event-day dropdown (#397)**

The dialog's date field is now a Select fed by `/api/dates` (`op_dates`), labeled "Aug 30 - OpenSun" style. A date that isn't in the Dates table NULLs `start_date_id`/`end_date_id` (the FK subqueries find no row) and orphans the shift time — the dropdown makes that unrepresentable. The read-only time rows in the form show the same "MMM DD - dayname" label. If a stored date is no longer in the Dates table, it still renders as an extra menu entry rather than vanishing.

No wire-format change: the request still sends `startTime`/`endTime` as `"YYYY-MM-DD HH:mm"`, so the API contract and the date-FK subqueries are untouched.

**3. Migration `004_backfill_shift_time_text.sql`**

Idempotent backfill for rows written before the fix (only touches rows where `_text` is NULL/empty). On prod this currently affects the 8 Census Lab Stewardship rows Rescue created (verified: `start_time_text=NULL` on all of them). **Needs a manual run on prod after merge** — same as migrations 001–003.

## Testing

- `npm run build` passes (type-check + all routes compile)
- INSERT and UPDATE SQL shapes executed against a real `op_shift_times` schema in a rolled-back transaction: `_text` columns and both date FKs populate correctly on insert and on date-change update
- Migration executed in a rolled-back transaction against a DB with one known-bad row (`496824`): `still_missing` went 1 → 0, row got `08:30`/`12:30`, rollback clean
- `npm run lint` is currently broken on main (`next lint --fix` — Next 16 dropped the flag), not from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)