### PR TITLE
fix(home): make 'Sign in' in How-to-Volunteer a real link

### DIFF
--- a/client/src/app/Home.tsx
+++ b/client/src/app/Home.tsx
@@ -200,8 +200,12 @@ export const Home = () => {
                 welcome you to our happy crew!
               </Typography>
               <Typography>
-                Are you ready to become a Census volunteer? Sign in above with
-                your Burner Profile to view shift requirements and sign up. If
+                Are you ready to become a Census volunteer?{" "}
+                <a href={isOAuthConfigured ? "/api/auth/okta" : "/sign-in"}>
+                  Sign in
+                </a>{" "}
+                above with your Burner Profile to view shift requirements and
+                sign up. If
                 you still have questions after reviewing our information, or if
                 you would like to share your ideas about how to make an impact
                 some other way, contact{" "}


### PR DESCRIPTION
Per Chipper 2026-07-06. The How-to-Volunteer paragraph said 'Sign in above' as plain text; the only blue/underlined element in that section was the coordinators email, steering people to email instead of just logging in. Now 'Sign in' is a real link (Okta off-playa / /sign-in on-playa), matching the adjacent email/Discord link styling. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)