### PR TITLE
feat(shifts): /shifts renders the agenda, replacing the old table (#470)

### DIFF
--- a/client/src/app/shifts/ShiftsAgenda.tsx
+++ b/client/src/app/shifts/ShiftsAgenda.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useContext } from "react";
+
+import { Schedule } from "@/app/volunteers/[shiftboardId]/schedule/Schedule";
+import { SessionContext } from "@/state/session/context";
+
+// /shifts now renders the agenda (Schedule) instead of the old data-table
+// (#470, Chipper 2026-07-06). The agenda needs the current volunteer's
+// shiftboardId, which the schedule route gets from the URL; here we read it
+// from the session instead. Signed out (shiftboardId 0, e.g. on-playa
+// walk-ups) → Schedule shows the open-shift browse view only.
+//
+// The old table lives on in @/app/shifts/Shifts — kept intact so we can revert
+// (point this page back at <Shifts />) or reuse it as the future table view.
+export const ShiftsAgenda = () => {
+  const {
+    sessionState: {
+      user: { shiftboardId },
+    },
+  } = useContext(SessionContext);
+
+  return <Schedule shiftboardId={shiftboardId ?? 0} />;
+};

--- a/client/src/app/shifts/page.tsx
+++ b/client/src/app/shifts/page.tsx
@@ -1,12 +1,14 @@
-import { Shifts } from "@/app/shifts/Shifts";
+import { ShiftsAgenda } from "@/app/shifts/ShiftsAgenda";
 
 export const metadata = {
   title: "Census | Shifts",
 };
+
+// Renders the agenda (see ShiftsAgenda). To revert to the old data-table,
+// swap this back to `import { Shifts } ...` / `return <Shifts />` — the old
+// table component is kept intact at @/app/shifts/Shifts.
 const ShiftsPage = () => {
-  // render
-  // ------------------------------------------------------------
-  return <Shifts />;
+  return <ShiftsAgenda />;
 };
 
 export default ShiftsPage;

--- a/client/src/app/volunteers/[shiftboardId]/schedule/Schedule.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/schedule/Schedule.tsx
@@ -8,19 +8,13 @@ import {
   CardContent,
   Chip,
   Container,
-  FormControl,
-  FormControlLabel,
-  InputLabel,
-  MenuItem,
-  Select,
   Stack,
-  Switch,
   Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import dayjs from "dayjs";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import useSWR from "swr";
 
 import { BreadcrumbsNav } from "@/components/general/BreadcrumbsNav";
@@ -77,14 +71,17 @@ const overlaps = (
 
 export const Schedule = ({ shiftboardId }: IScheduleProps) => {
   const theme = useTheme();
-  const [showOpen, setShowOpen] = useState(true);
-  const [department, setDepartment] = useState("All");
+
+  // Logged-out browse mode (on-playa walk-ups, shiftboardId <= 0): show the
+  // open-shift list only — no personal "your shifts", conflicts, or
+  // eligibility. Authenticated (id > 0) gets the full personalized agenda.
+  const isSignedIn = shiftboardId > 0;
 
   const {
     data: dataMine,
     error: errorMine,
   }: { data: IResVolunteerShiftItem[]; error: Error | undefined } = useSWR(
-    `/api/volunteers/${shiftboardId}/shifts`,
+    isSignedIn ? `/api/volunteers/${shiftboardId}/shifts` : null,
     fetcherGet
   );
   const {
@@ -97,12 +94,12 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
   // timeId -> required role name(s) for shifts this volunteer can't take.
   // Non-blocking: if it hasn't loaded (or errors) we just don't gray anything.
   const { data: dataElig }: { data: Record<number, string[]> } = useSWR(
-    `/api/volunteers/${shiftboardId}/shift-eligibility`,
+    isSignedIn ? `/api/volunteers/${shiftboardId}/shift-eligibility` : null,
     fetcherGet
   );
 
   // Normalize + merge the two sources into one date/time-sorted agenda.
-  const { items, departments } = useMemo(() => {
+  const { items } = useMemo(() => {
     const mine = dataMine ?? [];
     const open = dataOpen ?? [];
     const myTimeIds = new Set(mine.map((m) => m.shift.timeId));
@@ -179,20 +176,16 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
         : a.date.localeCompare(b.date)
     );
 
-    const departments = [
-      "All",
-      ...Array.from(new Set(agenda.map((i) => i.department).filter(Boolean))).sort(),
-    ];
-
-    return { items: agenda, departments };
+    return { items: agenda };
   }, [dataMine, dataOpen, dataElig]);
 
-  // Apply the toggle + department filter, then group into consecutive days.
+  // Present/Future by default — hide past shifts so nobody scrolls past
+  // yesterday to reach today. (The full Timeline/Type/Date/Fill filter set +
+  // "Include my assigned shifts" toggle is the next phase, per #470.) Group
+  // into consecutive days.
   const days = useMemo(() => {
     const filtered = items.filter(
-      (i) =>
-        (showOpen || i.state === "mine") &&
-        (department === "All" || i.department === department)
+      (i) => !dayjs(i.date).isBefore(dayjs(), "day")
     );
     const out: { date: string; dateName: string; items: IAgendaItem[] }[] = [];
     for (const item of filtered) {
@@ -202,7 +195,7 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
         out.push({ date: item.date, dateName: item.dateName, items: [item] });
     }
     return out;
-  }, [items, showOpen, department]);
+  }, [items]);
 
   const mineCount = items.filter((i) => i.state === "mine").length;
 
@@ -214,7 +207,7 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
         backgroundImage: "url(/banners/camp-at-day.jpg)",
         backgroundSize: "cover",
       }}
-      text="My Shifts"
+      text="Shifts"
     />
   );
 
@@ -228,7 +221,7 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
       </>
     );
   }
-  if (!dataMine || !dataOpen) {
+  if (!dataOpen || (isSignedIn && !dataMine)) {
     return (
       <>
         {hero}
@@ -260,60 +253,39 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
       <Container maxWidth="md" component="main">
         <Box sx={{ mb: 3 }}>
           <BreadcrumbsNav>
-            <Typography>My Shifts</Typography>
+            <Typography>Shifts</Typography>
           </BreadcrumbsNav>
         </Box>
 
         <Typography component="h2" variant="h4" sx={{ mb: 1 }}>
-          Your shifts &amp; open shifts
+          {isSignedIn ? "Your shifts & open shifts" : "Census shifts"}
         </Typography>
         <Typography color="text.secondary" sx={{ mb: 2 }}>
-          Everything you&apos;re signed up for, plus what&apos;s still open.
+          {isSignedIn
+            ? "Everything you're signed up for, plus what's still open."
+            : "Browse open Census shifts and sign up."}
         </Typography>
 
-        {/* controls */}
+        {/* legend — the full filter set (Timeline / Type / Date / Fill +
+            "Include my assigned shifts" toggle) is the next phase, per #470 */}
         <Stack
           direction="row"
           spacing={2}
-          alignItems="center"
+          sx={{ mb: 3 }}
           flexWrap="wrap"
           useFlexGap
-          sx={{ mb: 1.5 }}
         >
-          <FormControlLabel
-            control={
-              <Switch
-                checked={showOpen}
-                onChange={(e) => setShowOpen(e.target.checked)}
-              />
-            }
-            label="Show open shifts"
-          />
-          <FormControl size="small" sx={{ minWidth: 170 }}>
-            <InputLabel id="department-filter">Department</InputLabel>
-            <Select
-              labelId="department-filter"
-              label="Department"
-              value={department}
-              onChange={(e) => setDepartment(e.target.value)}
-            >
-              {departments.map((d) => (
-                <MenuItem key={d} value={d}>
-                  {d}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Stack>
-        <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
-          <Typography color="text.secondary" variant="body2">
-            {swatch(theme.palette.success.main)}You&apos;re signed up
-          </Typography>
-          {showOpen && (
+          {isSignedIn && (
             <Typography color="text.secondary" variant="body2">
-              {swatch(theme.palette.secondary.main)}Open — you can join
+              {swatch(theme.palette.success.main)}You&apos;re signed up
             </Typography>
           )}
+          <Typography color="text.secondary" variant="body2">
+            {swatch(theme.palette.secondary.main)}You can sign up
+          </Typography>
+          <Typography color="text.secondary" variant="body2">
+            {swatch(theme.palette.divider)}Unavailable
+          </Typography>
         </Stack>
 
         {days.length === 0 ? (


### PR DESCRIPTION
Per Chipper 2026-07-06 — the real fix: **`/shifts` now renders the agenda** via a thin session-reading wrapper (`ShiftsAgenda`). Every link to /shifts shows the new view; one shifts page. Signed-out (on-playa) → browse view. Present/Future default hides past. Removed the prototype toggle + Dept filter (not in #470); 3-color legend. **Old table kept intact** at `@/app/shifts/Shifts` for the table-view + one-line revert. tsc + eslint clean. Next: full filters + card polish.