### PR TITLE
fix(okta): auto-generate passcode on the canonical-id account-creation path

### DIFF
--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -350,12 +350,15 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
             // Canonical id known from Shiftboard history but no row exists
             // here yet -- create one using the canonical id (NOT a random
             // generateId) so we stay consistent with the rest of the
-            // Census ecosystem.
+            // Census ecosystem. Treat them like any other new volunteer
+            // (auto-generate a passcode) -- we just already know their
+            // shiftboard_id. Per Mew 2026-06-10.
+            const passcode = generatePasscode();
             await pool.query<RowDataPacket[]>(
               `INSERT INTO op_volunteers (
-                shiftboard_id, playa_name, world_name, email, okta_id, create_volunteer
-              ) VALUES (?, ?, ?, ?, ?, true)`,
-              [canonicalId, playaName, worldName, email, oktaId]
+                shiftboard_id, playa_name, world_name, email, okta_id, passcode, create_volunteer
+              ) VALUES (?, ?, ?, ?, ?, ?, true)`,
+              [canonicalId, playaName, worldName, email, oktaId, passcode]
             );
             shiftboardId = canonicalId;
           }

--- a/migrations/005_backfill_okta_passcode.sql
+++ b/migrations/005_backfill_okta_passcode.sql
@@ -1,0 +1,21 @@
+-- Migration: backfill missing passcodes left by the Okta path-2 bug.
+--
+-- The Okta callback (client/src/pages/api/auth/okta/callback.ts) has three
+-- account-creation paths. The "canonical shiftboard_id known from Shiftboard
+-- email history (sb_pinfo) but no op_volunteers row yet" path created the
+-- volunteer WITHOUT a passcode, unlike the other two paths (existing rows keep
+-- their imported passcode; truly-new rows auto-generate one). Mew confirmed
+-- (2026-06-10) these should be treated like any other new volunteer and get an
+-- auto-generated 4-digit passcode. The code fix sets it on creation going
+-- forward; this backfills rows already created without one.
+--
+-- generatePasscode() in the app produces a zero-padded 4-digit string
+-- (0000-9999); LPAD(FLOOR(RAND()*10000),4,'0') matches that shape, and RAND()
+-- is evaluated per row so each affected volunteer gets a distinct code.
+--
+-- Idempotent: only touches rows missing a passcode. On prod (2026-06-10) this
+-- affects 2 Okta volunteers.
+
+UPDATE op_volunteers
+SET passcode = LPAD(FLOOR(RAND() * 10000), 4, '0')
+WHERE passcode IS NULL OR TRIM(passcode) = '';


### PR DESCRIPTION
Approved by Mew (Discord, 2026-06-10). Surfaced by a process question from Chipper about how new Okta volunteers get a passcode.

## Problem
The Okta callback (`client/src/pages/api/auth/okta/callback.ts`) creates a volunteer via one of three paths:
1. **Existing op_volunteers row** matched by canonical id → keeps its imported passcode ✓
2. **Canonical shiftboard_id known from sb_pinfo, but no row yet** → INSERT **omitted the passcode column** ⚠️
3. **Truly new** (no canonical id) → `generatePasscode()` auto-generates one ✓

Path 2 left the volunteer with a blank passcode: nothing shown on `/info` and no on-playa tablet PIN sign-in until an admin set one. Inconsistent with both other paths.

## Fix
Path 2 now auto-generates a passcode just like path 3 — same as any new volunteer, we just already know their `shiftboard_id` (Mew: "they should be treated like any other new one except we already have a sbid for them").

## Migration `005_backfill_okta_passcode.sql`
Backfills rows already created without a passcode (`passcode IS NULL OR TRIM(passcode)=''`) with a random 4-digit code (`LPAD(FLOOR(RAND()*10000),4,'0')`, evaluated per row — matches `generatePasscode`'s 0000–9999 shape). **Affects 2 Okta volunteers on prod as of 2026-06-10.** Idempotent. **Needs a manual run on prod after merge** (like migrations 001–003).

## Testing
- `npm run build` passes.
- Migration executed in a rolled-back transaction (valid SQL; local dev DB has 0 affected rows, so a no-op there — the 2 affected rows are on prod).
- Verified on prod that exactly 2 rows are missing a passcode, both Okta users — matching the diagnosed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)