### PR TITLE
fix(info): de-emphasize the top "Visit your Burner Profile" link

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -914,10 +914,19 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
             </Stack>
             <Typography color="text.secondary" sx={{ mt: 1 }} variant="body2">
               Need to update your info?{" "}
+              {/* De-emphasized on purpose (Chipper 2026-07-02): reads as
+                  supporting subtext, not a primary action — the primary
+                  "update your Burner Profile" step lives in the checklist
+                  below. Still a working link, just not blue/underlined. */}
               <a
                 href="https://profiles.burningman.org/my-profile"
                 rel="noopener noreferrer"
                 target="_blank"
+                style={{
+                  color: "inherit",
+                  textDecoration: "none",
+                  fontStyle: "italic",
+                }}
               >
                 Visit your Burner Profile
               </a>


### PR DESCRIPTION
Per Chipper 2026-07-02. The top link (next to the account info) was pulling new volunteers off-task and bouncing them to their Burner Profile before they found the checklist (#460). Now reads as supporting subtext — muted color (no blue), no underline, italic — while staying a working link. The primary "update your Burner Profile" step stays in the checklist below.

Small copy/style change, `tsc` clean. Can ship solo or fold into the larger /info restructure if that lands (#461).

🤖 Generated with [Claude Code](https://claude.com/claude-code)