### PR TITLE
etl: Shiftboard shifts ETL + union into mailing-list generator

### DIFF
--- a/etl/README.md
+++ b/etl/README.md
@@ -36,7 +36,8 @@ Groups, so running this never emails anyone.
 Each run computes, from the prod DB, who should be on each list and appends the
 missing (deduped against rows already in the sheet, by shiftboard_id or email):
 - **CensusVolunteers{year}@** — anyone with a shift dated in the burn-end→burn-end
-  window `[LaborDay(Y-1)+7, LaborDay(Y)+7]` (all `op_volunteer_shifts`). Year and
+  window `[LaborDay(Y-1)+7, LaborDay(Y)+7]`, from EITHER the app
+  (`op_volunteer_shifts`) OR Shiftboard (`sb_shifts`, see below). Year and
   anchors are derived dynamically (Labor Day = first Monday of September; gates
   open = LaborDay−8), so no more `$year`.
 - **CensusNewVolunteers@** — a *new volunteer* is EITHER **(A)** added to the
@@ -57,6 +58,24 @@ misses that window (accepted, per Mew).
 Extra env (`secrets/etl.env`) + deps beyond Phase 2: `MAILLIST_SHEET_ID`,
 `GOOGLE_CREDENTIALS_FILE` (path to the `vccensus@…` service-account JSON, which
 must be shared as Editor on the sheet); `pip install gspread google-auth`.
+
+## Shiftboard shifts ETL (`etl_sb_shifts.py`)
+Pulls the Shiftboard **coverage report** (shift signups) into a prod `sb_shifts`
+table, so the mailing-list generator counts shifts signed up directly in
+Shiftboard as well as in the app. Cron: `25 2-22/4 * * *` (before `maillist_sync`).
+
+- `shiftboard_client.download_coverage(start, end)` GETs
+  `report.cgi?type=coverage&…&format=tab_delimited&download=Download` (the
+  `download=Download` and `YYYYMMDD` dates are both required — dashes or omitting
+  download silently return an HTML page / 0 rows) and parses the TSV.
+- Dates (per Mew): one-time `--catchup` pulls from the start of last year's burn;
+  the cron then uses the old `censusload.php` rolling window of ±4 months.
+- Within the pulled window it deletes + reinserts `source='shiftboard'` rows
+  (so in-window cancellations drop out) but never touches rows outside the window
+  or `source='seed'` rows — reserved for off-playa activity that isn't actually
+  in Shiftboard, if seeded from the legacy `shiftboard2`.
+
+Manual: `python etl_sb_shifts.py --catchup` / `--dry-run` / (no args = rolling apply).
 
 ## What's not
 - **Phase 3** (intake / welcome workflow): not started. Needs:

--- a/etl/etl_sb_shifts.py
+++ b/etl/etl_sb_shifts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""ETL: pull Shiftboard shift signups (coverage report) into prod `sb_shifts`.
+
+Why: the CensusScheduler app (op_volunteer_shifts) is not the only place shifts
+get signed up — several 2026 shifts went straight into Shiftboard. The
+mailing-list generator needs those too, so CensusVolunteers{year}@ reflects
+"signed up for a shift in Shiftboard OR the app".
+
+Date strategy (per Mew 2026-07-26): a one-time --catchup pulls from the start of
+last year's burn forward; the regular cron then follows the old censusload.php
+pattern — a rolling window of roughly ±4 months around now.
+
+The refresh is scoped: within the pulled date window we delete+reinsert the
+`shiftboard`-source rows (so cancellations in-window drop out), but never touch
+rows outside the window or `seed`-source rows (off-playa activity that isn't
+actually in Shiftboard, seeded separately). Idempotent.
+
+Run:
+    cd ~/census-etl && source venv/bin/activate
+    python etl_sb_shifts.py --catchup            # from last burn -> now+4mo
+    python etl_sb_shifts.py --dry-run            # rolling window, report only
+    python etl_sb_shifts.py                      # rolling window, apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pymysql
+from dotenv import load_dotenv
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+load_dotenv(HERE / "secrets" / "etl.env")
+
+from shiftboard_client import ShiftboardClient  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+)
+log = logging.getLogger("etl_sb_shifts")
+
+FOUR_MONTHS = dt.timedelta(days=4 * 30)  # matches censusload.php's 4*30*24*60*60
+
+
+def get_db() -> pymysql.connections.Connection:
+    return pymysql.connect(
+        host=os.environ["MYSQL_HOST"],
+        user=os.environ["MYSQL_USER"],
+        password=os.environ["MYSQL_PASSWORD"],
+        database=os.environ["MYSQL_DATABASE"],
+        ssl={"ssl": {}},
+        autocommit=False,
+        charset="utf8mb4",
+    )
+
+
+DDL = """
+CREATE TABLE IF NOT EXISTS sb_shifts (
+    sb_shift_id   BIGINT PRIMARY KEY,
+    shiftboard_id BIGINT NOT NULL,
+    `date`        DATE NOT NULL,
+    subject       VARCHAR(128),
+    shift         VARCHAR(64),
+    event_code    VARCHAR(64),
+    email         VARCHAR(255),
+    noshow        VARCHAR(10),
+    source        ENUM('shiftboard','seed') NOT NULL DEFAULT 'shiftboard',
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_sb (shiftboard_id),
+    KEY idx_date (`date`)
+)
+"""
+
+
+def labor_day(year: int) -> dt.date:
+    d = dt.date(year, 9, 1)
+    return d + dt.timedelta(days=(0 - d.weekday()) % 7)
+
+
+def gates_open(year: int) -> dt.date:
+    return labor_day(year) - dt.timedelta(days=8)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--catchup", action="store_true", help="pull from last burn start")
+    ap.add_argument("--today", help="override 'now' as YYYY-MM-DD (testing)")
+    args = ap.parse_args()
+
+    today = dt.date.fromisoformat(args.today) if args.today else dt.date.today()
+    if args.catchup:
+        start = gates_open(today.year - 1) if today.month < 9 else gates_open(today.year)
+        end = today + FOUR_MONTHS
+    else:  # old censusload.php rolling window: now ± 4 months
+        start = today - FOUR_MONTHS
+        end = today + FOUR_MONTHS
+    log.info("coverage window: %s -> %s (catchup=%s)", start, end, args.catchup)
+
+    client = ShiftboardClient(
+        os.environ["SHIFTBOARD_USER"],
+        os.environ["SHIFTBOARD_PASSWORD"],
+        os.environ.get("SHIFTBOARD_SESSION_ID", "534228"),
+    )
+    if not client.authenticate():
+        log.error("Shiftboard auth failed")
+        return 1
+
+    rows = client.download_coverage(start.isoformat(), end.isoformat())
+    # keep filled signups with a usable shift id
+    good = [
+        r for r in rows
+        if r["shiftboard_id"].isdigit() and int(r["shiftboard_id"]) > 0
+        and r["sb_shift_id"].isdigit()
+    ]
+    log.info("coverage rows=%d usable=%d distinct_sb=%d",
+             len(rows), len(good), len({r["shiftboard_id"] for r in good}))
+
+    if args.dry_run:
+        log.info("DRY RUN — would refresh shiftboard rows in [%s, %s] with %d signups",
+                 start, end, len(good))
+        return 0
+
+    db = get_db()
+    try:
+        with db.cursor() as cur:
+            cur.execute(DDL)
+            # refresh window: drop shiftboard-source rows in range, reinsert.
+            cur.execute(
+                "DELETE FROM sb_shifts WHERE source='shiftboard' AND `date` BETWEEN %s AND %s",
+                (start, end),
+            )
+            ins = """
+                INSERT INTO sb_shifts
+                    (sb_shift_id, shiftboard_id, `date`, subject, shift, event_code, email, noshow, source)
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,'shiftboard')
+                ON DUPLICATE KEY UPDATE
+                    shiftboard_id=VALUES(shiftboard_id), `date`=VALUES(`date`),
+                    subject=VALUES(subject), shift=VALUES(shift),
+                    event_code=VALUES(event_code), email=VALUES(email),
+                    noshow=VALUES(noshow), source='shiftboard'
+            """
+            cur.executemany(ins, [
+                (int(r["sb_shift_id"]), int(r["shiftboard_id"]), r["date"],
+                 r["subject"], r["shift"], r["event_code"], r["email"], r["noshow"])
+                for r in good
+            ])
+        db.commit()
+        log.info("sb_shifts refreshed: %d shiftboard signups in window", len(good))
+    finally:
+        db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/etl/maillist_sync.py
+++ b/etl/maillist_sync.py
@@ -90,23 +90,47 @@ def current_burn_year(db) -> int:
 
 
 def volunteers_with_shift(db, start: dt.date, end: dt.date) -> dict[str, str]:
-    """{shiftboard_id: email} with a shift dated in [start, end]."""
-    sql = """
-        SELECT DISTINCT v.shiftboard_id AS sb, LOWER(v.email) AS email
-        FROM op_volunteer_shifts vs
-        JOIN op_volunteers v ON v.shiftboard_id = vs.shiftboard_id
-        JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
-        JOIN op_shift_times st ON stp.shift_times_id = st.shift_times_id
-        JOIN op_dates d ON st.start_date_id = d.date_id
-        WHERE vs.remove_shift = 0 AND st.remove_shift_time = 0
-          AND stp.remove_time_position = 0
-          AND v.shiftboard_id > 0 AND v.delete_volunteer = 0
-          AND v.email IS NOT NULL AND v.email <> ''
-          AND d.`date` BETWEEN %s AND %s
-    """
+    """{shiftboard_id: email} with a shift dated in [start, end], from EITHER the
+    app (op_volunteer_shifts) OR Shiftboard (sb_shifts, populated by
+    etl_sb_shifts). Covers Mew's "signed up in Shiftboard OR the app"."""
+    out: dict[str, str] = {}
     with db.cursor() as cur:
-        cur.execute(sql, (start, end))
-        return {str(r["sb"]): r["email"] for r in cur.fetchall()}
+        # app signups
+        cur.execute(
+            """
+            SELECT DISTINCT v.shiftboard_id AS sb, LOWER(v.email) AS email
+            FROM op_volunteer_shifts vs
+            JOIN op_volunteers v ON v.shiftboard_id = vs.shiftboard_id
+            JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+            JOIN op_shift_times st ON stp.shift_times_id = st.shift_times_id
+            JOIN op_dates d ON st.start_date_id = d.date_id
+            WHERE vs.remove_shift = 0 AND st.remove_shift_time = 0
+              AND stp.remove_time_position = 0
+              AND v.shiftboard_id > 0 AND v.delete_volunteer = 0
+              AND v.email IS NOT NULL AND v.email <> ''
+              AND d.`date` BETWEEN %s AND %s
+            """,
+            (start, end),
+        )
+        for r in cur.fetchall():
+            out[str(r["sb"])] = r["email"]
+        # Shiftboard signups (prefer the op_volunteers email if we have one)
+        cur.execute(
+            """
+            SELECT DISTINCT s.shiftboard_id AS sb,
+                   LOWER(COALESCE(NULLIF(v.email, ''), s.email)) AS email
+            FROM sb_shifts s
+            LEFT JOIN op_volunteers v
+                   ON v.shiftboard_id = s.shiftboard_id AND v.delete_volunteer = 0
+            WHERE s.shiftboard_id > 0
+              AND s.`date` BETWEEN %s AND %s
+              AND COALESCE(NULLIF(v.email, ''), s.email) <> ''
+            """,
+            (start, end),
+        )
+        for r in cur.fetchall():
+            out.setdefault(str(r["sb"]), r["email"])  # don't clobber app email
+    return out
 
 
 def new_volunteers(db, since: dt.date) -> dict[str, str]:

--- a/etl/shiftboard_client.py
+++ b/etl/shiftboard_client.py
@@ -21,6 +21,7 @@ which despite the name returns tab-delimited text.
 
 from __future__ import annotations
 
+import csv
 import io
 import logging
 from typing import Any
@@ -151,6 +152,46 @@ class ShiftboardClient:
         if not content:
             raise ShiftboardError(f"download_profiles({group_id}) returned empty content")
         return _parse_profile_xlsx(content)
+
+    def download_coverage(self, start_date: str, end_date: str) -> list[dict[str, Any]]:
+        """Download + parse the coverage report (shift signups) as TSV.
+
+        Ports geteventsfile() from censusload.php. `start_date`/`end_date` accept
+        'YYYY-MM-DD' or 'YYYYMMDD'; the report.cgi endpoint wants YYYYMMDD (the
+        legacy passes date("Ymd",...) — sending dashes silently returns 0 rows).
+        Returns one dict per shift signup row.
+        """
+        sd = start_date.replace("-", "")
+        ed = end_date.replace("-", "")
+        url = (
+            "https://www.shiftboard.com/servola/reporting/report.cgi"
+            f"?type=coverage&deleted_teams=2&ss={self._ss}"
+            f"&start_date={sd}&end_date={ed}"
+            "&format=tab_delimited&include=all_fields&download=Download"
+        )
+        content = self._get_bytes(url)
+        if content is None:
+            raise ShiftboardError("download_coverage returned empty content")
+        text = content.decode("utf-8-sig", errors="replace")
+        rows: list[dict[str, Any]] = []
+        for r in csv.DictReader(io.StringIO(text), delimiter="\t"):
+            sb = (r.get("Shiftboard ID") or "").strip()
+            date = (r.get("Date") or "").strip()
+            if not sb or not date:
+                continue
+            rows.append(
+                {
+                    "sb_shift_id": (r.get("ID") or "").strip(),
+                    "shiftboard_id": sb,
+                    "date": date,
+                    "subject": (r.get("Subject") or "").strip(),
+                    "shift": (r.get("Shift") or "").strip(),
+                    "event_code": (r.get("Event Code") or "").strip(),
+                    "email": (r.get("Email") or "").strip(),
+                    "noshow": (r.get("No Show") or "").strip(),
+                }
+            )
+        return rows
 
     # ----------------------------------------------------- group membership
 


### PR DESCRIPTION
Captures shifts signed up **directly in Shiftboard** (not just the app) so `CensusVolunteers{year}@` is complete.

- **`shiftboard_client.download_coverage(start,end)`** — coverage-report TSV pull. Requires `&download=Download` + `YYYYMMDD` dates (dashes / no download → HTML page, 0 rows).
- **`etl_sb_shifts.py`** → prod `sb_shifts` table. One-time `--catchup` from last burn; cron (`25 2-22/4`) then uses the old `censusload.php` rolling ±4-month window. Delete+reinsert `source='shiftboard'` rows in-window (handles cancellations); never touches out-of-window or `source='seed'` rows (reserved for off-playa activity not in Shiftboard).
- **`maillist_sync`** — `volunteers_with_shift` now unions `op_volunteer_shifts` + `sb_shifts`.

Already live on prod: catch-up loaded 636 signups (154 volunteers); the generator union added **23 Shiftboard-only volunteers** to the 2026 list (97 → 120). Deps already installed; cron added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)