### PR TITLE
fix(info): welcome checklist item leads the list

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -1001,6 +1001,15 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     ),
   });
 
+  // Welcome leads the checklist — learn about Census first, then pick shifts
+  // (Chipper 2026-07-09). Pull it ahead of the view/add-shifts item (which was
+  // just unshifted to index 0).
+  const welcomeIdx = checklistItems.findIndex((i) => i.id === "welcome");
+  if (welcomeIdx > 0) {
+    const [welcomeItem] = checklistItems.splice(welcomeIdx, 1);
+    checklistItems.unshift(welcomeItem);
+  }
+
   const incompleteItems = checklistItems.filter((item) => !item.done);
   const completedItems = checklistItems.filter((item) => item.done);
 


### PR DESCRIPTION
Chipper 2026-07-09: welcome item to the top (learn first, then pick shifts). Verified in a local prod build against real data.