### PR TITLE
feat(info): welcome-course checklist item + self-check + return link (#483)

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -191,6 +191,10 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     `/api/volunteers/${shiftboardId}/info/profile-updated`,
     fetcherTrigger
   );
+  const { trigger: triggerWelcomeComplete } = useSWRMutation(
+    `/api/volunteers/${shiftboardId}/info/welcome-complete`,
+    fetcherTrigger
+  );
   const { trigger: triggerEmailPreference } = useSWRMutation(
     `/api/volunteers/${shiftboardId}/info/email-preference`,
     fetcherTrigger
@@ -375,6 +379,34 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     [triggerProfileUpdated, mutate, enqueueSnackbar]
   );
 
+  const handleWelcomeCompleteToggle = useCallback(
+    async (complete: boolean) => {
+      try {
+        await triggerWelcomeComplete({
+          body: { complete },
+          method: "POST",
+        });
+        mutate();
+        enqueueSnackbar(
+          <SnackbarText>
+            Welcome step <strong>updated</strong>
+          </SnackbarText>,
+          { variant: "success" }
+        );
+      } catch (error) {
+        if (error instanceof Error) {
+          enqueueSnackbar(
+            <SnackbarText>
+              <strong>{error.message}</strong>
+            </SnackbarText>,
+            { persist: true, variant: "error" }
+          );
+        }
+      }
+    },
+    [triggerWelcomeComplete, mutate, enqueueSnackbar]
+  );
+
   // role toggle handler
   const handleRoleToggle = useCallback(
     async (roleId: number, roleName: string, hasRole: boolean) => {
@@ -460,6 +492,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     shifts,
     trainings,
     volunteer,
+    welcomeComplete,
   } = data;
 
   const isAdmin = checkIsAdmin(accountType, roleListSession);
@@ -899,6 +932,43 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
       ),
     });
   }
+
+  // Welcome course (#483): learn about Census on the Burning Man Hive.
+  // Completes either via the self-check below or by clicking through from the
+  // end of the Hive course (which hits /welcome-complete → POSTs complete=true).
+  checklistItems.push({
+    id: "welcome",
+    label: welcomeComplete
+      ? "Learned about Census on Burning Man Hive"
+      : "Learn more about Census by reviewing the information on Burning Man Hive",
+    done: welcomeComplete,
+    content: (
+      <Box>
+        <Typography sx={{ mb: 1 }}>
+          Get to know Census and what your volunteering makes possible. Review
+          the information on the Burning Man Hive.
+        </Typography>
+        <Typography sx={{ mb: 1 }}>
+          <a
+            href="https://hive.burningman.org/spaces/14264554"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Open the Census Hive page
+          </a>
+        </Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={welcomeComplete}
+              onChange={(e) => handleWelcomeCompleteToggle(e.target.checked)}
+            />
+          }
+          label="I am already familiar with this information. Mark this item as complete."
+        />
+      </Box>
+    ),
+  });
 
   // Permanent CTA (per Chipper 2026-07-01): always present, always the FIRST
   // item, and intentionally never checks off — a standing prompt to view/add

--- a/client/src/app/welcome-complete/page.tsx
+++ b/client/src/app/welcome-complete/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { CircularProgress, Container, Stack, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+import { useContext, useEffect, useRef } from "react";
+
+import { SessionContext } from "@/state/session/context";
+
+// Return link volunteers click from the END of the Census welcome course on
+// the Burning Man Hive. Marks the "welcome" checklist item complete for the
+// signed-in volunteer, then drops them back on their info/checklist page.
+// If not signed in, bounce through sign-in with returnTo so they come back
+// here after authenticating. (#483)
+const WelcomeCompletePage = () => {
+  // context
+  // ------------------------------------------------------------
+  const {
+    sessionState: {
+      settings: { isAuthenticated },
+      user: { shiftboardId },
+    },
+  } = useContext(SessionContext);
+
+  // other hooks
+  // ------------------------------------------------------------
+  const router = useRouter();
+  const hasProcessed = useRef(false);
+
+  // side effects
+  // ------------------------------------------------------------
+  useEffect(() => {
+    // SessionProvider hydrates isAuthenticated from sessionStorage in its own
+    // effect. Wait for that: only redirect to sign-in once we know for sure
+    // there's no session (isAuthenticated stays false and shiftboardId 0).
+    if (hasProcessed.current) return;
+
+    if (!isAuthenticated || !shiftboardId) {
+      // Give hydration a tick; if still unauthenticated, send to sign-in.
+      const timer = setTimeout(() => {
+        if (hasProcessed.current) return;
+        hasProcessed.current = true;
+        router.replace("/sign-in?returnTo=/welcome-complete");
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+
+    hasProcessed.current = true;
+    const infoPath = `/volunteers/${shiftboardId}/info`;
+    fetch(`/api/volunteers/${shiftboardId}/info/welcome-complete`, {
+      method: "POST",
+      body: JSON.stringify({ complete: true }),
+    })
+      .catch(() => {
+        // Non-fatal: the volunteer can still self-check on the checklist.
+      })
+      .finally(() => {
+        router.replace(infoPath);
+      });
+  }, [isAuthenticated, shiftboardId, router]);
+
+  // render
+  // ------------------------------------------------------------
+  return (
+    <Container
+      component="main"
+      sx={{
+        alignItems: "center",
+        display: "flex",
+        justifyContent: "center",
+        pt: 6,
+      }}
+    >
+      <Stack alignItems="center" spacing={2}>
+        <CircularProgress color="secondary" />
+        <Typography color="text.secondary">
+          Marking your welcome step complete&hellip;
+        </Typography>
+      </Stack>
+    </Container>
+  );
+};
+
+export default WelcomeCompletePage;

--- a/client/src/components/types/volunteer-info.ts
+++ b/client/src/components/types/volunteer-info.ts
@@ -12,6 +12,9 @@ export interface IReqToggleOtherSap {
 export interface IReqToggleProfileUpdated {
   updated: boolean;
 }
+export interface IReqToggleWelcomeComplete {
+  complete: boolean;
+}
 export interface IReqToggleEmailUnsubscribed {
   unsubscribed: boolean;
 }
@@ -76,6 +79,7 @@ export interface IResVolunteerInfo {
     csp: number;
   }[];
   burnerProfileUpdated: boolean;
+  welcomeComplete: boolean;
   behavioralStandardsSigned: boolean;
   emailUnsubscribed: boolean;
 }

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -14,6 +14,7 @@ import { buildRequiredDays, PRE_OPEN_DATENAMES } from "lib/sapStatus";
 const ROLE_STAFF_ID = 2000006;
 const ROLE_OTHER_SAP_ID = 2000007;
 const ROLE_BURNER_PROFILE_UPDATED_ID = 2000010;
+const ROLE_WELCOME_COMPLETE_ID = 174766;
 const ROLE_BEHAVIORAL_STANDARDS_ID = 1000012;
 const ROLE_EMAIL_UNSUBSCRIBED_ID = 2000020;
 
@@ -261,6 +262,7 @@ const volunteerInfo = async (
       }
 
       const burnerProfileUpdated = roleIdSet.has(ROLE_BURNER_PROFILE_UPDATED_ID);
+      const welcomeComplete = roleIdSet.has(ROLE_WELCOME_COMPLETE_ID);
       const behavioralStandardsSigned = roleIdSet.has(
         ROLE_BEHAVIORAL_STANDARDS_ID
       );
@@ -318,6 +320,7 @@ const volunteerInfo = async (
           csp: s.sap_points ?? 0,
         })),
         burnerProfileUpdated,
+        welcomeComplete,
         behavioralStandardsSigned,
         emailUnsubscribed,
       };

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/welcome-complete/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/welcome-complete/index.ts
@@ -1,0 +1,93 @@
+import { RowDataPacket } from "mysql2";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { IReqToggleWelcomeComplete } from "@/components/types/volunteer-info";
+import { pool } from "lib/database";
+import { withAuth } from "@/lib/withAuth";
+import { isOwnerOrAdmin } from "@/lib/authz";
+
+const ROLE_WELCOME_COMPLETE_ID = 174766;
+
+const welcomeComplete = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session: { shiftboardId: number }
+) => {
+  const { shiftboardId } = req.query;
+
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
+
+  switch (req.method) {
+    // post
+    // ------------------------------------------------------------
+    case "POST": {
+      const { complete }: IReqToggleWelcomeComplete = JSON.parse(req.body);
+
+      // GET (info/index.ts) computes welcomeComplete from row existence:
+      // `roleIdSet.has(ROLE_WELCOME_COMPLETE_ID)`. So to actually uncheck
+      // the box we must DELETE the row; flipping add_role/remove_role keeps
+      // it visible. (Mirrors profile-updated, issue #332.)
+      if (complete === false) {
+        await pool.query<RowDataPacket[]>(
+          `DELETE FROM op_volunteer_roles
+          WHERE role_id=?
+          AND shiftboard_id=?`,
+          [ROLE_WELCOME_COMPLETE_ID, shiftboardId]
+        );
+        return res.status(200).json({
+          statusCode: 200,
+          message: "Deleted",
+        });
+      }
+
+      // complete === true: ensure the row exists with add_role=true.
+      const [dbVolunteerRoleList] = await pool.query<RowDataPacket[]>(
+        `SELECT shiftboard_id
+        FROM op_volunteer_roles
+        WHERE role_id=?
+        AND shiftboard_id=?`,
+        [ROLE_WELCOME_COMPLETE_ID, shiftboardId]
+      );
+      const [dbVolunteerRoleFirst] = dbVolunteerRoleList;
+
+      if (dbVolunteerRoleFirst) {
+        await pool.query<RowDataPacket[]>(
+          `UPDATE op_volunteer_roles
+          SET add_role=?, remove_role=?
+          WHERE role_id=?
+          AND shiftboard_id=?`,
+          [true, false, ROLE_WELCOME_COMPLETE_ID, shiftboardId]
+        );
+      } else {
+        await pool.query<RowDataPacket[]>(
+          `INSERT INTO op_volunteer_roles (
+            add_role,
+            remove_role,
+            role_id,
+            shiftboard_id
+          )
+          VALUES (?, ?, ?, ?)`,
+          [true, false, ROLE_WELCOME_COMPLETE_ID, shiftboardId]
+        );
+      }
+
+      return res.status(201).json({
+        statusCode: 201,
+        message: "Created",
+      });
+    }
+
+    // default
+    // ------------------------------------------------------------
+    default: {
+      return res.status(404).json({
+        statusCode: 404,
+        message: "Not found",
+      });
+    }
+  }
+};
+
+export default withAuth(welcomeComplete);


### PR DESCRIPTION
Wires role 174766 into a new checklist item (Hive link + self-check), a marker-role POST endpoint (mirrors profile-updated), the info GET welcomeComplete flag, and a /welcome-complete return page for the end of the Hive course. Tested in a local prod build against real data (both role states, no crash, return page redirects).