### PR TITLE
feat(info): checklist to the top; fold arrival/camp into the plans item (#461)

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -160,7 +160,6 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
 
   // refs
   // ------------------------------------------------------------
-  const onPlayaRef = useRef<HTMLDivElement>(null);
   const passcodeRef = useRef<HTMLDivElement>(null);
 
   // state
@@ -502,7 +501,94 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     });
   }
 
-  // On-playa plans
+  // On-playa plans \u2014 arrival date, early entry, and camping now live INLINE in
+  // this checklist item (#461) instead of a separate section at the top of the
+  // page, so the checklist is the page's spine and volunteers aren't bounced
+  // back up. Fields save on change; the item is expanded by default.
+  const onPlayaFields = (
+    <Box>
+      {/* arrival date */}
+      <Box sx={{ mb: 2 }}>
+        <Typography sx={{ mb: 0.5 }} variant="subtitle2">
+          Desired / Expected Arrival Date
+        </Typography>
+        <Select
+          aria-label="Desired / Expected Arrival Date"
+          displayEmpty
+          onChange={(e) => handleArrivalDateChange(e.target.value)}
+          size="small"
+          sx={{ minWidth: { xs: "100%", sm: 300 } }}
+          value={arrivalDate?.dateId ?? ""}
+        >
+          <MenuItem value="">
+            <em>&mdash; Select &mdash;</em>
+          </MenuItem>
+          {dates
+            .filter((d) => ARRIVAL_DATENAMES.includes(d.datename))
+            .map((d) => (
+              <MenuItem key={d.dateId} value={d.dateId}>
+                {d.datename} &mdash; {formatDateDisplay(d.date)}
+              </MenuItem>
+            ))}
+        </Select>
+      </Box>
+
+      {/* early entry question (only for pre-open dates) */}
+      {isPreOpen && (
+        <Box
+          sx={{
+            backgroundColor: theme.palette.action.hover,
+            borderLeft: `3px solid ${theme.palette.primary.main}`,
+            borderRadius: 1,
+            mb: 2,
+            p: 2,
+          }}
+        >
+          <Typography sx={{ mb: 1 }} variant="subtitle2">
+            Early Entry
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 1 }} variant="body2">
+            The arrival date you selected is prior to the gate opening at the
+            event. Do you already have a pass for early entry through a
+            different department, or would you like Census to provide this?
+          </Typography>
+          <Select
+            aria-label="Early entry source"
+            onChange={(e) => handleOtherSapToggle(e.target.value === "other")}
+            size="small"
+            sx={{ minWidth: { xs: "100%", sm: 300 } }}
+            value={hasOtherSap ? "other" : "census"}
+          >
+            <MenuItem value="census">
+              I would like Census to provide early entry
+            </MenuItem>
+            <MenuItem value="other">
+              I already have early entry through another department
+            </MenuItem>
+          </Select>
+        </Box>
+      )}
+
+      {/* camping location */}
+      <Box>
+        <Typography sx={{ mb: 0.5 }} variant="subtitle2">
+          Tell us about where you will be camping
+        </Typography>
+        <TextField
+          defaultValue={volunteer.location}
+          fullWidth
+          multiline
+          onBlur={(e) => handleLocationChange(e.target.value)}
+          placeholder="e.g., Counter Culture Camp at 7:30 & G"
+          rows={2}
+          size="small"
+        />
+        <Typography color="text.secondary" variant="caption">
+          How to find you on playa and any other relevant info
+        </Typography>
+      </Box>
+    </Box>
+  );
   const plansDone =
     arrivalDate !== null && (volunteer.location ?? "").trim().length > 0;
   checklistItems.push({
@@ -512,10 +598,14 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
       : "Tell us your plans for this year\u2019s event",
     done: plansDone,
     content: (
-      <Typography>
-        Update your arrival date, early entry status, and camping location in the{" "}
-        <strong>On-Playa Information and Early Entry / SAP</strong> section above.
-      </Typography>
+      <Box>
+        <Typography color="text.secondary" sx={{ mb: 2 }}>
+          As a Census volunteer, you may be eligible for early entry to the
+          event. Tell us your arrival date, early-entry needs, and where
+          you&apos;ll be camping.
+        </Typography>
+        {onPlayaFields}
+      </Box>
     ),
   });
 
@@ -922,106 +1012,6 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                 Visit your Burner Profile
               </a>
             </Typography>
-          </CardContent>
-        </Card>
-
-        {/* on-playa information and early entry / SAP */}
-        <Card ref={onPlayaRef} sx={{ mb: 3 }}>
-          <CardContent>
-            <Typography component="h2" sx={{ mb: 1 }} variant="h5">
-              On-Playa Information and Early Entry / SAP
-            </Typography>
-            <Typography color="text.secondary" sx={{ mb: 2 }} variant="body2">
-              As a Census volunteer, you may be eligible for early entry to the
-              event. Select your earliest available arrival date below, and
-              we&apos;ll show you what&apos;s needed to qualify for a Setup Access
-              Pass (SAP).
-            </Typography>
-
-            {/* arrival date */}
-            <Box sx={{ mb: 2 }}>
-              <Typography sx={{ mb: 0.5 }} variant="subtitle2">
-                Desired / Expected Arrival Date
-              </Typography>
-              <Select
-                aria-label="Desired / Expected Arrival Date"
-                displayEmpty
-                onChange={(e) =>
-                  handleArrivalDateChange(e.target.value)
-                }
-                size="small"
-                sx={{ minWidth: 300 }}
-                value={arrivalDate?.dateId ?? ""}
-              >
-                <MenuItem value="">
-                  <em>&mdash; Select &mdash;</em>
-                </MenuItem>
-                {dates
-                  .filter((d) => ARRIVAL_DATENAMES.includes(d.datename))
-                  .map((d) => (
-                    <MenuItem key={d.dateId} value={d.dateId}>
-                      {d.datename} &mdash; {formatDateDisplay(d.date)}
-                    </MenuItem>
-                  ))}
-              </Select>
-            </Box>
-
-            {/* early entry question (only for pre-open dates) */}
-            {isPreOpen && (
-              <Box
-                sx={{
-                  backgroundColor: theme.palette.action.hover,
-                  borderLeft: `3px solid ${theme.palette.primary.main}`,
-                  borderRadius: 1,
-                  mb: 2,
-                  p: 2,
-                }}
-              >
-                <Typography sx={{ mb: 1 }} variant="subtitle2">
-                  Early Entry
-                </Typography>
-                <Typography color="text.secondary" sx={{ mb: 1 }} variant="body2">
-                  The arrival date you selected is prior to the gate opening at the
-                  event. Do you already have a pass for early entry through a
-                  different department, or would you like Census to provide this?
-                </Typography>
-                <Select
-                  aria-label="Early entry source"
-                  onChange={(e) =>
-                    handleOtherSapToggle(e.target.value === "other")
-                  }
-                  size="small"
-                  sx={{ minWidth: 300 }}
-                  value={hasOtherSap ? "other" : "census"}
-                >
-                  <MenuItem value="census">
-                    I would like Census to provide early entry
-                  </MenuItem>
-                  <MenuItem value="other">
-                    I already have early entry through another department
-                  </MenuItem>
-                </Select>
-              </Box>
-            )}
-
-            {/* camping location */}
-            <Box>
-              <Typography sx={{ mb: 0.5 }} variant="subtitle2">
-                Tell us about where you will be camping
-              </Typography>
-              <TextField
-                defaultValue={volunteer.location}
-                fullWidth
-                multiline
-                onBlur={(e) => handleLocationChange(e.target.value)}
-                placeholder="e.g., Counter Culture Camp at 7:30 & G"
-                rows={2}
-                size="small"
-              />
-              <Typography color="text.secondary" variant="caption">
-                How to find you on playa and any other relevant info
-              </Typography>
-            </Box>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Per Chipper + Mew (#461, approved 2026-07-05). Makes the account page unmistakably a checklist.

- Removes the standalone 'On-Playa Information / SAP' top section; the **checklist is now the topmost card**.
- Arrival-date / early-entry / camping fields move **inline into the 'Tell us your plans' checklist item** (expanded, still save on change).
- Drops the unused onPlayaRef; selects go full-width on phones.

Kept the 'plans' item in place this pass — moving it below Training (Chipper's closer-to-playa reasoning) is a trivial follow-up. `tsc` clean; before/after previewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)