### PR TITLE
shifts: share on all shifts + hide 'Add this shift' when already on it

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -344,8 +344,9 @@ export const ShiftVolunteers = ({
     startTime: dayjs(dataShiftVolunteersItem.shift.startTime),
   });
   const isShiftCanceled = Boolean(dataShiftVolunteersItem.shift.canceled);
-  // Only offer "Come join me!" sharing on a shift the viewer is actually on,
-  // so the message is truthful (and not on a canceled shift).
+  // Whether the current viewer is already on this shift. Drives the share
+  // message wording and hides the non-admin "Add this shift" self-signup
+  // button (you can't add a shift you're already on).
   const isSignedUp =
     shiftboardId > 0 &&
     dataShiftVolunteersItem.volunteerList.some(
@@ -356,9 +357,12 @@ export const ShiftVolunteers = ({
 
   switch (checkInType) {
     case SHIFT_FUTURE: {
+      // Admins add other volunteers; a non-admin self-signs-up, but only if
+      // they're not already on the shift and a slot is open.
       isVolunteerAddAvailable =
         isAdmin ||
         (isAuthenticated &&
+          !isSignedUp &&
           dataShiftVolunteersItem.positionList.some(
             (positionItem: IResShiftPositionCountItem) =>
               positionItem.slotsTotal - positionItem.slotsFilled > 0
@@ -366,7 +370,9 @@ export const ShiftVolunteers = ({
       break;
     }
     case SHIFT_DURING: {
-      isVolunteerAddAvailable = true;
+      // Admins add others; a non-admin can still self-add during the shift
+      // unless they're already on it.
+      isVolunteerAddAvailable = isAdmin || !isSignedUp;
       isCheckInAvailable = true;
       break;
     }
@@ -668,11 +674,15 @@ export const ShiftVolunteers = ({
               {dataShiftVolunteersItem.shift.typeName}
             </Typography>
           </Box>
-          {isSignedUp && !isShiftCanceled && (
+          {!isShiftCanceled && (
             <Box sx={{ mb: 2 }}>
               <ShareButton
-                title="Census shift"
-                text="I just signed up for this Black Rock City Census shift on playa. Come join me!"
+                title="Black Rock City Census shift"
+                text={
+                  isSignedUp
+                    ? "I just signed up for this Black Rock City Census shift on playa. Come join me!"
+                    : "Check out this Black Rock City Census shift on playa!"
+                }
                 path={`/shifts/${timeIdParam}/volunteers`}
                 label="Share this shift"
               />


### PR DESCRIPTION
Two fixes to the shift detail page from Chipper's review of #549.

## 1. Share button on all shifts (not just signed-up)
The share button was gated to shifts you're on — but that gate only existed for the copy's sake. Now it shows on **every** (non-canceled) shift, with the message adapting:
- **Signed up:** "I just signed up for this Black Rock City Census shift on playa. Come join me!"
- **Not signed up:** "Check out this Black Rock City Census shift on playa!"

(Chipper: someone may want to share before signing up, or let a friend grab the spot first.)

## 2. Bug: 'Add this shift' showed when already signed up
A non-admin already on the shift still saw the pink **Add this shift** self-signup button (screenshot in Discord) — the condition checked auth + open slots but never whether *you're already on it*. Now gated on `!isSignedUp`.
- Admins are unaffected — they keep **Add volunteer** to add others.
- Self-**removal** is unaffected (separate row-level action).
- FUTURE: `isAdmin || (isAuthenticated && !isSignedUp && openSlot)`; DURING: `isAdmin || !isSignedUp`. On-playa walk-up (unauth) behavior unchanged.

Off-playa only (share button) still holds. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)