### PR TITLE
fix(mail): critical-drop email names the volunteer + who removed them

### DIFF
--- a/client/src/components/api/assignmentNotify.ts
+++ b/client/src/components/api/assignmentNotify.ts
@@ -165,7 +165,7 @@ function shiftIcsUid(
   return `census-shift-${timePositionId}-${shiftboardId}@volunteers.census.burningman.org`;
 }
 
-async function lookupActorDisplayName(
+export async function lookupActorDisplayName(
   pool: Pool,
   actorShiftboardId: number | null
 ): Promise<string | null> {

--- a/client/src/components/api/shiftVolunteers.ts
+++ b/client/src/components/api/shiftVolunteers.ts
@@ -6,14 +6,16 @@ import type { IReqReviewValues, IReqSwitchValues } from "@/components/types";
 import { UPDATE_TYPE_CHECK_IN, UPDATE_TYPE_REVIEW } from "@/constants";
 import { enqueueEmail } from "lib/mail";
 import {
+  lookupActorDisplayName,
   notifyRemoval,
   type RemovalCause,
 } from "@/components/api/assignmentNotify";
 
 // #313 — when a volunteer (self) or admin removes someone from a
 // position with `critical=1`, notify the VC list so they can move on
-// refilling. Pairs with the warning dialog from #308: the volunteer
-// has already acknowledged the gap before this code runs.
+// refilling. The warning dialog from #308 (which would make the
+// volunteer acknowledge the gap before a self-drop) is not built yet,
+// so the email no longer claims a warning was shown (#402).
 const VC_LIST_EMAIL = "censusvolunteercoordinators@burningman.org";
 const APP_BASE_URL =
   process.env.APP_BASE_URL ?? "https://volunteers.census.burningman.org";
@@ -32,7 +34,8 @@ interface CriticalDropContext extends RowDataPacket {
 async function notifyCriticalDrop(
   pool: Pool,
   shiftboardId: number,
-  timePositionId: number
+  timePositionId: number,
+  actorShiftboardId: number | null
 ): Promise<void> {
   const [rows] = await pool.query<CriticalDropContext[]>(
     `SELECT
@@ -65,23 +68,36 @@ async function notifyCriticalDrop(
 
   const dayLabel = ctx.datename ? `${ctx.datename} ${ctx.date}` : ctx.date;
   const timeLabel = ctx.start_time_text ? ` at ${ctx.start_time_text}` : "";
+  // The volunteer whose slot is now open — vs.shiftboard_id is the removed
+  // person, NOT whoever performed the removal.
   const volunteerLabel = ctx.playa_name
     ? `${ctx.playa_name}${ctx.world_name ? ` "${ctx.world_name}"` : ""}`
     : (ctx.world_name ?? `shiftboard_id ${shiftboardId}`);
+
+  // Distinguish a self-drop from an admin/coordinator removal so the CVC
+  // list can tell who is no longer covering the shift AND who took the
+  // action. Per Mew (2026-06-08): name the volunteer, not just the actor.
+  const isSelfDrop =
+    actorShiftboardId == null || actorShiftboardId === shiftboardId;
+  const actorName = isSelfDrop
+    ? null
+    : await lookupActorDisplayName(pool, actorShiftboardId);
+  const removedByLabel = isSelfDrop
+    ? "themselves (self-drop)"
+    : (actorName ?? "an administrator");
 
   await enqueueEmail({
     to: VC_LIST_EMAIL,
     subject: `[Census] CRITICAL OPENING: ${ctx.position} on ${dayLabel}`,
     bodyText: [
-      "A volunteer just dropped a critical position. The slot is now open.",
+      "A critical position is now open and needs to be refilled.",
       "",
       `Position: ${ctx.position}`,
       `Shift: ${dayLabel}${timeLabel}`,
-      `Dropped by: ${volunteerLabel}`,
+      `Volunteer: ${volunteerLabel}`,
+      `Removed by: ${removedByLabel}`,
       "",
       `Manage this shift's volunteers: ${APP_BASE_URL}/shifts/${ctx.shift_times_id}/volunteers`,
-      "",
-      "Note: the volunteer was shown a warning before this drop completed, so they're aware they left a critical gap.",
     ].join("\n"),
     category: "critical-drop",
   });
@@ -181,7 +197,12 @@ export const shiftVolunteerRemove = async (
   // not reachable from this handler — it fires only when the whole
   // shift's `canceled` flag flips, which is its own endpoint.
   try {
-    await notifyCriticalDrop(pool, shiftboardId, timePositionId);
+    await notifyCriticalDrop(
+      pool,
+      shiftboardId,
+      timePositionId,
+      session.shiftboardId
+    );
   } catch (err) {
     console.error(
       `[critical-drop] notifyCriticalDrop failed for shiftboard_id=${shiftboardId} time_position_id=${timePositionId}:`,


### PR DESCRIPTION
Per Mew (Discord, 2026-06-08): the CRITICAL OPENING email should "say who the volunteer was, not just who removed them."

## Problem
The email's `Dropped by: {name}` line was built from the *removed volunteer* (`vs.shiftboard_id`) — correct data, but the "Dropped by" framing reads as if that person self-dropped. When an **admin** removes a volunteer, the email named the volunteer with no indication an admin acted, and never identified the actor.

Real sample Mew flagged:
```
Dropped by: Chipper "Rachel McKay"
```

## Change
```
A critical position is now open and needs to be refilled.

Position: Art Tour Lead
Shift: Thur 2026-09-03 at 19:00
Volunteer: Chipper "Rachel McKay"
Removed by: themselves (self-drop)

Manage this shift's volunteers: https://volunteers.census.burningman.org/shifts/202779/volunteers
```
- **Volunteer:** the person whose slot is now open (unchanged data, clearer label)
- **Removed by:** `themselves (self-drop)` for a self-removal, or the admin's name (falls back to "an administrator") for an admin removal — resolved via the existing `lookupActorDisplayName` helper (now exported), passing `session.shiftboardId` as the actor
- Neutral header since the email fires on admin removals too, not only self-drops

Also **removes the false line** "the volunteer was shown a warning before this drop completed" — the #308 warning dialog isn't built yet, so that claim was untrue (#402). Updated the file's header comment to match.

## Testing
- `npm run build` passes.
- Self-drop vs admin-remove branch verified by reading the call path: `shiftVolunteerRemove` passes `session.shiftboardId`; `isSelfDrop = actorShiftboardId == null || actorShiftboardId === shiftboardId` mirrors the same logic already used for `notifyRemoval`'s RemovalCause.

Partially addresses #402 (removes the false warning claim); the warning dialog itself remains #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)