### PR TITLE
feat(signup): sign-up dialog falls back to shift description for blank positions

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd.tsx
@@ -72,6 +72,7 @@ interface IShiftVolunteersDialogAddProps {
     shift: {
       date: string;
       dateName: string;
+      details: string;
       endTime: string;
       startTime: string;
       typeName: string;
@@ -94,7 +95,7 @@ export const ShiftVolunteersDialogAdd = ({
   isDialogOpen,
   shiftVolunteersItem: {
     positionList,
-    shift: { date, dateName, endTime, startTime, typeName },
+    shift: { date, dateName, details, endTime, startTime, typeName },
     timeId: timeIdShift,
     volunteerList,
   },
@@ -958,21 +959,26 @@ export const ShiftVolunteersDialogAdd = ({
           {/* training */}
           {trainingDisplay}
 
-          {/* position details */}
-          {timePositionIdShiftWatch && (
-            <Grid size={12}>
-              <Typography gutterBottom>Position Details:</Typography>
-              <FormattedText
-                text={
-                  positionList.find(
-                    (shiftPositionItem) =>
-                      shiftPositionItem.timePositionId ===
-                      timePositionIdShiftWatch
-                  )?.positionDetails ?? "Not available."
-                }
-              />
-            </Grid>
-          )}
+          {/* position details — when a position has no description of its own,
+              fall back to the shift description so the sign-up pop-up never
+              shows a blank/"Not available." field (per Chipper 2026-06-15) */}
+          {timePositionIdShiftWatch &&
+            (() => {
+              const positionDetails = positionList.find(
+                (shiftPositionItem) =>
+                  shiftPositionItem.timePositionId === timePositionIdShiftWatch
+              )?.positionDetails;
+              const detailsText =
+                positionDetails && positionDetails.trim()
+                  ? positionDetails
+                  : details || "Not available.";
+              return (
+                <Grid size={12}>
+                  <Typography gutterBottom>Position Details:</Typography>
+                  <FormattedText text={detailsText} />
+                </Grid>
+              );
+            })()}
         </Grid>
         <DialogActions>
           <Button


### PR DESCRIPTION
Per Chipper (2026-06-15): single-position shifts (Census Lab Steward, Tech Support, Welcome Party, etc.) intentionally leave the position description blank and rely on the shift description. But the **Add-volunteer dialog** showed **"Not available."** for those — right at the sign-up moment.

**Fix (dialog only):** the dialog already receives the shift description (via the spread of `dataShiftVolunteersItem`); type + destructure it, and when the selected position's own `positionDetails` is blank, show the **shift description** instead.

- **Email path intentionally unchanged** (Chipper's call — it already shows an "About this shift type" section).
- ~10-line display-only change; `tsc --noEmit` clean.

**Before:** blank position → "Not available." · **After:** blank position → the shift description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)