### PR TITLE
feat(shift-detail): hide check-in + admin review before the shift; rename add button for non-admins

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -483,28 +483,33 @@ export const ShiftVolunteers = ({
         playaName,
         worldName,
         positionName,
-        <Switch
-          checked={isCheckedIn === ""}
-          disabled={!isCheckInAvailable}
-          onChange={(event) =>
-            handleCheckInToggle({
-              shift: {
-                positionName,
-                timePositionId,
-              },
-              volunteer: {
-                isCheckedIn: event.target.checked,
-                playaName,
-                shiftboardId,
-                worldName,
-              },
-            })
-          }
-          key={`${shiftboardId}-shift-volunteer`}
-        />,
-        // if volunteer is admin
+        // Check-in only appears once the shift's check-in window is open
+        // (getCheckInType !== SHIFT_FUTURE); before that it's meaningless.
+        isCheckInAvailable ? (
+          <Switch
+            checked={isCheckedIn === ""}
+            onChange={(event) =>
+              handleCheckInToggle({
+                shift: {
+                  positionName,
+                  timePositionId,
+                },
+                volunteer: {
+                  isCheckedIn: event.target.checked,
+                  playaName,
+                  shiftboardId,
+                  worldName,
+                },
+              })
+            }
+            key={`${shiftboardId}-shift-volunteer`}
+          />
+        ) : (
+          ""
+        ),
+        // if volunteer is admin AND check-in is open,
         // then display volunteer shift review and volunteer menu
-        isAdmin && (
+        isAdmin && isCheckInAvailable && (
           <IconButton
             onClick={() => {
               setDialogCurrent({
@@ -781,7 +786,7 @@ export const ShiftVolunteers = ({
               type="button"
               variant="contained"
             >
-              Add volunteer
+              {isAdmin ? "Add volunteer" : "Add this shift"}
             </Button>
           </Stack>
           {isMobile ? (
@@ -834,25 +839,26 @@ export const ShiftVolunteers = ({
                         {positionName}
                       </Typography>
                       <Stack alignItems="center" direction="row">
-                        <Switch
-                          checked={isCheckedIn === ""}
-                          disabled={!isCheckInAvailable}
-                          onChange={(event) =>
-                            handleCheckInToggle({
-                              shift: {
-                                positionName,
-                                timePositionId,
-                              },
-                              volunteer: {
-                                isCheckedIn: event.target.checked,
-                                playaName,
-                                shiftboardId,
-                                worldName,
-                              },
-                            })
-                          }
-                        />
-                        {isAdmin && (
+                        {isCheckInAvailable && (
+                          <Switch
+                            checked={isCheckedIn === ""}
+                            onChange={(event) =>
+                              handleCheckInToggle({
+                                shift: {
+                                  positionName,
+                                  timePositionId,
+                                },
+                                volunteer: {
+                                  isCheckedIn: event.target.checked,
+                                  playaName,
+                                  shiftboardId,
+                                  worldName,
+                                },
+                              })
+                            }
+                          />
+                        )}
+                        {isAdmin && isCheckInAvailable && (
                           <IconButton
                             onClick={() => {
                               setDialogCurrent({


### PR DESCRIPTION
Two shift-detail tweaks per Mew (2026-07-09).

## 1. Hide check-in + admin review before the shift
Before a shift's check-in window opens (`getCheckInType === SHIFT_FUTURE` →
`isCheckInAvailable === false`), the check-in toggle and the admin review (chat)
icon are meaningless — nobody can be checked in yet. They previously rendered
anyway (the switch just disabled). Now both are gated on `isCheckInAvailable`,
reusing the exact logic that governs when anyone can check *themselves* in.

- Applies to both the desktop DataTable cells and the mobile roster cards.
- The admin ⋮ actions menu (view account / remove) is **unchanged** — still
  available to admins pre-shift.

## 2. Rename the add button for non-admins
Non-admins now see **"Add this shift"** (it's self-signup for them); admins keep
**"Add volunteer"**.

## Testing (local off-playa prod build, future-dated Artist shift = SHIFT_FUTURE)

Verified on a real future shift (`/shifts/63/volunteers`) at mobile width:

| View | Check-in switch | Admin review icon | ⋮ menu | Add button |
|---|---|---|---|---|
| Admin, pre-shift | hidden ✓ | hidden ✓ | shown ✓ | "Add volunteer" ✓ |
| Non-admin, pre-shift | hidden ✓ | n/a | n/a | "Add this shift" ✓ |

During/after the check-in window (`isCheckInAvailable === true`) the switch and
review render exactly as before (unchanged JSX, only the wrapping condition
changed). `tsc` clean via `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)