### PR TITLE
Re-apply #420 description formatting (Chipper's decision to keep)

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -35,6 +35,7 @@ import { io } from "socket.io-client";
 import useSWR, { KeyedMutator } from "swr";
 import useSWRMutation from "swr/mutation";
 
+import { FormattedText } from "@/components/general/FormattedText";
 import { ShiftVolunteersDialogAdd } from "@/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd";
 import { ShiftVolunteersDialogRemove } from "@/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogRemove";
 import { ShiftVolunteersDialogReview } from "@/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogReview";
@@ -684,7 +685,9 @@ export const ShiftVolunteers = ({
                             {row.label}
                           </Typography>
                         </Grid>
-                        <Grid size={10}>{row.value}</Grid>
+                        <Grid size={10}>
+                          <FormattedText text={String(row.value)} />
+                        </Grid>
                       </Fragment>
                     ))}
                   </Grid>

--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd.tsx
@@ -28,6 +28,7 @@ import useSWRMutation from "swr/mutation";
 
 import { DialogContainer } from "@/components/general/DialogContainer";
 import { ErrorAlert } from "@/components/general/ErrorAlert";
+import { FormattedText } from "@/components/general/FormattedText";
 import { Loading } from "@/components/general/Loading";
 import { SnackbarText } from "@/components/general/SnackbarText";
 import type { IVolunteerOption, TCheckInTypes } from "@/components/types";
@@ -961,10 +962,15 @@ export const ShiftVolunteersDialogAdd = ({
           {timePositionIdShiftWatch && (
             <Grid size={12}>
               <Typography gutterBottom>Position Details:</Typography>
-              {positionList.find(
-                (shiftPositionItem) =>
-                  shiftPositionItem.timePositionId === timePositionIdShiftWatch
-              )?.positionDetails ?? "Not available."}
+              <FormattedText
+                text={
+                  positionList.find(
+                    (shiftPositionItem) =>
+                      shiftPositionItem.timePositionId ===
+                      timePositionIdShiftWatch
+                  )?.positionDetails ?? "Not available."
+                }
+              />
             </Grid>
           )}
         </Grid>

--- a/client/src/components/general/FormattedText.tsx
+++ b/client/src/components/general/FormattedText.tsx
@@ -1,0 +1,53 @@
+import { Box, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+// Renders a plain-text description (shift_details / position_details /
+// shift notes) with real paragraph spacing and bullet lists.
+//
+// These fields are stored as plain text with newlines. Rendered as a bare
+// React child they collapse into one run-on block (whitespace folding), so
+// this turns blank-line/newline breaks into spaced paragraphs and groups
+// consecutive "- " / "• " lines into a proper bulleted list.
+interface IFormattedTextProps {
+  text: string;
+}
+
+export const FormattedText = ({ text }: IFormattedTextProps) => {
+  const lines = (text ?? "").replace(/\r\n/g, "\n").split("\n");
+  const blocks: ReactNode[] = [];
+  let bullets: string[] = [];
+
+  const flushBullets = (key: string) => {
+    if (bullets.length === 0) return;
+    blocks.push(
+      <Box component="ul" key={key} sx={{ my: 0.5, pl: 3, "& li": { mb: 0.5 } }}>
+        {bullets.map((bullet, index) => (
+          <Typography component="li" key={index} variant="body2">
+            {bullet}
+          </Typography>
+        ))}
+      </Box>
+    );
+    bullets = [];
+  };
+
+  lines.forEach((raw, index) => {
+    const line = raw.trim();
+    const bulletMatch = line.match(/^[-•]\s+(.*)$/);
+    if (bulletMatch) {
+      bullets.push(bulletMatch[1]);
+      return;
+    }
+    flushBullets(`ul-${index}`);
+    if (line) {
+      blocks.push(
+        <Typography key={index} sx={{ mb: 1 }} variant="body2">
+          {line}
+        </Typography>
+      );
+    }
+  });
+  flushBullets("ul-end");
+
+  return <>{blocks}</>;
+};


### PR DESCRIPTION
Restores the `FormattedText` rendering from #420, which was briefly reverted in #422 during the keep-vs-revert discussion. Mew confirmed formatting is Chipper's call, and Chipper chose to **keep** it. This syncs `main` back to what's already running on prod (no deploy needed — prod has been running this code since #420).