### PR TITLE
copy: help page uses app-feedback Discord invite

### DIFF
--- a/client/src/app/help/Help.tsx
+++ b/client/src/app/help/Help.tsx
@@ -259,7 +259,7 @@ export const Help = () => {
                 <>
                   Join the conversation on the{" "}
                   <a
-                    href="https://discord.gg/jcWuyYDGcn"
+                    href="https://discord.com/invite/NNheeaPQRY"
                     target="_blank"
                     rel="noopener noreferrer"
                   >


### PR DESCRIPTION
Per Chipper: the Help page's **Census Discord server** link used the *homepage* invite (`discord.gg/jcWuyYDGcn`), which sets the new-volunteer join role and drops people in the new-volunteer channel.

Swap it for the app-feedback invite `https://discord.com/invite/NNheeaPQRY`, which sets the join role differently and drops users straight into **#app-feedback** — the right destination for app users hitting the help page.

One-line link change in `client/src/app/help/Help.tsx`. Homepage (Home.tsx) invite is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)