### PR TITLE
feat(reports): link to blackrockcitycensus.org for the full reports

### DIFF
--- a/client/src/app/reports/Reports.tsx
+++ b/client/src/app/reports/Reports.tsx
@@ -9,6 +9,7 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
+  Typography,
 } from "@mui/material";
 import Link from "next/link";
 
@@ -45,6 +46,17 @@ export const Reports = () => {
       <Container component="main" sx={{ flex: 1 }}>
         <Card>
           <CardContent>
+            <Typography sx={{ mb: 2 }}>
+              For the complete Black Rock City Census reports, visit{" "}
+              <Link
+                href="https://blackrockcitycensus.org"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                blackrockcitycensus.org
+              </Link>
+              .
+            </Typography>
             <List disablePadding>
               {reportList.map(({ id, text, url }) => {
                 return (


### PR DESCRIPTION
Per Mew — an interim callout above the in-app report list linking to the full Black Rock City Census reports on blackrockcitycensus.org, until they're copied into the app.

Copy-only. Verified on a local prod build (link renders in census-pink above the existing report list; opens in a new tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)