### PR TITLE
fix(roles): welcome marker role display name (#500)

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -101,6 +101,7 @@ const ROLE_DISPLAY_NAMES: Record<string, string> = {
   TrainingOutReachComplete: "Training: OutReach",
   TrainingDataEntryWizComplete: "Training: Data Entry Wiz",
   TrainingDataBeastDriverComplete: "Training: Data Beast Driver",
+  TrainingWelcomeComplete: "Training: Welcome",
 };
 
 // format ISO date string to readable format like "Aug 17"


### PR DESCRIPTION
Adds TrainingWelcomeComplete -> 'Training: Welcome' to ROLE_DISPLAY_NAMES; DB field renamed to camelCase to match the other Training:* roles. Systemic issue in #500.