### PR TITLE
UI cleanup: filter label, footer auth, checklist nudge, shift-detail rename

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -589,33 +589,35 @@ export const ShiftVolunteers = ({
           backgroundImage: "url(/banners/databeast-volunteers-waving.jpg)",
           backgroundSize: "cover",
         }}
-        text="Shift volunteers"
+        text="Shift Detail"
       />
       <Container component="main">
-        <Box component="section">
-          <BreadcrumbsNav>
-            <Link href="/shifts">
+        {isAdmin && (
+          <Box component="section">
+            <BreadcrumbsNav>
+              <Link href="/shifts">
+                <Typography
+                  sx={{
+                    alignItems: "center",
+                    display: "flex",
+                  }}
+                >
+                  <WorkHistoryIcon sx={{ mr: 0.5 }} />
+                  Shifts
+                </Typography>
+              </Link>
               <Typography
                 sx={{
                   alignItems: "center",
                   display: "flex",
                 }}
               >
-                <WorkHistoryIcon sx={{ mr: 0.5 }} />
-                Shifts
+                <Groups3Icon sx={{ mr: 0.5 }} />
+                Shift Detail
               </Typography>
-            </Link>
-            <Typography
-              sx={{
-                alignItems: "center",
-                display: "flex",
-              }}
-            >
-              <Groups3Icon sx={{ mr: 0.5 }} />
-              Shift volunteers
-            </Typography>
-          </BreadcrumbsNav>
-        </Box>
+            </BreadcrumbsNav>
+          </Box>
+        )}
         <Box component="section">
           {isShiftCanceled && (
             <Alert

--- a/client/src/app/shifts/[timeId]/volunteers/page.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/page.tsx
@@ -5,7 +5,7 @@ interface IShiftVolunteersPageProps {
 }
 
 export const metadata = {
-  title: "Census | Shift volunteers",
+  title: "Census | Shift Detail",
 };
 const ShiftVolunteersPage = async ({ params }: IShiftVolunteersPageProps) => {
   // logic

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -770,6 +770,34 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     });
   }
 
+  // Fallback nudge (#430, option B): if nothing else is actionable, point the
+  // volunteer at the shifts page so the checklist is never empty.
+  if (!checklistItems.some((item) => !item.done)) {
+    checklistItems.push({
+      id: "sign-up-for-shifts",
+      label: "Sign up for shifts",
+      done: false,
+      content: (
+        <Box>
+          <Typography sx={{ mb: 1 }}>
+            You’re all set! Browse open shifts and sign up for more ways to
+            help out.
+          </Typography>
+          <Link
+            href="/shifts"
+            style={{
+              color: theme.palette.primary.main,
+              fontWeight: 500,
+              textDecoration: "underline",
+            }}
+          >
+            Browse and sign up for shifts
+          </Link>
+        </Box>
+      ),
+    });
+  }
+
   const incompleteItems = checklistItems.filter((item) => !item.done);
   const completedItems = checklistItems.filter((item) => item.done);
 

--- a/client/src/components/general/DataTable.tsx
+++ b/client/src/components/general/DataTable.tsx
@@ -77,6 +77,13 @@ export const DataTable = ({
     rowHover: false,
     rowsPerPage: 100,
     selectableRows: undefined,
+    // "Reset" clears every active filter (incl. the default ones), so label it
+    // for what it actually does (#143). mui-datatables deep-merges textLabels.
+    textLabels: {
+      filter: {
+        reset: "Remove all filters",
+      },
+    },
     viewColumns: false,
     ...optionListCustom,
   };

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -21,7 +21,11 @@ import {
 } from "@/components/layout/pageList";
 import { DeveloperModeContext } from "@/state/developer-mode/context";
 import { SessionContext } from "@/state/session/context";
-import { checkIsAdmin, checkIsSuperAdmin } from "@/utils/checkIsRoleExist";
+import {
+  checkIsAdmin,
+  checkIsAuthenticated,
+  checkIsSuperAdmin,
+} from "@/utils/checkIsRoleExist";
 
 export const Footer = () => {
   // context
@@ -31,6 +35,7 @@ export const Footer = () => {
   } = useContext(DeveloperModeContext);
   const {
     sessionState: {
+      settings: { isAuthenticated: isAuthenticatedSession },
       user: { roleList },
     },
   } = useContext(SessionContext);
@@ -44,14 +49,28 @@ export const Footer = () => {
   // ------------------------------------------------------------
   const isAdmin = checkIsAdmin(accountType, roleList);
   const isSuperAdmin = checkIsSuperAdmin(accountType, roleList);
+  const isAuthenticated = checkIsAuthenticated(
+    accountType,
+    isAuthenticatedSession
+  );
+  // NEXT_PUBLIC_* inlines at build time so this is a static decision.
+  const isOnPlaya = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
 
   // render
   // ------------------------------------------------------------
-  const pageListHalfCount = Math.ceil(pageListDefault.length / 2);
-  const pageListHalfFirst = pageListDefault.slice(0, pageListHalfCount);
-  const pageListHalfSecond = pageListDefault.slice(
+  // Shifts requires login off-playa, so hide it from the footer for
+  // logged-out users — mirrors the drawer filter in Header.tsx (#413).
+  const pageListDefaultVisible = pageListDefault.filter(({ path }) => {
+    if (path === "/shifts" && !isAuthenticated && !isOnPlaya) {
+      return false;
+    }
+    return true;
+  });
+  const pageListHalfCount = Math.ceil(pageListDefaultVisible.length / 2);
+  const pageListHalfFirst = pageListDefaultVisible.slice(0, pageListHalfCount);
+  const pageListHalfSecond = pageListDefaultVisible.slice(
     pageListHalfCount,
-    pageListDefault.length
+    pageListDefaultVisible.length
   );
 
   return (


### PR DESCRIPTION
Four small, low-risk front-end fixes from the issue review (no backend / route / DB changes). Closes #143, #413, #430; addresses two of three items in #434.

## Changes

**#143 — Filter "Reset" → "Remove all filters"**
The MUIDataTable filter dialog's `Reset` button actually clears *every* active filter, including the default ones (Chipper: the word "reset" implies "restore defaults," which it doesn't). Relabeled via `textLabels.filter.reset` in the shared `DataTable` so it's consistent on every list page.

**#413 — Hide footer "Shifts" link for logged-out users**
`Shifts` requires login off-playa, so logged-out visitors clicking it in the footer got bounced. The footer now applies the same auth/playa filter the Header drawer already uses. (Home left visible per Mew — clicking it just routes to sign-in.)

**#430 — "Sign up for shifts" checklist nudge (option B)**
Adds a `Sign up for shifts` checklist item linking to `/shifts`, shown whenever the volunteer has no other actionable item — so the checklist is never empty for fully-set-up volunteers.

**#434 — Shift Detail page (2 of 3 items)**
- Breadcrumb gated to admins only (same treatment #411 applied to the account page).
- Heading + browser title renamed `Shift volunteers` → `Shift Detail`.
- **Not done:** hiding per-position CSP — Mew chose to keep it (reverses the issue's first item; flagging for Chipper).

## Verification
- `tsc --noEmit`: clean
- `next build`: clean (all routes compile)
- Front-end only — no API/DB/route changes.

## Visual checks to run on a test build before prod
- [ ] `/shifts` filter dialog shows "Remove all filters"
- [ ] Footer (logged-out, off-playa) omits Shifts; signed-in shows it
- [ ] `/shifts/[id]/volunteers` heading reads "Shift Detail"; breadcrumb hidden for non-admins, shown for admins
- [ ] A fully-set-up volunteer's checklist shows the "Sign up for shifts" item

🤖 Generated with [Claude Code](https://claude.com/claude-code)