### PR TITLE
feat(shifts): native share button on shift detail (#265)

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -45,6 +45,7 @@ import { DataTable } from "@/components/general/DataTable";
 import { ErrorPage } from "@/components/general/ErrorPage";
 import { Loading } from "@/components/general/Loading";
 import { MoreMenu } from "@/components/general/MoreMenu";
+import { ShareButton } from "@/components/general/ShareButton";
 import { SnackbarText } from "@/components/general/SnackbarText";
 import { Hero } from "@/components/layout/Hero";
 import type { IReqSwitchValues, ISwitchValues } from "@/components/types";
@@ -113,7 +114,7 @@ export const ShiftVolunteers = ({
   const {
     sessionState: {
       settings: { isAuthenticated: isAuthenticatedSession },
-      user: { roleList },
+      user: { roleList, shiftboardId },
     },
   } = useContext(SessionContext);
 
@@ -343,6 +344,13 @@ export const ShiftVolunteers = ({
     startTime: dayjs(dataShiftVolunteersItem.shift.startTime),
   });
   const isShiftCanceled = Boolean(dataShiftVolunteersItem.shift.canceled);
+  // Only offer "Come join me!" sharing on a shift the viewer is actually on,
+  // so the message is truthful (and not on a canceled shift).
+  const isSignedUp =
+    shiftboardId > 0 &&
+    dataShiftVolunteersItem.volunteerList.some(
+      (volunteerItem) => volunteerItem.shiftboardId === shiftboardId
+    );
   let isVolunteerAddAvailable = false;
   let isCheckInAvailable = false;
 
@@ -660,6 +668,16 @@ export const ShiftVolunteers = ({
               {dataShiftVolunteersItem.shift.typeName}
             </Typography>
           </Box>
+          {isSignedUp && !isShiftCanceled && (
+            <Box sx={{ mb: 2 }}>
+              <ShareButton
+                title="Census shift"
+                text="I just signed up for this shift on playa. Come join me!"
+                path={`/shifts/${timeIdParam}/volunteers`}
+                label="Share this shift"
+              />
+            </Box>
+          )}
           {/*
            * Suppress any row whose right-column value is empty so we
            * don't render a lonely "Meal" or "Notes" label with nothing

--- a/client/src/components/general/ShareButton.tsx
+++ b/client/src/components/general/ShareButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { IosShare as ShareIcon } from "@mui/icons-material";
+import { Button } from "@mui/material";
+import { useSnackbar } from "notistack";
+
+import { SnackbarText } from "@/components/general/SnackbarText";
+
+// The on-playa build is offline and runs on shared check-in tablets — sharing
+// a link is pointless/broken there, so the button is baked out entirely.
+// NEXT_PUBLIC_PIN_ENABLED is set at build time (see Header.tsx / middleware.ts).
+const isOnPlaya = process.env.NEXT_PUBLIC_PIN_ENABLED !== "false";
+
+interface IShareButtonProps {
+  title: string;
+  text: string;
+  // Relative path (e.g. "/shifts/123/volunteers"); resolved to an absolute URL
+  // at click time so it's SSR-safe and always carries the current origin.
+  path: string;
+  label?: string;
+}
+
+export const ShareButton = ({
+  title,
+  text,
+  path,
+  label = "Share",
+}: IShareButtonProps) => {
+  const { enqueueSnackbar } = useSnackbar();
+
+  if (isOnPlaya) return null;
+
+  const handleShare = async () => {
+    const url = new URL(path, window.location.origin).href;
+
+    // Prefer the native share sheet (mobile); fall back to copy-link where the
+    // Web Share API isn't available (most desktop browsers).
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+      } catch {
+        // User dismissed the share sheet (AbortError) or it failed — no-op.
+      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      enqueueSnackbar(
+        <SnackbarText>Link copied to clipboard</SnackbarText>,
+        { variant: "success" }
+      );
+    } catch {
+      enqueueSnackbar(
+        <SnackbarText>Couldn&apos;t copy the link — copy it from your browser bar</SnackbarText>,
+        { variant: "error" }
+      );
+    }
+  };
+
+  return (
+    <Button variant="contained" startIcon={<ShareIcon />} onClick={handleShare}>
+      {label}
+    </Button>
+  );
+};


### PR DESCRIPTION
Closes the native-share v1 of #265. Approved by Mew (2026-07-21): build + deploy OK, **off-playa only**.

## What this does
A **Share** button on the shift detail page (`/shifts/[timeId]/volunteers`) that fires the **Web Share API** (`navigator.share()`) — the phone's native share sheet — prefilled with:
- **text:** "I just signed up for this shift on playa. Come join me!"
- **url:** an absolute link to that shift

The friend taps it → the **existing** sign-in `returnTo` flow bounces them through Burner Profile login and **lands them back on the shift**, ready to sign up. (That round-trip was already built — middleware sets `returnTo`, `SignIn.tsx` honors it — so no new auth work here.)

## Design notes
- **Reusable `ShareButton`** (`components/general/ShareButton.tsx`) — takes `title`/`text`/`path`/`label`, resolves the path to an absolute URL at click time. Same component will drop into the survey-share work later.
- **Native share over the old email design.** #265 originally specced an email-lookup-banner flow + a `shift_shares` table; that was a workaround from when we thought a standard share wasn't possible. This needs no DB table, no email, no recipient lookup.
- **Off-playa only** (Mew): baked out via `NEXT_PUBLIC_PIN_ENABLED` (same gate Header/middleware use). On-playa is offline + shared tablets — sharing a link is pointless there.
- **Gated to signed-up + not-canceled shifts**, so the "I just signed up" copy is truthful and we don't recruit to a canceled shift.
- **Desktop fallback:** copy-link to clipboard + a "Link copied" toast (Web Share support is patchy on desktop).
- **Origin:** PEERS asked for this — their two-person shifts mean people want to sign up *with* a friend.

## Verification
- `npm run build` clean (both `PIN_ENABLED=false` and `=true`).
- Playwright, **off-playa** (`PIN_ENABLED=false`): button renders; `navigator.share` fires with the exact `{title, text, url}` payload (absolute URL); desktop fallback copies the link + shows the toast.
- Playwright, **on-playa** (`PIN_ENABLED=true`): button count = 0 (baked out). ✅
- (The signed-up gating is a simple `volunteerList.some(id === me)`; the button only shows on shifts you're on.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
