### PR TITLE
fix(security): owner-or-admin gate on /api/volunteers/[id]/* endpoints (#410, #350)

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -794,7 +794,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
         {/* breadcrumbs */}
         <Box sx={{ mb: 3 }}>
           <BreadcrumbsNav>
-            <Link href="/volunteers">Volunteers</Link>
+            {/* Volunteers list is admin-only — don't show the link to
+                non-admins (they'd hit "no permission"). MUI Breadcrumbs
+                drops the falsy child, so no stray separator. */}
+            {isAdmin && <Link href="/volunteers">Volunteers</Link>}
             <Typography>{volunteer.playaName}</Typography>
           </BreadcrumbsNav>
         </Box>

--- a/client/src/lib/authz.ts
+++ b/client/src/lib/authz.ts
@@ -1,0 +1,34 @@
+import type { RowDataPacket } from "mysql2";
+
+import { ROLE_ADMIN_ID, ROLE_SUPER_ADMIN_ID } from "@/constants";
+import { pool } from "lib/database";
+
+// Server-side authorization helpers for the /api/volunteers/[shiftboardId]/*
+// family. `withAuth` already guarantees a valid session (logged in); these add
+// the missing object-level check so a logged-in volunteer can only act on their
+// OWN record, while admins can act on anyone's (the on-playa "admin helps a
+// volunteer" workflow). See #410 (read IDOR) and #350 (passcode write).
+
+// True if the given shiftboard_id holds the Admin or SuperAdmin role.
+export async function isAdmin(shiftboardId: number): Promise<boolean> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT 1
+     FROM op_volunteer_roles
+     WHERE shiftboard_id = ?
+       AND role_id IN (?, ?)
+       AND remove_role = false
+     LIMIT 1`,
+    [shiftboardId, ROLE_ADMIN_ID, ROLE_SUPER_ADMIN_ID]
+  );
+  return rows.length > 0;
+}
+
+// True if the session may act on `requestedShiftboardId`: it's their own
+// record, or they're an admin.
+export async function isOwnerOrAdmin(
+  session: { shiftboardId: number },
+  requestedShiftboardId: number
+): Promise<boolean> {
+  if (session.shiftboardId === requestedShiftboardId) return true;
+  return isAdmin(session.shiftboardId);
+}

--- a/client/src/pages/api/volunteers/[shiftboardId]/account/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/account/index.ts
@@ -7,9 +7,18 @@ import type {
 } from "@/components/types/volunteers";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 
-const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
+const volunteers = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
   const { shiftboardId } = req.query;
+
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
 
   switch (req.method) {
     // get

--- a/client/src/pages/api/volunteers/[shiftboardId]/account/passcode/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/account/passcode/index.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { IReqPasscode } from "@/components/types/volunteers";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 
 const volunteers = async (
   req: NextApiRequest,
@@ -16,9 +17,9 @@ const volunteers = async (
     // get
     // ------------------------------------------------------------
     // Self-only reveal. An admin can SET someone else's passcode (PATCH
-    // below — not gated; see #350 for the broader tightening), but
-    // nobody — including admins — can READ an existing one through this
-    // endpoint. Per Mew 2026-05-25.
+    // below — now owner-or-admin gated, #350), but nobody — including
+    // admins — can READ an existing one through this endpoint.
+    // Per Mew 2026-05-25.
     case "GET": {
       const requestId = Number(shiftboardId);
       if (!session || session.shiftboardId !== requestId) {
@@ -49,6 +50,12 @@ const volunteers = async (
     // patch
     // ------------------------------------------------------------
     case "PATCH": {
+      // Owner-or-admin gate (#350): a volunteer may set their own passcode;
+      // admins may reset anyone's.
+      if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+        return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+      }
+
       // update volunteer passcode
       const { passcode }: IReqPasscode = JSON.parse(req.body);
 

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/components/types/volunteer-info";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 
 // SAP day-by-day requirements keyed by arrival datename.
 // Each entry is either a single datename string, or an array meaning "any of these."
@@ -52,8 +53,18 @@ const PRE_OPEN_DATENAMES = [
   "PreSat",
 ];
 
-const volunteerInfo = async (req: NextApiRequest, res: NextApiResponse) => {
+const volunteerInfo = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
   const { shiftboardId } = req.query;
+
+  // Owner-or-admin gate (#410): being logged in isn't enough — a volunteer may
+  // only read their own record; admins may read anyone's.
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
 
   switch (req.method) {
     // get

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/other-sap/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/other-sap/index.ts
@@ -4,11 +4,20 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { IReqToggleOtherSap } from "@/components/types/volunteer-info";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 
 const ROLE_OTHER_SAP_ID = 2000007;
 
-const otherSap = async (req: NextApiRequest, res: NextApiResponse) => {
+const otherSap = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
   const { shiftboardId } = req.query;
+
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
 
   switch (req.method) {
     // post

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/profile-updated/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/profile-updated/index.ts
@@ -4,11 +4,20 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { IReqToggleProfileUpdated } from "@/components/types/volunteer-info";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 
 const ROLE_BURNER_PROFILE_UPDATED_ID = 2000010;
 
-const profileUpdated = async (req: NextApiRequest, res: NextApiResponse) => {
+const profileUpdated = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
   const { shiftboardId } = req.query;
+
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
 
   switch (req.method) {
     // post

--- a/client/src/pages/api/volunteers/[shiftboardId]/sap/[sapId]/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/sap/[sapId]/index.ts
@@ -6,11 +6,20 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 
 const SAP_FILES_DIR = process.env.SAP_FILES_DIR ?? "/data/census/saps/";
 
-const sapDownload = async (req: NextApiRequest, res: NextApiResponse) => {
+const sapDownload = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
   const { shiftboardId, sapId } = req.query;
+
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
 
   switch (req.method) {
     // get

--- a/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { IResVolunteerShiftItem } from "@/components/types/volunteers";
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
 import {
   shiftVolunteerRemove,
   shiftVolunteerUpdate,
@@ -14,12 +15,17 @@ const volunteerShifts = async (
   res: NextApiResponse,
   session: { shiftboardId: number }
 ) => {
+  const { shiftboardId } = req.query;
+
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
+
   switch (req.method) {
     // get
     // ------------------------------------------------------------
     case "GET": {
       // get all volunteer shifts
-      const { shiftboardId } = req.query;
       const [dbVolunteerShiftList] = await pool.query<RowDataPacket[]>(
         `SELECT
           d.date,

--- a/client/src/pages/api/volunteers/index.ts
+++ b/client/src/pages/api/volunteers/index.ts
@@ -3,8 +3,21 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IResVolunteerShiftCountItem } from "@/components/types/volunteers";
 import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
+import { isAdmin } from "@/lib/authz";
 
-const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
+const volunteers = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
+  // Admin-only: the full volunteer roster is admin data. This endpoint had
+  // NO auth at all — any caller (even unauthenticated) could dump every
+  // volunteer's name/id. Now requires a logged-in admin.
+  if (!(await isAdmin(session.shiftboardId))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
+
   switch (req.method) {
     // get
     // ------------------------------------------------------------
@@ -93,4 +106,4 @@ const volunteers = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default volunteers;
+export default withAuth(volunteers);


### PR DESCRIPTION
Approved by Mew (Discord, 2026-06-13). Closes the IDOR (#410) + passcode-write hole (#350) and the rest of the same family.

## Problem
`withAuth` guaranteed a valid session (logged in) but the volunteer endpoints then served/accepted whatever `shiftboard_id` was in the URL with **no object-level check**. Any logged-in volunteer could read or act on **anyone's** record by editing the id in the URL.

## Fix
New `client/src/lib/authz.ts` (`isAdmin`, `isOwnerOrAdmin`) + a gate on each endpoint **before any DB access**: a volunteer may act only on their own record; **admins may act on anyone's** (preserves the on-playa admin-helps-volunteer workflow — confirmed with Mew).

Gated: `info` (read PII — #410), `account`, `sap/[sapId]` download, `info/other-sap`, `info/profile-updated`, `shifts`, and the `account/passcode` **PATCH** (#350).

Left intentionally owner-only (unchanged): the passcode **GET** reveal (admins can reset but not read passcodes) and `info/email-preference`.

## Testing
- `npm run build` passes.
- Independent security review (subagent): verdict **safe to deploy** — gates fire before access on all 7, `isOwnerOrAdmin` is parameterized + fails closed (NaN/array/leading-zero coercion can't bypass), passcode GET stays owner-only, full directory coverage, 3-arg signature matches `withAuth`. Summary in a comment below.
- Admin workflow preserved (owner **or** admin).

## Follow-up (separate issue)
The review surfaced a **pre-existing** related gap: the shift PATCH/DELETE sub-handlers (`components/api/shiftVolunteers.ts`) act on a `shiftboardId` from the request **body**, not the URL-gated one — filed separately, out of this PR's scope.

Fixes #410, fixes #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)