### PR TITLE
fix(info): update revoked in-app Discord invite link

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/GetInvolved.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/GetInvolved.tsx
@@ -21,7 +21,7 @@ const ITEMS: IGetInvolvedItem[] = [
     title: "Join the Census Discord",
     description: "Connect with the Census community year-round.",
     linkLabel: "Join Discord",
-    href: "https://discord.gg/FqDcF89Ktp",
+    href: "https://discord.gg/BAzSsh4P9g",
   },
   {
     title: "Sign up as a DataNerd",


### PR DESCRIPTION
The "Get involved" sidebar invite on the account page (`discord.gg/FqDcF89Ktp`) was inadvertently revoked when expiring invites were cleaned up, leaving a **dead link** on a live page. Points it at the working invite `discord.gg/BAzSsh4P9g`.

One-line copy/data fix in `GetInvolved.tsx`. The homepage Discord link (`discord.gg/jcWuyYDGcn`) is correct and untouched. Updated copy for this section is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)