### PR TITLE
fix(shifts): mobile description formatting — stack labels, render **bold** + `---` dividers

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -682,12 +682,12 @@ export const ShiftVolunteers = ({
                             <Divider sx={{ my: 2 }} />
                           </Grid>
                         )}
-                        <Grid size={2}>
+                        <Grid size={{ xs: 12, sm: 2 }}>
                           <Typography component="h3" variant="h6">
                             {row.label}
                           </Typography>
                         </Grid>
-                        <Grid size={10}>
+                        <Grid size={{ xs: 12, sm: 10 }}>
                           <FormattedText text={String(row.value)} />
                         </Grid>
                       </Fragment>

--- a/client/src/components/general/FormattedText.tsx
+++ b/client/src/components/general/FormattedText.tsx
@@ -1,16 +1,32 @@
-import { Box, Typography } from "@mui/material";
-import type { ReactNode } from "react";
+import { Box, Divider, Typography } from "@mui/material";
+import { Fragment, type ReactNode } from "react";
 
 // Renders a plain-text description (shift_details / position_details /
-// shift notes) with real paragraph spacing and bullet lists.
+// shift notes) with real paragraph spacing, bullet lists, inline **bold**,
+// and horizontal dividers.
 //
 // These fields are stored as plain text with newlines. Rendered as a bare
 // React child they collapse into one run-on block (whitespace folding), so
-// this turns blank-line/newline breaks into spaced paragraphs and groups
-// consecutive "- " / "• " lines into a proper bulleted list.
+// this turns blank-line/newline breaks into spaced paragraphs, groups
+// consecutive "- " / "• " lines into a bulleted list, renders a line of only
+// dashes/asterisks/underscores ("---") as a divider, and turns **text** into
+// bold. Authors can put a "---" line between two notes to separate them.
 interface IFormattedTextProps {
   text: string;
 }
+
+// Turn inline **bold** markers into <strong>. Simple, non-nested.
+const renderInline = (text: string): ReactNode => {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, index) => {
+    const bold = part.match(/^\*\*([^*]+)\*\*$/);
+    return bold ? (
+      <strong key={index}>{bold[1]}</strong>
+    ) : (
+      <Fragment key={index}>{part}</Fragment>
+    );
+  });
+};
 
 export const FormattedText = ({ text }: IFormattedTextProps) => {
   const lines = (text ?? "").replace(/\r\n/g, "\n").split("\n");
@@ -23,7 +39,7 @@ export const FormattedText = ({ text }: IFormattedTextProps) => {
       <Box component="ul" key={key} sx={{ my: 0.5, pl: 3, "& li": { mb: 0.5 } }}>
         {bullets.map((bullet, index) => (
           <Typography component="li" key={index} variant="body2">
-            {bullet}
+            {renderInline(bullet)}
           </Typography>
         ))}
       </Box>
@@ -33,6 +49,13 @@ export const FormattedText = ({ text }: IFormattedTextProps) => {
 
   lines.forEach((raw, index) => {
     const line = raw.trim();
+    // horizontal rule: a line of only --- / *** / ___ (3+) becomes a divider,
+    // e.g. to separate two distinct notes stored in one field.
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(line)) {
+      flushBullets(`ul-${index}`);
+      blocks.push(<Divider key={index} sx={{ my: 1.5 }} />);
+      return;
+    }
     const bulletMatch = line.match(/^[-•]\s+(.*)$/);
     if (bulletMatch) {
       bullets.push(bulletMatch[1]);
@@ -42,7 +65,7 @@ export const FormattedText = ({ text }: IFormattedTextProps) => {
     if (line) {
       blocks.push(
         <Typography key={index} sx={{ mb: 1 }} variant="body2">
-          {line}
+          {renderInline(line)}
         </Typography>
       );
     }


### PR DESCRIPTION
Per Chipper + Mew 2026-07-01 (mobile testing). **Before/after screenshots approved by Mew.**

### Changes
- **Mobile label overlap** (`ShiftVolunteers.tsx`): the Details/Meal/Notes label column was a fixed `size={2}` (~16% width), so on a phone the label overflowed into the paragraph. Now responsive — `{ xs: 12, sm: 2 }` / `{ xs: 12, sm: 10 }` — so the label stacks above the text on phones, stays side-by-side on desktop.
- **Inline bold** (`FormattedText.tsx`): `**text**` now renders as bold (`<strong>`) instead of showing the literal asterisks.
- **Dividers** (`FormattedText.tsx`): a line of only `---` / `***` / `___` renders as a `<Divider>`, so two notes stored in one field can be visually separated.

### Validation
- `tsc --noEmit` clean.
- Rendered before/after at phone width, signed in — approved by Mew.

Separate follow-up: the mobile **table-overflow** fix (the "outside the black box" DataTable issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)