### PR TITLE
copy: Help v2 — multistep login, playa/home icons, hyperlinks, VIP rename

### DIFF
--- a/client/src/app/help/Help.tsx
+++ b/client/src/app/help/Help.tsx
@@ -15,9 +15,28 @@ import {
   Typography,
 } from "@mui/material";
 
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Hero } from "@/components/layout/Hero";
+
+// App URL — shown as shareable text and used for the "this is where you
+// volunteer" link.
+const APP_URL = "https://volunteers.census.burningman.org";
+
+// Links out to another page open in a new tab so readers keep their place in
+// the Help.
+const PageLink = ({ href, children }: { href: string; children: ReactNode }) => (
+  <a href={href} target="_blank" rel="noopener noreferrer">
+    {children}
+  </a>
+);
+
+// In-page jump to another Help section. A plain hash anchor fires hashchange,
+// which the page listens for to open + scroll to the target accordion.
+const Jump = ({ to, children }: { to: string; children: ReactNode }) => (
+  <a href={`#${to}`}>{children}</a>
+);
 
 // Bulleted list that renders naturally inside an accordion.
 const Bullets = ({ items }: { items: ReactNode[] }) => (
@@ -30,14 +49,37 @@ const Bullets = ({ items }: { items: ReactNode[] }) => (
   </List>
 );
 
+// Numbered steps — used for the multi-step flows (signing in, trainings).
+const Steps = ({ items }: { items: ReactNode[] }) => (
+  <List component="ol" disablePadding sx={{ listStyle: "decimal", pl: 4 }}>
+    {items.map((item, index) => (
+      <ListItem key={index} disablePadding sx={{ display: "list-item" }}>
+        <ListItemText primary={item} />
+      </ListItem>
+    ))}
+  </List>
+);
+
 const Section = ({
+  id,
   title,
+  expanded,
+  onToggle,
   children,
 }: {
+  id: string;
   title: string;
+  expanded: boolean;
+  onToggle: () => void;
   children: ReactNode;
 }) => (
-  <Accordion disableGutters>
+  <Accordion
+    id={id}
+    disableGutters
+    expanded={expanded}
+    onChange={onToggle}
+    sx={{ scrollMarginTop: 80 }}
+  >
     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
       <Typography sx={{ fontWeight: 700 }}>{title}</Typography>
     </AccordionSummary>
@@ -46,6 +88,34 @@ const Section = ({
 );
 
 export const Help = () => {
+  // Which sections are open (accordions are independently expandable).
+  const [open, setOpen] = useState<Set<string>>(new Set());
+
+  const toggle = (id: string) =>
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+
+  // Open + scroll to a section when the URL hash points at it — both on load
+  // (arriving from another page's link) and on in-page jump clicks.
+  useEffect(() => {
+    const openFromHash = () => {
+      const id = window.location.hash.slice(1);
+      if (!id) return;
+      setOpen((prev) => new Set(prev).add(id));
+      document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    };
+    openFromHash();
+    window.addEventListener("hashchange", openFromHash);
+    return () => window.removeEventListener("hashchange", openFromHash);
+  }, []);
+
   return (
     <>
       <Hero
@@ -59,53 +129,110 @@ export const Help = () => {
         <Box component="section" sx={{ mb: 3 }}>
           <Card>
             <CardContent>
-              <Typography>
+              <Typography sx={{ mb: 1 }}>
                 Welcome! This page walks you through using the Census volunteer
                 app — signing in, signing up for shifts, your checklist,
-                trainings, and more. Tap any section below to open it. If
-                you&apos;re using a tablet at the Census Lab on playa, jump to{" "}
-                <strong>At the Census Lab (on playa)</strong> near the bottom.
+                trainings, and more. Tap any section below to open it.
+              </Typography>
+              <Typography>
+                Some steps depend on where you are: <strong>🏜️ on playa</strong>{" "}
+                (at the Census Lab) vs <strong>🏠 from home</strong> (your own
+                device). Watch for those icons. On the tablets at the Census
+                Lab? Jump to{" "}
+                <Jump to="on-playa">At the Census Lab (on playa)</Jump>.
               </Typography>
             </CardContent>
           </Card>
         </Box>
 
         <Box component="section" sx={{ mb: 4 }}>
-          <Section title="Getting started — signing in">
-            <Bullets
+          <Section
+            id="getting-started"
+            title="Getting started — signing in"
+            expanded={open.has("getting-started")}
+            onToggle={() => toggle("getting-started")}
+          >
+            <Typography sx={{ mb: 1 }}>
+              The Census app lives at{" "}
+              <PageLink href={APP_URL}>volunteers.census.burningman.org</PageLink>
+              . That&apos;s the place to volunteer with Census — easy to
+              remember, and easy to share with a friend who wants to join.
+            </Typography>
+
+            <Typography sx={{ mt: 2, mb: 1, fontWeight: 700 }}>
+              🏠 From home, on your own device
+            </Typography>
+            <Steps
               items={[
                 <>
-                  <strong>From home, on your own device:</strong> open the{" "}
-                  <strong>Home</strong> page and use{" "}
-                  <strong>Sign in to Census</strong>. You&apos;ll sign in with
-                  your Burner Profile. Don&apos;t have one yet? Create it at{" "}
-                  <a
-                    href="https://profiles.burningman.org"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    profiles.burningman.org
-                  </a>
+                  Go to{" "}
+                  <PageLink href={APP_URL}>
+                    volunteers.census.burningman.org
+                  </PageLink>
                   .
                 </>,
                 <>
-                  <strong>On the Census Lab tablets (on playa):</strong> sign in
-                  with the passcode printed on your volunteer name badge.
+                  Tap the big pink <strong>Sign in to Census</strong> button at
+                  the top of the page.
                 </>,
                 <>
-                  <strong>New volunteer without an account?</strong> Use the{" "}
-                  <strong>Create an account</strong> link on the sign-in screen,
-                  or ask a lab host to set you up with a name badge.
+                  You&apos;ll be sent to the <strong>Burning Man login</strong>{" "}
+                  (the same one Hive uses) to sign in with your Burner Profile.
+                </>,
+                <>
+                  Once you sign in, you&apos;re brought right back to the Census
+                  app automatically. <strong>This redirect is normal</strong> —
+                  you&apos;re not being logged out.
+                </>,
+                <>
+                  No Burner Profile yet? Create one at{" "}
+                  <PageLink href="https://profiles.burningman.org">
+                    profiles.burningman.org
+                  </PageLink>
+                  , then come back and sign in.
+                </>,
+              ]}
+            />
+
+            <Typography sx={{ mt: 2, mb: 1, fontWeight: 700 }}>
+              🏜️ On playa, at the Census Lab tablets
+            </Typography>
+            <Bullets
+              items={[
+                <>
+                  Sign in with the passcode printed on your volunteer name
+                  badge.
+                </>,
+              ]}
+            />
+
+            <Typography sx={{ mt: 2, mb: 1, fontWeight: 700 }}>
+              New volunteer without an account?
+            </Typography>
+            <Bullets
+              items={[
+                <>
+                  <strong>🏠 From home:</strong> use the{" "}
+                  <strong>Create an account</strong> link on the sign-in screen.
+                </>,
+                <>
+                  <strong>🏜️ On playa:</strong> ask a lab host to set you up with
+                  a name badge.
                 </>,
               ]}
             />
           </Section>
 
-          <Section title="Signing up for shifts">
+          <Section
+            id="signing-up"
+            title="Signing up for shifts"
+            expanded={open.has("signing-up")}
+            onToggle={() => toggle("signing-up")}
+          >
             <Typography sx={{ mb: 1 }}>
-              Open <strong>Shifts</strong> from the menu. Shifts are grouped by
-              day, and each card shows the time, how many spots are filled, and
-              the points it&apos;s worth.
+              Open <PageLink href="/shifts">Shifts</PageLink> from the menu.
+              Shifts are grouped by day, and each card shows the time, how many
+              spots are filled, and the points it&apos;s worth.
             </Typography>
             <Typography sx={{ mb: 1 }}>What the cards mean:</Typography>
             <Bullets
@@ -133,10 +260,11 @@ export const Help = () => {
             </Typography>
             <Typography sx={{ mb: 1 }}>
               <strong>To remove a shift:</strong> go to your{" "}
-              <strong>Account</strong> page, find the shift in your list, open
-              its menu, and choose <strong>Remove shift</strong>. (A few lead or
-              critical shifts can&apos;t be dropped on your own — reach out to a
-              volunteer coordinator if you need off one of those.)
+              <Jump to="vip">Volunteer Information Page (VIP)</Jump>, find the
+              shift in your list, open its menu, and choose{" "}
+              <strong>Remove shift</strong>. (A few lead or critical shifts
+              can&apos;t be dropped on your own — reach out to a volunteer
+              coordinator if you need off one of those.)
             </Typography>
             <Typography>
               Use the filter (funnel icon) to narrow by day, type, or
@@ -145,14 +273,23 @@ export const Help = () => {
             </Typography>
           </Section>
 
-          <Section title="Your checklist">
+          <Section
+            id="vip"
+            title="Your Volunteer Information Page (VIP)"
+            expanded={open.has("vip")}
+            onToggle={() => toggle("vip")}
+          >
             <Typography sx={{ mb: 1 }}>
-              Your <strong>Account</strong> page has a checklist of what to
-              complete before playa:
+              Your <strong>Volunteer Information Page (VIP)</strong> — currently
+              labeled <strong>Account</strong> in the menu — has a checklist of
+              what to complete before playa:
             </Typography>
             <Bullets
               items={[
-                "Required trainings for the shifts you sign up for",
+                <>
+                  Required <Jump to="trainings">trainings</Jump> for the shifts
+                  you sign up for
+                </>,
                 "The Behavioral Standards agreement",
                 "The welcome course",
                 "Keeping your Burner Profile up to date",
@@ -164,52 +301,86 @@ export const Help = () => {
             </Typography>
           </Section>
 
-          <Section title="Trainings">
-            <Bullets
+          <Section
+            id="trainings"
+            title="Trainings"
+            expanded={open.has("trainings")}
+            onToggle={() => toggle("trainings")}
+          >
+            <Typography sx={{ mb: 1 }}>
+              Trainings live in the <strong>Census community on Hive</strong>{" "}
+              (Burning Man&apos;s Hive platform). Complete each required course
+              there:
+            </Typography>
+            <Steps
               items={[
                 <>
-                  Trainings live in the <strong>Census community on Hive</strong>{" "}
-                  (Burning Man&apos;s Hive platform). Complete each required
-                  course there.
+                  On your <Jump to="vip">VIP checklist</Jump>, tap a course name
+                  to open it in Hive.
                 </>,
                 <>
-                  On your checklist, tap a course name to open it in Hive, then
-                  log in with your Burner Profile.
+                  Log in with your Burner Profile — the same Burning Man login
+                  as the app.
                 </>,
                 <>
-                  When you finish a course, it&apos;s marked complete on your
-                  checklist. If a course you&apos;ve finished still shows as
-                  incomplete, open its link from the checklist once more to sync
-                  it.
+                  Finish the course. When you&apos;re done, Hive may send you
+                  back or ask you to log in again — <strong>that&apos;s
+                  expected</strong>, you&apos;re not locked out. Head back to the
+                  Census app.
+                </>,
+                <>
+                  The course marks itself complete on your checklist. If a course
+                  you&apos;ve finished still shows incomplete, open its link from
+                  the checklist once more to sync it.
                 </>,
               ]}
             />
+            <Typography sx={{ mt: 1 }}>
+              <strong>Heads up:</strong> because Hive uses the same Burning Man
+              login as the Census app, finishing a course can feel like it
+              logged you out. It didn&apos;t — just return to the app and
+              you&apos;re still signed in.
+            </Typography>
           </Section>
 
-          <Section title="Shift points (CSP) & early entry (SAP)">
+          <Section
+            id="csp-sap"
+            title="Shift points (CSP) & early entry (SAP)"
+            expanded={open.has("csp-sap")}
+            onToggle={() => toggle("csp-sap")}
+          >
             <Bullets
               items={[
                 <>
                   <strong>CSP (Census Shift Points):</strong> every shift is
                   worth points. Signing up for enough shifts meets your
-                  volunteer commitment. Your Account page shows your running
-                  total and anything still needed.
+                  volunteer commitment. Your{" "}
+                  <Jump to="vip">VIP</Jump> shows your running total and anything
+                  still needed.
                 </>,
                 <>
-                  <strong>SAP (early-entry access):</strong> if you&apos;re
-                  arriving before the event opens to help with setup shifts, you
-                  may need an early-entry pass. It&apos;s generally issued for
-                  the day before your first shift. Staff, anyone who already has
-                  a pass from another source, and folks arriving after gates
-                  open don&apos;t need one. Set your{" "}
-                  <strong>arrival date</strong> on your Account page so this is
-                  calculated correctly.
+                  <strong>SAP (Setup Access Pass — early entry):</strong> if
+                  you&apos;re arriving before the event opens to help with setup
+                  shifts, you may need an early-entry pass. It&apos;s generally
+                  issued for the day before your first shift. Staff, anyone who
+                  already has a pass from another source, and folks arriving
+                  after gates open don&apos;t need one. Set your{" "}
+                  <strong>arrival date</strong> on your{" "}
+                  <Jump to="vip">VIP</Jump> so this is calculated correctly.
                 </>,
               ]}
             />
           </Section>
 
-          <Section title="Your account">
+          <Section
+            id="your-account"
+            title="Your account details"
+            expanded={open.has("your-account")}
+            onToggle={() => toggle("your-account")}
+          >
+            <Typography sx={{ mb: 1 }}>
+              On your <Jump to="vip">VIP</Jump> (menu → Account) you can:
+            </Typography>
             <Bullets
               items={[
                 "Update your playa name, world name, email, phone, location, and emergency contact.",
@@ -220,7 +391,12 @@ export const Help = () => {
             />
           </Section>
 
-          <Section title="At the Census Lab (on playa)">
+          <Section
+            id="on-playa"
+            title="🏜️ At the Census Lab (on playa)"
+            expanded={open.has("on-playa")}
+            onToggle={() => toggle("on-playa")}
+          >
             <Typography sx={{ mb: 1 }}>
               The Census Lab has tablets for signing volunteers in, plus a kiosk
               anyone visiting can use.
@@ -229,8 +405,8 @@ export const Help = () => {
               items={[
                 <>
                   <strong>Checking a volunteer in:</strong> open{" "}
-                  <strong>Shifts</strong>, tap the shift, find the
-                  volunteer&apos;s name, and flip their toggle. The check-in
+                  <PageLink href="/shifts">Shifts</PageLink>, tap the shift, find
+                  the volunteer&apos;s name, and flip their toggle. The check-in
                   toggle appears from 1 hour before the shift starts until 2
                   hours after it ends.
                 </>,
@@ -248,23 +424,25 @@ export const Help = () => {
             />
           </Section>
 
-          <Section title="Still need help?">
+          <Section
+            id="help"
+            title="Still need help?"
+            expanded={open.has("help")}
+            onToggle={() => toggle("help")}
+          >
             <Bullets
               items={[
                 <>
-                  Send a message from the <strong>Contact</strong> page (menu →
+                  Send a message from the{" "}
+                  <PageLink href="/contact">Contact</PageLink> page (menu →
                   Contact) — pick a coordinator, or choose the technology option
                   for app issues.
                 </>,
                 <>
                   Join the conversation on the{" "}
-                  <a
-                    href="https://discord.com/invite/NNheeaPQRY"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <PageLink href="https://discord.com/invite/NNheeaPQRY">
                     Census Discord server
-                  </a>
+                  </PageLink>
                   .
                 </>,
               ]}

--- a/client/src/app/help/Help.tsx
+++ b/client/src/app/help/Help.tsx
@@ -283,10 +283,17 @@ export const Help = () => {
               can&apos;t be dropped on your own — reach out to a volunteer
               coordinator if you need off one of those.)
             </Typography>
-            <Typography>
+            <Typography sx={{ mb: 1 }}>
               Use the filter (funnel icon) to narrow by day, type, or
               availability — or turn on <strong>My Shifts</strong> to see just
               the ones you&apos;re on.
+            </Typography>
+            <Typography>
+              <strong>Share a shift with a friend:</strong> on any shift, tap{" "}
+              <strong>Share this shift</strong> to send it through your
+              phone&apos;s share menu (text, Messenger, etc.). Your friend taps
+              the link, signs in with their Burner Profile, and can join the
+              shift too — handy for signing up together.
             </Typography>
           </Section>
 

--- a/client/src/app/help/Help.tsx
+++ b/client/src/app/help/Help.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Hero } from "@/components/layout/Hero";
@@ -30,12 +30,6 @@ const PageLink = ({ href, children }: { href: string; children: ReactNode }) => 
   <a href={href} target="_blank" rel="noopener noreferrer">
     {children}
   </a>
-);
-
-// In-page jump to another Help section. A plain hash anchor fires hashchange,
-// which the page listens for to open + scroll to the target accordion.
-const Jump = ({ to, children }: { to: string; children: ReactNode }) => (
-  <a href={`#${to}`}>{children}</a>
 );
 
 // Bulleted list that renders naturally inside an accordion.
@@ -102,19 +96,42 @@ export const Help = () => {
       return next;
     });
 
-  // Open + scroll to a section when the URL hash points at it — both on load
-  // (arriving from another page's link) and on in-page jump clicks.
-  useEffect(() => {
-    const openFromHash = () => {
-      const id = window.location.hash.slice(1);
-      if (!id) return;
-      setOpen((prev) => new Set(prev).add(id));
-      document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
-    };
-    openFromHash();
-    window.addEventListener("hashchange", openFromHash);
-    return () => window.removeEventListener("hashchange", openFromHash);
+  // Open a section and scroll to it. rAF lets the accordion expand before we
+  // scroll, so sections low on the page don't land short.
+  const openSection = useCallback((id: string) => {
+    setOpen((prev) => new Set(prev).add(id));
+    requestAnimationFrame(() =>
+      document.getElementById(id)?.scrollIntoView({ behavior: "smooth" })
+    );
   }, []);
+
+  // Open + scroll when the URL hash points at a section — on load (arriving
+  // from another page's link) and on back/forward navigation.
+  useEffect(() => {
+    const fromHash = () => {
+      const id = window.location.hash.slice(1);
+      if (id) openSection(id);
+    };
+    fromHash();
+    window.addEventListener("hashchange", fromHash);
+    return () => window.removeEventListener("hashchange", fromHash);
+  }, [openSection]);
+
+  // In-page jump. Drives open+scroll directly (not via hashchange) so it still
+  // works when the hash already matches the target — e.g. a #vip link clicked
+  // while the URL is already #vip but the VIP accordion was collapsed.
+  const Jump = ({ to, children }: { to: string; children: ReactNode }) => (
+    <a
+      href={`#${to}`}
+      onClick={(e) => {
+        e.preventDefault();
+        window.history.replaceState(null, "", `#${to}`);
+        openSection(to);
+      }}
+    >
+      {children}
+    </a>
+  );
 
   return (
     <>

--- a/client/src/app/help/Help.tsx
+++ b/client/src/app/help/Help.tsx
@@ -152,7 +152,7 @@ export const Help = () => {
                 trainings, and more. Tap any section below to open it.
               </Typography>
               <Typography>
-                Some steps depend on where you are: <strong>🏜️ on playa</strong>{" "}
+                Some steps depend on where you are: <strong>⛺ on playa</strong>{" "}
                 (at the Census Lab) vs <strong>🏠 from home</strong> (your own
                 device). Watch for those icons. On the tablets at the Census
                 Lab? Jump to{" "}
@@ -212,7 +212,7 @@ export const Help = () => {
             />
 
             <Typography sx={{ mt: 2, mb: 1, fontWeight: 700 }}>
-              🏜️ On playa, at the Census Lab tablets
+              ⛺ On playa, at the Census Lab tablets
             </Typography>
             <Bullets
               items={[
@@ -233,7 +233,7 @@ export const Help = () => {
                   <strong>Create an account</strong> link on the sign-in screen.
                 </>,
                 <>
-                  <strong>🏜️ On playa:</strong> ask a lab host to set you up with
+                  <strong>⛺ On playa:</strong> ask a lab host to set you up with
                   a name badge.
                 </>,
               ]}
@@ -410,7 +410,7 @@ export const Help = () => {
 
           <Section
             id="on-playa"
-            title="🏜️ At the Census Lab (on playa)"
+            title="⛺ At the Census Lab (on playa)"
             expanded={open.has("on-playa")}
             onToggle={() => toggle("on-playa")}
           >


### PR DESCRIPTION
**Help v2** — Chipper's batch of Help-page updates from the 2026-07-20 review. Copy + in-page navigation only; no app behavior/logic/data touched.

### What changed
- **Multistep login + redirect explainer** — *Getting started* and *Trainings* are now numbered steps that spell out the Burning Man login redirect: *you'll pop to the BM login (the same one Hive uses), then get sent right back to Census — this is normal, you're not being logged out.* Directly targets the Hive same-login confusion volunteers hit at the end of a course.
- **🏜️ on playa / 🏠 from home icons** — steps that depend on location are marked, and the two new-volunteer account paths (from-home vs at-the-lab) are separated.
- **App link** — `volunteers.census.burningman.org` surfaced in *Getting started* as the shareable "this is where you volunteer" URL.
- **Section rename** — *Your checklist* → *Your Volunteer Information Page (VIP)*, with "(labeled **Account** in the menu)" so it's still findable. (The app-wide Account→VIP rename is still an open question for Captain — this only touches Help copy.)
- **Hyperlinks** —
  - Out-links (Shifts, Contact, the app) open in a **new tab** so readers keep their place in the Help.
  - **In-page jump links** auto-open + scroll the target accordion via URL hash (also works when arriving from another page's link, e.g. `/help#trainings`).
- **Acronym** — SAP expanded to *Setup Access Pass* on first use.

### Verification
- `npm run build` clean; `/help` compiles static.
- Playwright: deep-link `/help#vip` opens the VIP accordion; clicking an in-page `#trainings` link opens Trainings. ✅

### Deferred / still open (called out on purpose)
- **Screenshots** (pink Sign-in button / checklist / shift card) — held for a follow-up once copy is locked, per Chipper's own maintenance concern (images go stale + would move if the copy pass reshuffles sections).
- **Tablet-fallback wording** — kept the generic "tell a shift lead / Census leadership" line; needs Chipper's real current procedure.
- **Chipper's copy pass** — copy is hers; markups welcome.

Holding deploy for review. Copy sits within Chipper's authority; this is the "something final to look at."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
