### PR TITLE
Auto-set arrival date from first SAP-eligible shift

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -516,10 +516,9 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
           Desired / Expected Arrival Date
         </Typography>
         {arrivalAutoSet && (
-          <Alert severity="warning" sx={{ mb: 1 }}>
-            We set this to the day before your first Setup Access Pass
-            (SAP)&ndash;eligible shift so your SAP could be issued. If you&rsquo;re
-            arriving earlier, please pick your actual arrival date below.
+          <Alert severity="info" sx={{ mb: 1, fontWeight: "bold" }}>
+            We set your arrival to the day before your first shift so your SAP
+            can issue &mdash; change it below if you&rsquo;re arriving earlier.
           </Alert>
         )}
         <Select

--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -451,6 +451,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
 
   const {
     arrivalDate,
+    arrivalAutoSet,
     behavioralStandardsSigned,
     burnerProfileUpdated,
     dates,
@@ -514,6 +515,13 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
         <Typography sx={{ mb: 0.5 }} variant="subtitle2">
           Desired / Expected Arrival Date
         </Typography>
+        {arrivalAutoSet && (
+          <Alert severity="warning" sx={{ mb: 1 }}>
+            We set this to the day before your first Setup Access Pass
+            (SAP)&ndash;eligible shift so your SAP could be issued. If you&rsquo;re
+            arriving earlier, please pick your actual arrival date below.
+          </Alert>
+        )}
         <Select
           aria-label="Desired / Expected Arrival Date"
           displayEmpty

--- a/client/src/components/api/arrivalAutoSet.ts
+++ b/client/src/components/api/arrivalAutoSet.ts
@@ -1,0 +1,75 @@
+import { ResultSetHeader, RowDataPacket } from "mysql2";
+import { Pool } from "mysql2/promise";
+
+// A SAP only fires once op_volunteers.arrival_date_id is set, but that column is
+// otherwise written only by the manual "arrival day" form. When a volunteer has
+// a SAP-eligible shift, set their arrival to the day BEFORE their first eligible
+// shift — but only if it's currently NULL or LATER than that day, so we never
+// move an earlier, self-chosen arrival. arrival_auto_set records that we set it
+// so the UI can show a "we set this, adjust if you're arriving earlier" header.
+//
+// Best-effort: callers wrap it so a failure never fails the signup. Returns true
+// when it changed the arrival date. See migration 009.
+export const autoSetArrival = async (
+  pool: Pool,
+  shiftboardId: number
+): Promise<boolean> => {
+  // 1. first SAP-eligible shift date for this volunteer.
+  // "SAP-eligible" = a shift starting on OpenSun (gates-open Sunday) or EARLIER
+  // (Mew 2026-07-26): those require entering before the gates open, so they get
+  // a SAP. Shifts starting Mon or later need no early entry and must NOT trigger
+  // the auto-set. ponytail: anchor off the OpenSun datename rather than a
+  // hardcoded date, so it survives year rollovers like the rest of the app.
+  const [firstRows] = await pool.query<RowDataPacket[]>(
+    `SELECT MIN(d.date) AS first_date
+       FROM op_volunteer_shifts vs
+       JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+       JOIN op_shift_times st ON stp.shift_times_id = st.shift_times_id
+       JOIN op_dates d ON st.start_date_id = d.date_id
+      WHERE vs.shiftboard_id = ?
+        AND vs.remove_shift = false
+        AND stp.remove_time_position = false
+        AND st.remove_shift_time = false
+        AND d.date <= (SELECT date FROM op_dates WHERE datename = 'OpenSun' LIMIT 1)`,
+    [shiftboardId]
+  );
+  const firstDate = firstRows[0]?.first_date;
+  if (!firstDate) return false; // no OpenSun-or-earlier shift → not SAP-eligible
+
+  // 2. target = day before that shift. Look up its date_id; if the day-before
+  // isn't a known event day (e.g. the shift is on the earliest date), fall back
+  // to the shift day itself so a pass still fires.
+  // ponytail: exact-date match + one day-of fallback; no calendar-table math.
+  const [targetRows] = await pool.query<RowDataPacket[]>(
+    `SELECT date_id, date FROM op_dates
+      WHERE date IN (DATE_SUB(?, INTERVAL 1 DAY), ?)
+      ORDER BY date ASC
+      LIMIT 1`,
+    [firstDate, firstDate]
+  );
+  const target = targetRows[0];
+  if (!target) return false; // shift day not in op_dates (shouldn't happen)
+
+  // 3. only set when NULL or later than target (never move an earlier arrival)
+  const [curRows] = await pool.query<RowDataPacket[]>(
+    `SELECT v.arrival_date_id, d.date AS arrival_date
+       FROM op_volunteers v
+       LEFT JOIN op_dates d ON v.arrival_date_id = d.date_id
+      WHERE v.shiftboard_id = ?`,
+    [shiftboardId]
+  );
+  const cur = curRows[0];
+  if (!cur) return false;
+  const needsSet =
+    cur.arrival_date_id == null ||
+    new Date(cur.arrival_date) > new Date(target.date);
+  if (!needsSet) return false;
+
+  await pool.query<ResultSetHeader>(
+    `UPDATE op_volunteers
+        SET arrival_date_id = ?, arrival_auto_set = 1, update_volunteer = true
+      WHERE shiftboard_id = ?`,
+    [target.date_id, shiftboardId]
+  );
+  return true;
+};

--- a/client/src/components/types/volunteer-info.ts
+++ b/client/src/components/types/volunteer-info.ts
@@ -30,6 +30,10 @@ export interface IResVolunteerInfo {
     datename: string;
     date: string;
   } | null;
+  // true when arrival was auto-set from the volunteer's first SAP-eligible
+  // shift (rather than chosen by them) — drives a "we set this, adjust if
+  // you're arriving earlier" warning header.
+  arrivalAutoSet: boolean;
   sapStatus: {
     bypass: boolean;
     bypassReason: "sap_issued" | "staff" | "other_sap" | "post_opening" | null;

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -10,6 +10,7 @@ import type {
 import { withAuth } from "@/lib/withAuth";
 import { pool } from "lib/database";
 import { notifyAssignment } from "@/components/api/assignmentNotify";
+import { autoSetArrival } from "@/components/api/arrivalAutoSet";
 import {
   shiftVolunteerRemove,
   shiftVolunteerUpdate,
@@ -255,6 +256,18 @@ const shiftVolunteers = async (
           )
           VALUES (true, ?, ?, ?)`,
           [noShow, shiftboardId, timePositionId]
+        );
+      }
+
+      // Auto-set arrival date from this (possibly SAP-eligible) signup so the
+      // SAP fires without the volunteer having to fill the arrival form.
+      // Best-effort — a failure here must not fail the assignment.
+      try {
+        await autoSetArrival(pool, shiftboardId);
+      } catch (err) {
+        console.error(
+          `[arrival-auto-set] autoSetArrival failed for shiftboard_id=${shiftboardId}:`,
+          err
         );
       }
 

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -43,7 +43,8 @@ const volunteerInfo = async (
           world_name,
           email,
           location,
-          arrival_date_id
+          arrival_date_id,
+          arrival_auto_set
         FROM op_volunteers
         WHERE delete_volunteer=false
         AND shiftboard_id=?`,
@@ -293,6 +294,7 @@ const volunteerInfo = async (
           location: dbVolunteer.location ?? "",
         },
         arrivalDate,
+        arrivalAutoSet: Boolean(dbVolunteer.arrival_auto_set),
         sapStatus: {
           bypass,
           bypassReason,
@@ -336,9 +338,11 @@ const volunteerInfo = async (
       );
 
       if (arrivalDateId !== undefined) {
+        // Volunteer set arrival themselves → clear the auto-set flag so the
+        // "we set this for you" warning header no longer shows.
         await pool.query<RowDataPacket[]>(
           `UPDATE op_volunteers
-          SET arrival_date_id=?, update_volunteer=true
+          SET arrival_date_id=?, arrival_auto_set=0, update_volunteer=true
           WHERE shiftboard_id=?`,
           [arrivalDateId, shiftboardId]
         );

--- a/migrations/009_arrival_auto_set.sql
+++ b/migrations/009_arrival_auto_set.sql
@@ -1,0 +1,16 @@
+-- Migration: auto-set volunteer arrival date from their first SAP-eligible shift.
+--
+-- Problem: a SAP only fires once op_volunteers.arrival_date_id is set, but that
+-- column is written ONLY by the manual "arrival day" form. Volunteers who sign
+-- up for eligible shifts but never fill the form get arrival_date_id=NULL, so
+-- their SAP never issues (e.g. Peter Lansing / 8391, and 22 others).
+--
+-- Fix: when a volunteer has a SAP-eligible shift, auto-set arrival_date_id to the
+-- day BEFORE their first SAP-eligible shift, but only if it's currently NULL or
+-- LATER than that day (never move an earlier, self-chosen arrival). The new
+-- arrival_auto_set flag records that we set it, so the UI can show a warning
+-- header inviting the volunteer to adjust if they're arriving earlier.
+
+ALTER TABLE op_volunteers
+  ADD COLUMN arrival_auto_set TINYINT(1) NOT NULL DEFAULT 0
+  AFTER arrival_date_id;


### PR DESCRIPTION
## Problem
A volunteer's SAP only fires once `op_volunteers.arrival_date_id` is set, but that column was written **only** by the manual "arrival day" form. Volunteers who signed up for SAP-eligible shifts but never filled the form had `arrival_date_id = NULL`, so their SAP never issued (e.g. Peter Lansing / 8391, who has a PreSat Aug 29 shift but no arrival).

## Rule (per Mew)
- **SAP-eligible** = the volunteer has a shift on **OpenSun (gates-open Sunday) or earlier** — those require entering before gates open, so they get a SAP.
- Auto-set `arrival_date_id` to the **day before their first SAP-eligible shift**.
- Only when currently **NULL or later** than that day (pull earlier, never push later — never override an earlier self-chosen arrival).
- Volunteers whose first shift is **Monday or later are left untouched** (no early entry needed).

## Changes
- `migrations/009_arrival_auto_set.sql` — adds `op_volunteers.arrival_auto_set` flag.
- `components/api/arrivalAutoSet.ts` — shared `autoSetArrival(pool, shiftboardId)` helper.
- `shifts/[timeId]/volunteers` POST — calls it best-effort on signup (going forward).
- `volunteers/[shiftboardId]/info` — PATCH clears the flag when the volunteer sets arrival themselves; GET now returns `arrivalAutoSet`.
- `VolunteerInfo.tsx` — warning header shown when arrival was auto-set, inviting the volunteer to adjust if arriving earlier.

## Deploy notes
- **Migration 009 has already been applied to prod**, and a **one-time backfill of 23 volunteers** was run (matches the reviewed dry-run 1:1; rollback snapshot saved on the prod box). This PR ships the *going-forward* on-signup behavior + UI.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)