### PR TITLE
feat(nav): User Labels link under SAPs in super-admin nav

### DIFF
--- a/client/src/components/layout/pageList.tsx
+++ b/client/src/components/layout/pageList.tsx
@@ -7,6 +7,7 @@ import {
   ConfirmationNumber as ConfirmationNumberIcon,
   Help as HelpIcon,
   Home as HomeIcon,
+  Print as PrintIcon,
   QuestionAnswer as QuestionAnswerIcon,
   Settings as SettingsIcon,
   VerifiedUser as VerifiedUserIcon,
@@ -68,6 +69,12 @@ export const pageListSuperAdmin = [
     icon: <ConfirmationNumberIcon />,
     label: "SAPs",
     path: "/saps",
+  },
+  {
+    // direct PDF download (Avery 5523 sheet), not an app page
+    icon: <PrintIcon />,
+    label: "User Labels",
+    path: "/api/labels",
   },
   {
     icon: <WorkHistoryIcon />,


### PR DESCRIPTION
Adds a **User Labels** entry (printer icon) directly beneath SAPs in the super-admin nav, linking to the `/api/labels` PDF from #553. Renders in both the header drawer and footer (both consume `pageListSuperAdmin`). Verified with an authed local screenshot; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)