### PR TITLE
copy: name Black Rock City Census in the shift share message

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -672,7 +672,7 @@ export const ShiftVolunteers = ({
             <Box sx={{ mb: 2 }}>
               <ShareButton
                 title="Census shift"
-                text="I just signed up for this shift on playa. Come join me!"
+                text="I just signed up for this Black Rock City Census shift on playa. Come join me!"
                 path={`/shifts/${timeIdParam}/volunteers`}
                 label="Share this shift"
               />


### PR DESCRIPTION
Per Chipper: the shift Share message now reads *"I just signed up for this **Black Rock City Census** shift on playa. Come join me!"* — puts the org name in the shared text (branding + the every-mention-says-Census rule). One-line string change in `ShiftVolunteers.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)