### PR TITLE
copy: homepage copy for logged-in users + Census-on-Hive wording (#4/#5/#6)

### DIFF
--- a/client/src/app/Home.tsx
+++ b/client/src/app/Home.tsx
@@ -58,18 +58,26 @@ export const Home = () => {
             2026 Black Rock City Census volunteer shifts are now open!
           </Typography>
 
-          <Typography sx={{ mb: 2 }}>
-            Sign in below with your Burner Profile to view shift requirements and
-            sign up. Don&apos;t have a Burner Profile yet? Create one at{" "}
-            <a
-              href="https://profiles.burningman.org"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              profiles.burningman.org
-            </a>
-            .
-          </Typography>
+          {isAuthenticated ? (
+            <Typography sx={{ mb: 2 }}>
+              You&apos;re signed in. View your account below, or head to the{" "}
+              <Link href="/shifts">Shifts</Link> page to see requirements and sign
+              up.
+            </Typography>
+          ) : (
+            <Typography sx={{ mb: 2 }}>
+              Sign in below with your Burner Profile to view shift requirements and
+              sign up. Don&apos;t have a Burner Profile yet? Create one at{" "}
+              <a
+                href="https://profiles.burningman.org"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                profiles.burningman.org
+              </a>
+              .
+            </Typography>
+          )}
 
           {/*
            * Login affordance sits between the header and the body copy
@@ -200,13 +208,23 @@ export const Home = () => {
                 welcome you to our happy crew!
               </Typography>
               <Typography>
-                Are you ready to become a Census volunteer?{" "}
-                <a href={isOAuthConfigured ? "/api/auth/okta" : "/sign-in"}>
-                  Sign in
-                </a>{" "}
-                above with your Burner Profile to view shift requirements and
-                sign up. If
-                you still have questions after reviewing our information, or if
+                {isAuthenticated ? (
+                  <>
+                    You&apos;re all set — use the{" "}
+                    <Link href="/shifts">Shifts</Link> page above to view shift
+                    requirements and sign up.
+                  </>
+                ) : (
+                  <>
+                    Are you ready to become a Census volunteer?{" "}
+                    <a href={isOAuthConfigured ? "/api/auth/okta" : "/sign-in"}>
+                      Sign in
+                    </a>{" "}
+                    above with your Burner Profile to view shift requirements and
+                    sign up.
+                  </>
+                )}{" "}
+                If you still have questions after reviewing our information, or if
                 you would like to share your ideas about how to make an impact
                 some other way, contact{" "}
                 <a href="mailto:censusvolunteercoordinators@burningman.org">
@@ -236,7 +254,7 @@ export const Home = () => {
               <Typography>
                 Brief descriptions of the various volunteer roles are below.
                 More information about roles and the training necessary for each
-                can be found at our Census Hive site linked above.
+                can be found in our Census Community on Hive, linked above.
               </Typography>
               <Typography>
                 <strong>Random Samplers</strong> are stationed on Gate Road or

--- a/client/src/app/volunteers/[shiftboardId]/info/GetInvolved.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/GetInvolved.tsx
@@ -19,10 +19,10 @@ interface IGetInvolvedItem {
 // Order per Chipper 2026-07-05: Hive first, Discord last.
 const ITEMS: IGetInvolvedItem[] = [
   {
-    title: "Explore Census Hive",
+    title: "Explore the Census Community on Hive",
     description:
-      "The Census Hive page is a great place to dive into the BRC Census pool. Volunteer training is conducted on Hive, and there’s tonnes to learn about our various volunteer opportunities while you’re there. Log in using your Burner Profile ID and password.",
-    linkLabel: "Visit Census Hive",
+      "The Census Hive Community is a great place to dive into the BRC Census pool. Volunteer training is conducted on Hive, and there’s tonnes to learn about our various volunteer opportunities while you’re there. Log in using your Burner Profile ID and password.",
+    linkLabel: "Visit the Census Community on Hive",
     href: "https://hive.burningman.org/spaces/14264554",
   },
   {

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -852,8 +852,8 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
       content: (
         <Box>
           <Typography sx={{ mb: 1 }}>
-            Complete each required training course on Census Hive. Click a
-            course name below to open it.
+            Complete each required training course in the Census Community on
+            Hive. Click a course name below to open it.
           </Typography>
           {trainings.map((t) => (
             <Stack


### PR DESCRIPTION
Chipper's review items #4, #5, #6 — minor copy only (Mew-approved to ship during the freeze; features stay held).

- **#5** homepage intro showed the unauthenticated "Sign in below with your Burner Profile…" prompt even to logged-in users. Now auth-aware.
- **#6** the "How to Volunteer" paragraph led with "Sign in above…" (a stale sign-in link for authed users). Now reads "You're all set — use the Shifts page…" when signed in; shared trailing copy unchanged.
- **#4** "Census Hive" → "the Census Community on Hive" and "The Census Hive page" → "The Census Hive Community" (it's Burning Man Hive; Census is a community on it). Applied in GetInvolved (account right column, the spot Chipper flagged), the VolunteerInfo checklist line, and the Home roles blurb for consistency.

Verified authed + unauth homepage renders (the conditional flips correctly, no stale prompts); `tsc --noEmit` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)