### PR TITLE
feat(shift-detail): position alias + roster/Positions mobile cards

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -705,11 +705,48 @@ export const ShiftVolunteers = ({
           <Typography component="h2" variant="h4" sx={{ mb: 2 }}>
             Positions
           </Typography>
-          <DataTable
-            columnList={columnListPositions}
-            dataTable={dataTablePositions}
-            optionListCustom={optionListCustomPositions}
-          />
+          {isMobile ? (
+            <Stack spacing={1}>
+              {dataShiftVolunteersItem.positionList.map(
+                ({
+                  csp,
+                  positionName,
+                  slotsFilled,
+                  slotsTotal,
+                }: IResShiftPositionCountItem) => (
+                  <Box
+                    key={`${positionName}-position-card`}
+                    sx={{
+                      bgcolor: "background.paper",
+                      border: 1,
+                      borderColor: "divider",
+                      borderRadius: 1,
+                      px: 2,
+                      py: 1,
+                    }}
+                  >
+                    {/* line 1: position name (bold) */}
+                    <Typography sx={{ fontWeight: 700 }}>
+                      {positionName}
+                    </Typography>
+                    {/* line 2: filled / total + CSP (secondary, no labels) */}
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "text.secondary" }}
+                    >
+                      {slotsFilled} / {slotsTotal} · CSP {csp}
+                    </Typography>
+                  </Box>
+                )
+              )}
+            </Stack>
+          ) : (
+            <DataTable
+              columnList={columnListPositions}
+              dataTable={dataTablePositions}
+              optionListCustom={optionListCustomPositions}
+            />
+          )}
         </Box>
         <Box component="section">
           <Stack
@@ -748,7 +785,7 @@ export const ShiftVolunteers = ({
             </Button>
           </Stack>
           {isMobile ? (
-            <Box>
+            <Stack spacing={1}>
               {dataShiftVolunteersItem.volunteerList.map(
                 ({
                   isCheckedIn,
@@ -763,8 +800,11 @@ export const ShiftVolunteers = ({
                   <Box
                     key={`${shiftboardId}-shift-volunteer-card`}
                     sx={{
-                      borderBottom: 1,
+                      bgcolor: "background.paper",
+                      border: 1,
                       borderColor: "divider",
+                      borderRadius: 1,
+                      px: 2,
                       py: 1,
                     }}
                   >
@@ -885,7 +925,7 @@ export const ShiftVolunteers = ({
                   </Box>
                 )
               )}
-            </Box>
+            </Stack>
           ) : (
             <DataTable
               columnList={columnListVolunteers}

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -35,7 +35,7 @@ const shiftVolunteers = async (
           d.date,
           d.datename,
           pt.position_details,
-          pt.position,
+          COALESCE(NULLIF(stp.position_alias, ''), pt.position) AS position,
           pt.prerequisite_id,
           pt.role_id,
           pt.max_per_volunteer,
@@ -72,7 +72,7 @@ const shiftVolunteers = async (
       );
       const [dbShiftVolunteerList] = await pool.query<RowDataPacket[]>(
         `SELECT
-          pt.position,
+          COALESCE(NULLIF(stp.position_alias, ''), pt.position) AS position,
           stp.position_type_id,
           v.playa_name,
           v.world_name,

--- a/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
@@ -30,7 +30,7 @@ const volunteerShifts = async (
         `SELECT
           d.date,
           d.datename,
-          pt.position,
+          COALESCE(NULLIF(stp.position_alias, ''), pt.position) AS position,
           stp.position_type_id,
           stp.sap_points,
           sc.department,


### PR DESCRIPTION
Mew: position alias everywhere (shift-detail + volunteer-shifts APIs, COALESCE fallback); roster cards get a background; Positions table gets compact mobile cards. Validated on an aliased shift.