### PR TITLE
feat(auth): roles-on-login roster — auto-grant camp/staff roles at login

### DIFF
--- a/client/src/pages/api/auth/okta/callback.ts
+++ b/client/src/pages/api/auth/okta/callback.ts
@@ -394,6 +394,34 @@ const oktaCallback = async (req: NextApiRequest, res: NextApiResponse) => {
       shiftboardId = newId;
     }
 
+    // Roles-on-login: grant any camp/staff roles the roster (migration 007)
+    // lists for this email that the volunteer doesn't already hold. ADDITIVE
+    // only — never removes a role. This is how camp-roster folks who've never
+    // logged into the app get their role the moment they first sign in (they
+    // can't have op_volunteer_roles rows before their account exists, FK). Same
+    // spirit as the sampler-role recommendation in census-python, but keyed to
+    // a manual roster instead of shift history. Wrapped so a roster miss or a
+    // deployment without the table never blocks login.
+    try {
+      const [rosterRows] = await pool.query<RowDataPacket[]>(
+        "SELECT role_id FROM op_role_grant_roster WHERE LOWER(email)=LOWER(?)",
+        [email]
+      );
+      for (const { role_id } of rosterRows) {
+        await pool.query(
+          `INSERT INTO op_volunteer_roles (shiftboard_id, role_id, add_role, remove_role)
+           VALUES (?, ?, true, false)
+           ON DUPLICATE KEY UPDATE add_role=true, remove_role=false`,
+          [shiftboardId, role_id]
+        );
+      }
+    } catch (rosterErr) {
+      console.warn(
+        "roster role grant skipped:",
+        rosterErr instanceof Error ? rosterErr.message : rosterErr
+      );
+    }
+
     // build the account response (same shape as passcode sign-in)
     const account = await buildAccountResponse(shiftboardId);
     if (!account) {

--- a/migrations/007_add_role_grant_roster.sql
+++ b/migrations/007_add_role_grant_roster.sql
@@ -1,0 +1,70 @@
+-- Migration: roles-on-login roster (per Mew 2026-06-22).
+--
+-- A small authoritative roster of camp/staff roles keyed by email. On login,
+-- the Okta callback looks the volunteer up by email and grants any roles listed
+-- here that they don't already hold (ADDITIVE only — it never removes a role).
+-- This is the "roles on first login" facility for the camp roster (Census Lab,
+-- Counter Culture, Staff): people who haven't logged into the app yet — and so
+-- can't have op_volunteer_roles rows (FK to op_volunteers) — get their role the
+-- moment they first sign in. Same spirit as the sampler-role recommendation in
+-- census-python, but keyed to a manual roster instead of shift history.
+--
+-- To add someone for a future roster: INSERT a (LOWER(email), role_id) row.
+-- role_id: 2000009 = CensusLabCamp, 2000008 = CounterCultureCamp, 2000006 = Staff.
+--
+-- Run-once create; the seed is idempotent (INSERT IGNORE on the PK).
+
+CREATE TABLE IF NOT EXISTS op_role_grant_roster (
+  email   VARCHAR(255) NOT NULL,
+  role_id BIGINT       NOT NULL,
+  PRIMARY KEY (email, role_id)
+);
+
+INSERT IGNORE INTO op_role_grant_roster (email, role_id) VALUES
+  ('aaronshev@gmail.com', 2000006),
+  ('alekchakroff@gmail.com', 2000006),
+  ('alekchakroff@gmail.com', 2000009),
+  ('amylie9@gmail.com', 2000006),
+  ('amylie9@gmail.com', 2000009),
+  ('andi.morency@burningman.org', 2000006),
+  ('andi.morency@burningman.org', 2000009),
+  ('ann976norton@gmail.com', 2000006),
+  ('ann976norton@gmail.com', 2000008),
+  ('beaulieu-prevost.dominic@uqam.ca', 2000006),
+  ('chipper@burningman.org', 2000006),
+  ('cinnamonbm2008@burningman.org', 2000006),
+  ('davechristiansen@outlook.com', 2000008),
+  ('ehannigan@me.com', 2000008),
+  ('eric.bahn@gmail.com', 2000009),
+  ('evansonearth@gmail.com', 2000008),
+  ('heathermessal@gmail.com', 2000009),
+  ('hunterinnewyorkcity@gmail.com', 2000008),
+  ('jaiden0@hotmail.com', 2000009),
+  ('jeremiah.conley@yahoo.com', 2000006),
+  ('jeremiah.conley@yahoo.com', 2000009),
+  ('jimstamper@mail.com', 2000008),
+  ('laurameisenegreen@gmail.com', 2000008),
+  ('meredithkb@yahoo.com', 2000006),
+  ('mu@burningman.org', 2000006),
+  ('mu@burningman.org', 2000008),
+  ('mx.weking@gmail.com', 2000006),
+  ('mx.weking@gmail.com', 2000009),
+  ('natreid013@gmail.com', 2000008),
+  ('random@burningman.org', 2000006),
+  ('random@burningman.org', 2000009),
+  ('raratan@gmail.com', 2000009),
+  ('rkohara@gmail.com', 2000009),
+  ('robertbunsold@gmail.com', 2000008),
+  ('rqreyes@gmail.com', 2000006),
+  ('rqreyes@gmail.com', 2000008),
+  ('sd12@cornell.edu', 2000009),
+  ('sdurkee@mac.com', 2000008),
+  ('ssloan.cnm@gmail.com', 2000008),
+  ('surge16@msn.com', 2000006),
+  ('surge16@msn.com', 2000009),
+  ('vernon.andrews76@gmail.com', 2000008),
+  ('victoriaprimeau@gmail.com', 2000006),
+  ('victoriaprimeau@gmail.com', 2000009),
+  ('welcome2planetshan@gmail.com', 2000008),
+  ('woodie@netpress.com', 2000006),
+  ('woodie@netpress.com', 2000009);


### PR DESCRIPTION
Builds the "roles on first login" facility Mew asked for (2026-06-22).

## What it does
- **Migration 007** adds `op_role_grant_roster` (email → role_id), seeded from the authoritative **Lab / Counter Culture / Staff** roster (47 pairs).
- The **Okta login callback** now, after resolving the account, grants any roster roles for the volunteer's email they don't already hold — **additive only, never removes** — wrapped in try/catch so a roster miss or a table-less deploy never blocks login.

## Why
Camp-roster folks who've never logged into the app can't be given roles ahead of time — `op_volunteer_roles` has an FK to `op_volunteers`, so the row must exist first. This grants their role the moment they first sign in. Same spirit as the sampler-role recommendation in census-python, but keyed to a manual roster instead of shift history.

## Deploy
- Run **`migrations/007_add_role_grant_roster.sql`** (creates + seeds the table; idempotent).
- No env changes.

## Adding people later
`INSERT IGNORE INTO op_role_grant_roster (email, role_id) VALUES (LOWER('…'), 2000009|2000008|2000006);` — applies on that person's next login.

## Testing
- Build + typecheck green. Grant is additive + idempotent (`ON DUPLICATE KEY UPDATE add_role=true, remove_role=false`); the removed wrong-Lab roles won't return since those people aren't on the Lab roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)