### PR TITLE
fix(session): 24h session for off-playa web; keep 1h on-playa

### DIFF
--- a/client/src/lib/session.ts
+++ b/client/src/lib/session.ts
@@ -1,7 +1,17 @@
 import crypto from "crypto";
 
 const COOKIE_NAME = "census-session";
-const SESSION_DURATION_MS = 60 * 60 * 1000; // 1 hour
+// Session lifetime differs by deployment (per Mew 2026-07-02):
+//   - On-playa lab tablets are SHARED — keep the window short so a set-down
+//     tablet doesn't leave someone logged in as another volunteer/admin.
+//   - Off-playa (Okta-only, NEXT_PUBLIC_PIN_ENABLED="false") volunteers sign
+//     up from their own devices at home, so a 1-hour window just logs them
+//     out mid-flow. Give them a full day.
+// NEXT_PUBLIC_* is inlined at build time, so this is a per-build decision.
+const SESSION_DURATION_MS =
+  process.env.NEXT_PUBLIC_PIN_ENABLED === "false"
+    ? 24 * 60 * 60 * 1000 // 24 hours off-playa (web)
+    : 60 * 60 * 1000; // 1 hour on-playa (shared tablets)
 
 interface SessionPayload {
   shiftboardId: number;


### PR DESCRIPTION
Volunteers signing up from their own devices off-playa were getting logged out mid-flow by the 1-hour session (the Elderbert saga, #460). This splits session lifetime by deployment:

- **Off-playa** (`NEXT_PUBLIC_PIN_ENABLED="false"`, Okta-only) → **24h**
- **On-playa** lab tablets → **1h** (unchanged — shared devices; a set-down tablet shouldn't leave someone logged in as another volunteer/admin)

`NEXT_PUBLIC_PIN_ENABLED` is inlined at build time, so this is decided per build (prod off-playa build → 24h; on-playa build → 1h). One-line-ish change in `client/src/lib/session.ts`.

**Approved by Mew 2026-07-02.** `tsc --noEmit` clean.

Note: this is an *absolute* session lifetime (not sliding). The fuller fix for "logged out while actively working" is a sliding/renewing session — tracked separately as a future item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)