### PR TITLE
feat(shift-detail): sort lead positions first, then non-lead critical, then by name

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -416,10 +416,9 @@ export const ShiftVolunteers = ({
     filter: false,
     pagination: false,
     search: false,
-    sortOrder: {
-      direction: "asc" as const,
-      name: "Name",
-    },
+    // No default sortOrder: the API already returns positions in priority
+    // order (lead first, then non-lead critical, then the rest alphabetically).
+    // Column headers stay clickable for ad-hoc re-sorting.
   };
 
   // prepare datatable volunteers
@@ -577,10 +576,9 @@ export const ShiftVolunteers = ({
     }
   );
   const optionListCustomVolunteers = {
-    sortOrder: {
-      direction: "asc" as const,
-      name: "Playa name",
-    },
+    // No default sortOrder: the API already returns the roster in priority
+    // order (lead positions first, then non-lead critical, then the rest by
+    // playa name). Column headers stay clickable for ad-hoc re-sorting.
   };
 
   // render

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -67,7 +67,13 @@ const shiftVolunteers = async (
         AND pt.position_type_id=stp.position_type_id
         WHERE st.remove_shift_time=false
         AND st.shift_times_id=?
-        ORDER BY pt.position COLLATE utf8mb4_general_ci`,
+        ORDER BY
+          CASE
+            WHEN pt.\`lead\`=1 THEN 0
+            WHEN pt.critical=1 THEN 1
+            ELSE 2
+          END,
+          pt.position COLLATE utf8mb4_general_ci`,
         [timeId]
       );
       const [dbShiftVolunteerList] = await pool.query<RowDataPacket[]>(
@@ -94,6 +100,11 @@ const shiftVolunteers = async (
         AND v.shiftboard_id=vs.shiftboard_id
         WHERE vs.remove_shift=false
         ORDER BY
+          CASE
+            WHEN pt.\`lead\`=1 THEN 0
+            WHEN pt.critical=1 THEN 1
+            ELSE 2
+          END,
           v.playa_name COLLATE utf8mb4_general_ci,
           v.world_name COLLATE utf8mb4_general_ci`,
         [timeId]


### PR DESCRIPTION
Per Mew (2026-07-09): on the shift-detail page, both the **Positions list** and
the **volunteer roster** should lead with lead-flagged positions, then non-lead
critical, then everyone else — and then sort by playa name.

## How
Sorted in SQL via a priority tier:
```sql
CASE WHEN pt.`lead`=1 THEN 0 WHEN pt.critical=1 THEN 1 ELSE 2 END
```
- **Positions** break ties by position name.
- **Roster** breaks ties by playa name, then world name.
- `lead` is a MySQL reserved word → backticked.
- Removed the DataTable default `sortOrder` on both tables so the **desktop**
  view honors the API's priority order (the **mobile** cards already render in
  array order). Column headers remain clickable for ad-hoc re-sorting.

No type/shape changes — the client renders each list in the order the API
returns it.

## Testing (local off-playa prod build, shift 5 — 4 positions mixed lead/critical, 14 volunteers)

Positions order: `Gate Sampling Lead` (lead) → `DataBeast Driver` (non-lead critical) → `Gate Sampler`, `Traffic Tamer`.

Roster order (verified at **both** desktop table + mobile cards):
Cali Green, Dan, Rocket (Gate Sampling Lead) → Jeremiah (DataBeast Driver) → Ben, Christina, … (Gate Sampler/Traffic Tamer, alphabetical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)