### PR TITLE
fix(info): align get-involved sidebar to the checklist row, not the header

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -797,8 +797,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
         text="Account"
       />
       <Container maxWidth="lg">
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, md: isOnPlaya ? 12 : 8 }}>
+        {/* Header (breadcrumbs + welcome + on-playa/SAP) spans full width.
+            The two-column split with the "get more involved" sidebar
+            begins lower, at the checklist, so the sidebar aligns with the
+            checklist row rather than the page header. */}
         {/* breadcrumbs */}
         <Box sx={{ mb: 3 }}>
           <BreadcrumbsNav>
@@ -953,6 +955,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
           </CardContent>
         </Card>
 
+        {/* main content (checklist and everything below) shares a row with
+            the get-involved sidebar, so the sidebar starts at the checklist */}
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: isOnPlaya ? 12 : 8 }}>
         {/* checklist */}
         <Card sx={{ mb: 3 }}>
           <CardContent>


### PR DESCRIPTION
Follow-up to #416, from Chipper's review of the deployed sidebar.

**Problem:** the "Get more involved" sidebar was a sibling column to the *entire* main column, so on a wide screen it started at the top of the row — right next to the playa-name header — instead of beside the checklist.

**Fix (layout only):** lift the header block (breadcrumbs + welcome card + on-playa/SAP card) to full width directly under the `Container`, and start the two-column `Grid` at the checklist. The sidebar's top now aligns with the checklist row.

- No logic/data changes; `tsc --noEmit` clean.
- Minimal diff (the header/checklist JSX is unchanged apart from where the Grid opens), so it reviews easily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)