### PR TITLE
fix(volunteers): exclude removed shifts from Attended/Absent/Remaining counts; spell out column labels

### DIFF
--- a/client/src/app/volunteers/Volunteers.tsx
+++ b/client/src/app/volunteers/Volunteers.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 import { Chat as ChatIcon } from "@mui/icons-material";
-import {
-  Box,
-  Card,
-  CardContent,
-  Chip,
-  Container,
-  Grid,
-  Typography,
-} from "@mui/material";
+import { Box, Chip, Container, Typography } from "@mui/material";
 import { green, grey, red } from "@mui/material/colors";
 import { FilterType } from "mui-datatables";
 import { useRouter } from "next/navigation";
@@ -83,7 +75,7 @@ export const Volunteers = () => {
       },
     },
     {
-      name: "Att.",
+      name: "Attended",
       options: {
         filter: false,
         setCellHeaderProps: setCellHeaderPropsCenter,
@@ -93,7 +85,7 @@ export const Volunteers = () => {
       },
     },
     {
-      name: "Abs.",
+      name: "Absent",
       options: {
         customFilterListOptions: {
           render: (value: string) => `Absent: ${value}`,
@@ -117,7 +109,7 @@ export const Volunteers = () => {
       },
     },
     {
-      name: "Rem.",
+      name: "Remaining",
       options: {
         customFilterListOptions: {
           render: (value: string) => `Remaining: ${value}`,
@@ -247,41 +239,6 @@ export const Volunteers = () => {
             dataTable={dataTable}
             optionListCustom={optionListCustom}
           />
-        </Box>
-        <Box component="section">
-          <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
-            Legend
-          </Typography>
-          <Card sx={{ mb: 2 }}>
-            <CardContent>
-              <Grid container>
-                <Grid size={2}>
-                  <Typography component="p" variant="h6">
-                    Att.
-                  </Typography>
-                </Grid>
-                <Grid alignItems="center" container size={10}>
-                  <Typography component="p">Attended</Typography>
-                </Grid>
-                <Grid size={2}>
-                  <Typography component="p" variant="h6">
-                    Abs.
-                  </Typography>
-                </Grid>
-                <Grid alignItems="center" container size={10}>
-                  <Typography component="p">Absent</Typography>
-                </Grid>
-                <Grid size={2}>
-                  <Typography component="p" variant="h6">
-                    Rem.
-                  </Typography>
-                </Grid>
-                <Grid alignItems="center" container size={10}>
-                  <Typography component="p">Remaining</Typography>
-                </Grid>
-              </Grid>
-            </CardContent>
-          </Card>
         </Box>
       </Container>
     </>

--- a/client/src/pages/api/volunteers/index.ts
+++ b/client/src/pages/api/volunteers/index.ts
@@ -33,6 +33,10 @@ const volunteers = async (
         FROM op_volunteers AS v
         LEFT JOIN op_volunteer_shifts AS vs
         ON vs.shiftboard_id=v.shiftboard_id
+        -- exclude removed shifts so dropped signups don't inflate the
+        -- Attended/Absent/Remaining counts (kept in the ON clause to
+        -- preserve the LEFT JOIN for volunteers with no shifts).
+        AND vs.remove_shift=false
         ORDER BY
           v.playa_name COLLATE utf8mb4_general_ci,
           v.world_name COLLATE utf8mb4_general_ci`


### PR DESCRIPTION
## Bug
The admin **Volunteers** list counts each volunteer's Attended / Absent / Remaining shifts by `LEFT JOIN`ing `op_volunteer_shifts` **without filtering `remove_shift`** — so dropped/removed shifts are counted too. Reported by Chipper: Rescue showed **11 remaining** but has **8** (3 were removed shifts).

**Fix:** add `AND vs.remove_shift=false` to the join (kept in the `ON` clause so the `LEFT JOIN` still includes volunteers with zero shifts). Verified against prod: Rescue has 8 active `noshow='X'` rows + 3 removed → the filter yields the correct 8.

## Also (per Chipper)
- Spell out the abbreviated headers: **Att./Abs./Rem. → Attended/Absent/Remaining**. Safe — the table data is array-of-arrays (columns map by position, not by `name`).
- Remove the now-redundant **"Legend"** section (it explained the abbreviations) + its now-unused `Card`/`CardContent`/`Grid` imports.

## Verification
- `tsc --noEmit`: clean
- `next build`: clean
- Genuine bug → fits the launch-freeze "bugs are fine" exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)