### PR TITLE
fix: check-in off-playa + ⋮ reflow + browser-cache headers (#491 #493 #488)

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -5,6 +5,26 @@ const nextConfig: NextConfig = {
   // split). Keep them out of the bundler so pdfjs's ESM worker/eval and
   // formidable's native bits load from node_modules at runtime intact.
   serverExternalPackages: ["pdfjs-dist", "pdf-lib", "formidable"],
+  async headers() {
+    return [
+      {
+        // Force browsers to revalidate HTML documents so a deploy/revert
+        // actually reaches users instead of getting stuck behind a stale
+        // cached page (#488 — this bit us hard on 2026-07-06). Matches page
+        // routes only: NOT /_next/* (hashed static assets keep their built-in
+        // immutable caching), NOT /api/*, and NOT anything with a file
+        // extension (.js/.css/.png/etc.). must-revalidate + no-cache means the
+        // browser may keep a copy but must check it's current on each load.
+        source: "/((?!_next/|api/|.*\\.).*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, must-revalidate",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
@@ -254,6 +254,9 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     );
 
   const isAdmin = checkIsAdmin(accountType, roleList);
+  // Check-in is an on-playa feature; hide the column off-playa (#491) — kept
+  // as a real column (data alignment intact) but excluded from display.
+  const isOnPlaya = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
   const handleCheckInToggle = async ({
     shift: { positionName, timePositionId },
     volunteer: { isCheckedIn, playaName, shiftboardId, worldName },
@@ -328,6 +331,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     {
       name: "Check in",
       options: {
+        display: (isOnPlaya ? "true" : "excluded") as "true" | "excluded",
         filter: false,
         searchable: false,
         setCellHeaderProps: setCellHeaderPropsCenter,

--- a/client/src/components/general/MoreMenu.tsx
+++ b/client/src/components/general/MoreMenu.tsx
@@ -28,6 +28,9 @@ export const MoreMenu = ({ Icon, MenuList }: IMoreMenuProps) => {
       <Menu
         anchorEl={anchorEl}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        // Don't lock body scroll on open — MUI's scrollbar-compensation
+        // reflows the page to a tiny width on mobile (#493).
+        disableScrollLock
         elevation={2}
         onClick={handleMenuClose}
         onClose={handleMenuClose}


### PR DESCRIPTION
Three tested fixes (local production build verified):
- **#488 cache headers** — HTML `no-cache,must-revalidate`, static stays immutable (verified). Stops stale-page pain.
- **#491** — hide check-in column off-playa (display:excluded, data intact).
- **#493** — `disableScrollLock` on MoreMenu so ⋮ stops reflowing the page on mobile.

Approved: #488 by Mew; #491 #493 by Mew/Chipper. `tsc`+eslint clean; account page renders 0 errors in prod build.