### PR TITLE
Flip /shifts to the agenda; retire separate My Shifts

### DIFF
--- a/client/src/app/shifts/ShiftsAgenda.tsx
+++ b/client/src/app/shifts/ShiftsAgenda.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useContext } from "react";
+
+import { Schedule } from "@/app/volunteers/[shiftboardId]/schedule/Schedule";
+import { SessionContext } from "@/state/session/context";
+
+// ponytail: the agenda IS the Shifts page now (the "My Shifts" flip). Schedule
+// was already built to handle both a signed-out walk-up (shiftboardId 0 →
+// browse-only) and a signed-in volunteer (personal shifts + eligibility), so
+// /shifts just feeds it the session id. Revert = repoint page.tsx back to the
+// old <Shifts> table, which is intentionally kept one import away.
+export const ShiftsAgenda = () => {
+  const {
+    sessionState: {
+      user: { shiftboardId },
+    },
+  } = useContext(SessionContext);
+
+  return <Schedule shiftboardId={shiftboardId} />;
+};

--- a/client/src/app/shifts/page.tsx
+++ b/client/src/app/shifts/page.tsx
@@ -1,4 +1,4 @@
-import { Shifts } from "@/app/shifts/Shifts";
+import { ShiftsAgenda } from "@/app/shifts/ShiftsAgenda";
 
 export const metadata = {
   title: "Census | Shifts",
@@ -6,7 +6,7 @@ export const metadata = {
 const ShiftsPage = () => {
   // render
   // ------------------------------------------------------------
-  return <Shifts />;
+  return <ShiftsAgenda />;
 };
 
 export default ShiftsPage;

--- a/client/src/app/volunteers/[shiftboardId]/schedule/page.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/schedule/page.tsx
@@ -1,26 +1,10 @@
-import { Schedule } from "@/app/volunteers/[shiftboardId]/schedule/Schedule";
-import { AuthGate } from "@/components/general/AuthGate";
-import { ACCOUNT_TYPE_AUTHENTICATED } from "@/constants";
+import { redirect } from "next/navigation";
 
-interface ISchedulePageProps {
-  params: Promise<{ shiftboardId: string }>;
-}
-
-export const metadata = {
-  title: "Census | My Shifts",
-};
-const SchedulePage = async ({ params }: ISchedulePageProps) => {
-  // logic
-  // ------------------------------------------------------------
-  const { shiftboardId } = await params;
-
-  // render
-  // ------------------------------------------------------------
-  return (
-    <AuthGate accountTypeToCheck={ACCOUNT_TYPE_AUTHENTICATED}>
-      <Schedule shiftboardId={Number(shiftboardId)} />
-    </AuthGate>
-  );
+// My Shifts is no longer a separate page — /shifts IS the agenda now (the flip).
+// Redirect any old bookmarks/links here to the single Shifts page, which reads
+// the signed-in volunteer from the session and shows the same personal view.
+const SchedulePage = () => {
+  redirect("/shifts");
 };
 
 export default SchedulePage;

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,5 +1,4 @@
 import {
-  CalendarMonth as CalendarMonthIcon,
   ExpandLess as ExpandLessIcon,
   ExpandMore as ExpandMoreIcon,
   Login as LoginIcon,
@@ -329,23 +328,6 @@ export const Header = () => {
                         <ManageAccountsIcon />
                       </ListItemIcon>
                       <ListItemText>Account</ListItemText>
-                    </ListItemButton>
-                  </Link>
-                </ListItem>
-                <ListItem disablePadding>
-                  <Link
-                    href={`/volunteers/${shiftboardId}/schedule`}
-                    onClick={handleDrawerClose}
-                  >
-                    <ListItemButton
-                      selected={
-                        pathname === `/volunteers/${shiftboardId}/schedule`
-                      }
-                    >
-                      <ListItemIcon>
-                        <CalendarMonthIcon />
-                      </ListItemIcon>
-                      <ListItemText>My Shifts</ListItemText>
                     </ListItemButton>
                   </Link>
                 </ListItem>


### PR DESCRIPTION
Makes the agenda the single **Shifts** page and drops **My Shifts** as a separate entity (Chipper sign-off 2026-07-17; Mew pre-approved).

## What changed
- `/shifts` now renders the agenda (`<ShiftsAgenda>` → `<Schedule>`), reading the signed-in volunteer's `shiftboardId` from the session.
- Removed the separate **My Shifts** drawer entry — it's now the My-Shifts filter toggle inside the one Shifts page.
- Old `/volunteers/[id]/schedule` **redirects to `/shifts`** so bookmarks/links still land.
- The old `<Shifts>` data-table is kept one import away as trivial revert insurance (repoint `page.tsx`).

## Why it's low-risk
`Schedule` was already built to handle both a signed-out walk-up (`shiftboardId 0` → browse-only) and a signed-in volunteer, and its cards link to the **same** `/shifts/[timeId]/volunteers` page the old table did — so the **on-playa check-in flow is unchanged**. (This is the flip that was reverted once before as #504; the agenda has since been stabilized via #505/#498.)

## Verification (against production builds, rendered authed)
- **Off-playa / volunteer**: `/shifts` renders the agenda — day headers, slot counts, CSP, 🚫 Full, 🔒 role-gating, ⚠️ conflicts, ✓ "You're signed up". Old table gone. Redirect confirmed. Zero console errors.
- **On-playa / walk-up (unauth kiosk)**: `/shifts` stays open (allowlisted), renders browse-only — no personal markers, My-Shifts toggle hidden. Zero console errors. (This path the old auth-gated My Shifts route never exercised.)
- `tsc --noEmit` clean; `next build` clean for both on-playa and off-playa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)