### PR TITLE
fix(shift-detail): "Add this shift" label on the position-add dialog for non-admins

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogAdd.tsx
@@ -1151,7 +1151,7 @@ export const ShiftVolunteersDialogAdd = ({
             type="submit"
             variant="contained"
           >
-            Add volunteer
+            {isAdmin ? "Add volunteer" : "Add this shift"}
           </Button>
         </DialogActions>
       </form>


### PR DESCRIPTION
Chipper review item #7 (Mew-approved). The outer add button was made non-admin-aware in #525, but the **pop-up dialog** (after a volunteer picks a position) still said "Add volunteer". This mirrors the same `isAdmin ? "Add volunteer" : "Add this shift"` conditional (identical to the already-verified pattern in `ShiftVolunteers.tsx:787`) so a regular volunteer sees "Add this shift" all the way through.

One-line label change; `isAdmin` already in scope. `tsc --noEmit` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)