### PR TITLE
fix(session): off-playa idle timeout = 24h (stop the 5-min re-logins)

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -92,9 +92,17 @@ export const Header = () => {
     );
   };
 
+  // On-playa (shared tablets) keeps the short idle auto-logout so a walk-up
+  // doesn't leave someone else signed in. Off-playa (personal devices) the
+  // idle timeout matches the ~24h session, so people aren't kicked out for
+  // stepping away for a few minutes. Per Mew 2026-07-06.
+  const idleTimeoutMs =
+    process.env.NEXT_PUBLIC_PIN_ENABLED !== "false"
+      ? IDLE_MINUTES * 60 * 1000
+      : 24 * 60 * 60 * 1000;
   useIdleTimer({
     onIdle: handleSignOut,
-    timeout: isDisableIdleEnabled ? undefined : IDLE_MINUTES * 60 * 1000,
+    timeout: isDisableIdleEnabled ? undefined : idleTimeoutMs,
   });
 
   // side effects


### PR DESCRIPTION
The 24h **session** shipped in #465, but a separate **5-minute idle timer** was still logging off-playa users out after a few minutes idle (the constant re-logins Chipper/Mew hit). This sets the off-playa idle timeout to 24h to match the session; **on-playa keeps the short idle logout** (shared tablets). Per Mew 2026-07-06.

One-line behavioral change in Header.tsx. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)