### PR TITLE
fix(fetcher): throw on non-2xx so API errors show ErrorPage, not a white-screen

### DIFF
--- a/client/src/utils/fetcher.ts
+++ b/client/src/utils/fetcher.ts
@@ -1,5 +1,16 @@
-export const fetcherGet = async (url: string) =>
-  fetch(url).then((res) => res.json());
+export const fetcherGet = async (url: string) => {
+  const res = await fetch(url);
+  // Throw on non-2xx so SWR sets `error` (and retries) instead of handing the
+  // error body back as `data`. Without this, a transient API failure (e.g. a
+  // wedged DB pool → 500, or a 404 for a removed volunteer) got destructured
+  // as if it were a real payload and white-screened the page. Callers already
+  // guard with `if (error) return <ErrorPage/>`.
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? `Request failed (${res.status})`);
+  }
+  return res.json();
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fetcherTrigger = async (url: string, { arg }: { arg: any }) =>


### PR DESCRIPTION
## Problem

Mew hit `Application error: a client-side exception has occurred` loading
`/volunteers/820897/info` in prod. 820897's data is fine (exists, not deleted,
5 roles, clean shifts) and the page renders fine now — the failure was **transient**.

Root cause: `fetcherGet` did `fetch(url).then(res => res.json())` for **any**
status. A non-200 body — a transient 500 (very likely the recurring mysql2 pool
wedge, #prod-pool) or a 404 for a removed volunteer — was handed back to SWR as
`data`, then destructured as if it were a real payload (`roles.includes(...)` →
`undefined.includes` → white-screen), instead of hitting the intended
`if (error) return <ErrorPage/>` path.

Reproduced deterministically on `/volunteers/26302/{account,info}` (26302 is a
permanent 404 — no `op_volunteers` row) and via a simulated 500 on
`/volunteers/820897/info` (the transient case). Both white-screened before.

## Fix

`fetcherGet` now throws on `!res.ok`, so SWR sets `error` **and retries**
transient failures. One shared util, all 34 callers covered.

- `fetcherTrigger` is intentionally left unchanged — `SignIn.tsx` relies on it
  returning the 404 body to inspect `statusCode === 404`.
- Healthy 200s are byte-identical to before (`return res.json()`), so no
  behavior change on working pages.

## Testing (local off-playa prod build, matching prod's `NEXT_PUBLIC_PIN_ENABLED="false"`)

| Scenario | Before | After |
|---|---|---|
| `/volunteers/26302/account` (404) | white-screen | graceful ErrorPage |
| `/volunteers/820897/info` + simulated 500 | white-screen | graceful ErrorPage (SWR retries) |
| healthy pages (`/info`, `/volunteers`) | ok | ok (no regression) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)