### PR TITLE
feat(info): "Get more involved" sidebar on the account page (#335)

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/GetInvolved.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/GetInvolved.tsx
@@ -1,0 +1,89 @@
+import { OpenInNew as OpenInNewIcon } from "@mui/icons-material";
+import { Box, Card, CardContent, Link, Stack, Typography } from "@mui/material";
+
+// "Optional: Get more involved with Census" sidebar on the account/info page.
+// Off-playa only (gated by the parent) — the links don't work on the offline
+// on-playa tablets, and volunteers aren't signed into Discord/Google/Hive
+// there anyway (#335). Plain link-cards, not checklist items: these are
+// optional, open-ended ways to stay connected, not tasks with a done state.
+// The Discord invite is a per-page invite that tracks joins on the Discord
+// side, so no in-app tracking is needed.
+
+interface IGetInvolvedItem {
+  title: string;
+  description: string;
+  linkLabel: string;
+  href: string;
+}
+
+const ITEMS: IGetInvolvedItem[] = [
+  {
+    title: "Join the Census Discord",
+    description: "Connect with the Census community year-round.",
+    linkLabel: "Join Discord",
+    href: "https://discord.gg/FqDcF89Ktp",
+  },
+  {
+    title: "Sign up as a DataNerd",
+    description: "Help analyze and visualize Census data.",
+    linkLabel: "Learn more",
+    href: "https://groups.google.com/a/burningman.org/g/censusdatanerds",
+  },
+  {
+    title: "Volunteer year-round",
+    description: "Stay involved with Census beyond the event.",
+    linkLabel: "Learn more",
+    href: "https://groups.google.com/a/burningman.org/g/censusyearround",
+  },
+  {
+    title: "Explore Census Hive",
+    description: "Browse training resources, guides, and more.",
+    linkLabel: "Visit Census Hive",
+    href: "https://hive.burningman.org/spaces/14264554",
+  },
+];
+
+export const GetInvolved = () => {
+  return (
+    <Card sx={{ position: { md: "sticky" }, top: { md: 16 } }}>
+      <CardContent>
+        <Typography
+          component="h2"
+          variant="overline"
+          sx={{ color: "text.secondary", fontWeight: 700, lineHeight: 1.4 }}
+        >
+          Optional: Get more involved with Census
+        </Typography>
+        <Typography color="text.secondary" variant="body2" sx={{ mb: 2 }}>
+          Optional ways to stay connected with Census year-round.
+        </Typography>
+
+        <Stack spacing={2}>
+          {ITEMS.map((item) => (
+            <Box key={item.href}>
+              <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                {item.title}
+              </Typography>
+              <Typography
+                color="text.secondary"
+                variant="body2"
+                sx={{ mb: 0.5 }}
+              >
+                {item.description}
+              </Typography>
+              <Link
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ alignItems: "center", display: "inline-flex", gap: 0.5 }}
+              >
+                {item.linkLabel}
+                <OpenInNewIcon fontSize="inherit" />
+              </Link>
+            </Box>
+          ))}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+};

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -46,6 +46,7 @@ import useSWRMutation from "swr/mutation";
 import { PasscodeDialogUpdate } from "@/app/volunteers/[shiftboardId]/account/PasscodeDialogUpdate";
 import { PasscodeReveal } from "@/app/volunteers/[shiftboardId]/account/PasscodeReveal";
 import { VolunteerShifts } from "@/app/volunteers/[shiftboardId]/account/VolunteerShifts";
+import { GetInvolved } from "@/app/volunteers/[shiftboardId]/info/GetInvolved";
 import { BreadcrumbsNav } from "@/components/general/BreadcrumbsNav";
 import { ErrorPage } from "@/components/general/ErrorPage";
 import { Loading } from "@/components/general/Loading";
@@ -151,6 +152,11 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
   // other volunteers' passcodes (they can still RESET via the Update
   // dialog, just can't read existing values). Per Mew 2026-05-25.
   const isSelfView = shiftboardIdSession === shiftboardId;
+
+  // Off-playa only: the "Get more involved" sidebar links don't work on the
+  // offline on-playa tablets, and volunteers aren't signed into those
+  // accounts there (#335).
+  const isOnPlaya = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
 
   // refs
   // ------------------------------------------------------------
@@ -790,7 +796,9 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
         }}
         text="Account"
       />
-      <Container maxWidth="md">
+      <Container maxWidth="lg">
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: isOnPlaya ? 12 : 8 }}>
         {/* breadcrumbs */}
         <Box sx={{ mb: 3 }}>
           <BreadcrumbsNav>
@@ -1323,6 +1331,13 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
             </Card>
           </Box>
         )}
+          </Grid>
+          {!isOnPlaya && (
+            <Grid size={{ xs: 12, md: 4 }}>
+              <GetInvolved />
+            </Grid>
+          )}
+        </Grid>
       </Container>
 
       {/* passcode update dialog */}


### PR DESCRIPTION
Implements #335, to Chipper's approved mockup + Mew's go-ahead ("tell claude to implement", Discord 2026-06-13).

## What
An **off-playa-only** right-hand sidebar on the account/`info` page, "Optional: Get more involved with Census", with four link-cards (title + one-line description + external link):
- **Join the Census Discord** → tracked per-page invite (`discord.gg/FqDcF89Ktp`) — joins tracked on the Discord side, so no in-app state
- **Sign up as a DataNerd** → censusdatanerds Google Group
- **Volunteer year-round** → censusyearround Google Group
- **Explore Census Hive** → hive.burningman.org space

## Design decisions (settled with Chipper)
- **Link-cards, not checklist items** — these are optional/open-ended, not tasks with a done state; checkboxes would add false task-pressure + persisted state for no payoff (engagement tracking is handled by the Discord invite instead).
- **Off-playa only** (`NEXT_PUBLIC_PIN_ENABLED === "false"`) — links don't work on offline tablets and volunteers aren't signed into those accounts there (#335).
- **Layout**: container widened to `lg`; content + sidebar in a responsive Grid (sidebar `md:4`, stacks below on mobile; content goes full-width on playa when the sidebar is hidden). New `GetInvolved.tsx` component.

## Pending
- **Chipper's copy review** — card text uses the mockup wording; easy to tweak.

## Testing
- `npm run build` passes.
- Independent review to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)