### PR TITLE
fix(info): de-emphasize top 'Visit your Burner Profile' link (supersedes #468)

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -1004,10 +1004,19 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
             </Stack>
             <Typography color="text.secondary" sx={{ mt: 1 }} variant="body2">
               Need to update your info?{" "}
+              {/* De-emphasized on purpose (Chipper 2026-07-02): reads as
+                  supporting subtext, not a primary action — the primary
+                  "update your Burner Profile" step lives in the checklist
+                  below. Still a working link, just not blue/underlined. */}
               <a
                 href="https://profiles.burningman.org/my-profile"
                 rel="noopener noreferrer"
                 target="_blank"
+                style={{
+                  color: "inherit",
+                  textDecoration: "none",
+                  fontStyle: "italic",
+                }}
               >
                 Visit your Burner Profile
               </a>


### PR DESCRIPTION
Re-applies #468 on current main (original branch conflicted with the #480 restructure). Makes the top burner-profile link supporting subtext (inherit color, no underline, italic) so the primary action is the checklist step below. Per Chipper. `tsc` clean.