### PR TITLE
copy(home): repurpose homepage for volunteer recruitment

### DIFF
--- a/client/src/app/Home.tsx
+++ b/client/src/app/Home.tsx
@@ -55,13 +55,25 @@ export const Home = () => {
       <Container component="main">
         <Box component="section">
           <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
-            Welcome!
+            2026 Black Rock City Census volunteer shifts are now open!
+          </Typography>
+
+          <Typography sx={{ mb: 2 }}>
+            Sign in below with your Burner Profile to view shift requirements and
+            sign up. Don&apos;t have a Burner Profile yet? Create one at{" "}
+            <a
+              href="https://profiles.burningman.org"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              profiles.burningman.org
+            </a>
+            .
           </Typography>
 
           {/*
-           * Login affordance sits between the Welcome header and the body
-           * copy (per Chipper + Mew, 2026-05-25). Auth state drives the
-           * content:
+           * Login affordance sits between the header and the body copy
+           * (per Chipper + Mew, 2026-05-25). Auth state drives the content:
            *   - authenticated → "View your account" link to /info
            *   - unauth + Okta enabled (off-playa) → Okta SSO button
            *   - unauth + PIN enabled (on-playa) → link to /sign-in for
@@ -103,82 +115,101 @@ export const Home = () => {
 
           <Card>
             <CardContent>
-              <Typography>
-                Black Rock City (BRC) Census is a collaborative research project
-                started in 2002 with the goal of learning more about the
-                participants who make up Black Rock City. We conduct a random
-                sample of Burners entering the event, then collect online survey
-                responses after the Burn. We combine these two data sources to
-                get more statistically accurate data about the people who attend
-                Burning Man each year.
+              <Typography component="h3" variant="h5" sx={{ mb: 1 }}>
+                Overview
               </Typography>
               <Typography>
-                Data from BRC Census help Burning Man Project represent the
-                Burner community in conversations with local, state, and federal
-                agencies and elected officials. It is also used to understand
-                the impact we have on the environment. In alignment with Burning
-                Man Project&apos;s Environmental Sustainability Roadmap, we want
-                to reduce our carbon footprint and make the event more
-                sustainable. In the last few years, Black Rock City Census has
-                offered a way to track the year-to-year impact of concerns
-                related to this issue by collecting data about transportation
-                and the use of Burner Express bus service.
+                BRC Census is a collaborative research project that started in
+                2002 with the goal of learning more about the participants who
+                make up Black Rock City. We conduct a random sample of Burners
+                entering the event, then collect online survey responses after
+                the Burn. We combine these two data sources to get more
+                statistically accurate data about the people who attended Burning
+                Man that year.
               </Typography>
               <Typography>
-                Just as important is what BRC Census can learn from YOU and the
-                gift of your data! This is your chance to have your presence in
-                Black Rock City counted and to learn about our community. The
-                Census is one of the primary ways Burning Man Project tracks
-                changes in population, behavior, and attitudes of event
-                participants, giving us all the ability to understand just a bit
-                more about the city many of us call home. The more we understand
-                the makeup of Black Rock City and the diverse Burning Man
-                experiences it offers, the better equipped we are to meet the
-                needs of the community and help Burning Man culture continue to
-                flourish.
+                Check out the{" "}
+                <a
+                  href="https://blackrockcitycensus.org/index.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Black Rock City Census Population Analysis
+                </a>{" "}
+                to explore our data.
               </Typography>
             </CardContent>
           </Card>
         </Box>
+
         <Box component="section">
           <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
-            Learn more
+            Learn More about BRC Census
           </Typography>
           <Card>
             <CardContent>
               <Typography>
-                To learn more, please visit our portal in the Burning Man
-                Journal and the Census Results Archive for reports on past
-                years&apos; Census data. The most recent{" "}
-                <a
-                  href="https://blackrockcitycensus.org/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Black Rock City Census Population Report
-                </a>{" "}
-                is available for your perusal at any time.
-              </Typography>
-              <Typography>
-                If you have a question, comment, concern, or if you would like a
-                reminder about filling out the Census online survey after the
-                event, please fill out the{" "}
-                <Link href={{ pathname: "/contact" }}>Contact</Link> form
-                located in the tablet menu or email{" "}
-                <a href="mailto:censusvolunteercoordinators@burningman.org">
-                  censusvolunteercoordinators@burningman.org
-                </a>
-                . The{" "}
+                The{" "}
                 <a
                   href="https://hive.burningman.org/spaces/14264554/content"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Census Portal on Burning Man Hive
+                  Black Rock City Census Community on Hive
                 </a>{" "}
-                is a great place to learn about our efforts and conduct any
-                training you may require. Finally, you&apos;re more than welcome
-                to meet and chat with the team on our{" "}
+                is the best place to get all the information you need about who
+                we are and what we do. You will also get the most up-to-date
+                information about volunteering. On Hive, you can learn about how
+                we gather and use data, see the various roles available for
+                volunteers, meet the leadership team, get a calendar of our
+                upcoming events, and complete the training you need to volunteer
+                (this varies by role). If you do not yet have a Burner Profile,
+                create one at{" "}
+                <a
+                  href="https://profiles.burningman.org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  profiles.burningman.org
+                </a>
+                . Once that&apos;s done, return here and{" "}
+                <a
+                  href="https://hive.burningman.org/spaces/14264554/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  click this link
+                </a>{" "}
+                to log in and view our Census community on Hive.
+              </Typography>
+            </CardContent>
+          </Card>
+        </Box>
+
+        <Box component="section">
+          <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
+            How to Volunteer
+          </Typography>
+          <Card>
+            <CardContent>
+              <Typography>
+                We&apos;re glad you&apos;re interested in the Black Rock City
+                Census! Each year the Census gathers data that serves a vital
+                purpose for Burning Man, in addition to just being interesting to
+                know. It&apos;s an all-volunteer effort, and we would love to
+                welcome you to our happy crew!
+              </Typography>
+              <Typography>
+                Are you ready to become a Census volunteer? Sign in above with
+                your Burner Profile to view shift requirements and sign up. If
+                you still have questions after reviewing our information, or if
+                you would like to share your ideas about how to make an impact
+                some other way, contact{" "}
+                <a href="mailto:censusvolunteercoordinators@burningman.org">
+                  censusvolunteercoordinators@burningman.org
+                </a>{" "}
+                and let us know how you want to participate! You&apos;re also more
+                than welcome to meet and chat with the team on our{" "}
                 <a
                   href="https://discord.gg/jcWuyYDGcn"
                   target="_blank"
@@ -186,7 +217,81 @@ export const Home = () => {
                 >
                   Census Discord server
                 </a>
-                !
+                .
+              </Typography>
+            </CardContent>
+          </Card>
+        </Box>
+
+        <Box component="section">
+          <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
+            Volunteer Roles
+          </Typography>
+          <Card>
+            <CardContent>
+              <Typography>
+                Brief descriptions of the various volunteer roles are below.
+                More information about roles and the training necessary for each
+                can be found at our Census Hive site linked above.
+              </Typography>
+              <Typography>
+                <strong>Random Samplers</strong> are stationed on Gate Road or
+                BRC Airport as Burners arrive on playa. They collect basic
+                demographic information from randomly selected participants. Good
+                mobility, punctuality, enthusiasm, and communication skills are
+                essential!
+              </Typography>
+              <Typography>
+                <strong>Traffic Tamers</strong> team up with Random Samplers on
+                Gate Road to work the lanes of traffic ahead of the sampling
+                point, getting participants excited about filling out the brief
+                sampling form. Mobility, punctuality, and enthusiasm are all
+                important traits!
+              </Typography>
+              <Typography>
+                <strong>Census Lab Hosts</strong> welcome visitors to the Census
+                Lab. They answer participants&apos; questions about the Census
+                and invite them to participate in a variety of ways.
+              </Typography>
+              <Typography>
+                <strong>Pop-up Lab Hosts</strong> travel on our Census transport
+                vehicle, the Data Beast, to a random location on playa to
+                educate participants about Census and invite them to write in the
+                Field Notes Journals.
+              </Typography>
+              <Typography>
+                <strong>Data Entry</strong> volunteers assist on playa, entering
+                the data collected during random sampling shifts. This role calls
+                for quick and accurate typists with good attention to detail!
+              </Typography>
+              <Typography>
+                <strong>Data Disseminators</strong> assist with on-playa
+                outreach, distributing our Friday preliminary report out to major
+                areas within BRC and encouraging participants to fill out the
+                online survey at the end of the event. These volunteers must be
+                friendly, mobile and clear communicators.
+              </Typography>
+              <Typography>
+                A core team of dedicated Census volunteers work year-round to
+                help with data analysis and visualization, blog post writing and
+                editing, pre-Burn planning, and other tasks.
+              </Typography>
+              <Typography>
+                If any of these sound like good fits for you or if you would like
+                to make an impact some other way, contact{" "}
+                <a href="mailto:censusvolunteercoordinators@burningman.org">
+                  censusvolunteercoordinators@burningman.org
+                </a>{" "}
+                and let us know how you want to participate! We suggest reading
+                through the{" "}
+                <a
+                  href="https://hive.burningman.org/spaces/14264554/content"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Black Rock City Census Community on Hive
+                </a>{" "}
+                first.
               </Typography>
             </CardContent>
           </Card>


### PR DESCRIPTION
Rebuilds the app homepage (`client/src/app/Home.tsx`) to be **volunteer-recruitment focused** rather than post-event survey reminders, per Chipper + Maya (2026-06-28).

**Baseline:** the BMP Comms-controlled volunteering page (`burningman.org/black-rock-city/volunteering/census/`), with Chipper's 2026-06-27 "Web update request" email edits applied.

### Email edits applied
- **H1** → "2026 Black Rock City Census volunteer shifts are now open!"
- **Overview** → "for more information" → "to explore our data"
- Removed the **"Explore the Data"** section
- **"Learn More About the BRC Census"** → "Learn More about BRC Census"; "who the Census is" → "who we are and what we do"
- **Hive login** line → Burner Profile create + "click this link" to log into Hive (per the email's exact wording/link)
- **How to Volunteer** → kept intro paragraph; replaced the 3 steps

### App adaptations
- "Visit volunteers.census.burningman.org and login…" → **"Sign in with your Burner Profile"** (visitors are already on the app/VIP)
- Kept the **existing Census Discord link** (`discord.gg/jcWuyYDGcn`), folded into How to Volunteer
- **Volunteer Roles** section **kept** (the email removes it from the public page, but Chipper wants it on the app) — ported verbatim, email/Hive as links

### Unchanged
- Hero banner image and the Sign-in button (style/placement intact)

### Validation
- `next build` passes
- Local full-page screenshot reviewed + approved by Chipper

Copy-only / layout change → within Chipper's deploy authority (no Mew sign-off needed). Supersedes the stale `copy/homepage-before-login-refresh` / `deploy/homepage-copy-only` branches (older survey-reminder framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)