### PR TITLE
Volunteer info: dedicated earned/assigned SAP box

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -480,29 +480,9 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     content: React.ReactNode;
   }[] = [];
 
-  // SAP Issued
-  if (sapStatus.sapFile) {
-    checklistItems.push({
-      id: "sap-issued",
-      label: "Your Setup Access Pass (SAP) is ready",
-      done: true,
-      content: (
-        <Box>
-          <Typography sx={{ mb: 1 }}>
-            Your SAP has been issued and emailed to you. You can also download it
-            here:
-          </Typography>
-          <Button
-            href={`/api/volunteers/${shiftboardId}/sap/${sapStatus.sapFile.sapId}`}
-            startIcon={<DownloadIcon />}
-            variant="contained"
-          >
-            Download SAP PDF
-          </Button>
-        </Box>
-      ),
-    });
-  }
+  // SAP display now lives in its own always-visible box near the top (the
+  // earnedSapDate Alert), not as a checklist item that hides once "done"
+  // (per Mew 2026-07-27).
 
   // On-playa plans \u2014 arrival date, early entry, and camping now live INLINE in
   // this checklist item (#461) instead of a separate section at the top of the
@@ -1127,6 +1107,35 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                 Your current total:{" "}
                 <strong>{sapStatus.totalCsp}</strong> Census Shift Points (CSP)
                 scheduled
+              </Alert>
+            )}
+
+            {/* SAP status — its own box, only once earned or assigned, never
+                buried in the completed-items accordion (per Mew 2026-07-27). */}
+            {sapStatus.earnedSapDate && (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                {sapStatus.sapFile ? (
+                  <Stack spacing={1} alignItems="flex-start">
+                    <span>
+                      Your <strong>Setup Access Pass (SAP)</strong> for{" "}
+                      <strong>{formatDateDisplay(sapStatus.earnedSapDate)}</strong>{" "}
+                      is ready.
+                    </span>
+                    <Button
+                      href={`/api/volunteers/${shiftboardId}/sap/${sapStatus.sapFile.sapId}`}
+                      startIcon={<DownloadIcon />}
+                      variant="contained"
+                      size="small"
+                    >
+                      Download SAP PDF
+                    </Button>
+                  </Stack>
+                ) : (
+                  <span>
+                    You have <strong>earned a SAP</strong> for{" "}
+                    <strong>{formatDateDisplay(sapStatus.earnedSapDate)}</strong>.
+                  </span>
+                )}
               </Alert>
             )}
 

--- a/client/src/components/types/volunteer-info.ts
+++ b/client/src/components/types/volunteer-info.ts
@@ -43,6 +43,10 @@ export interface IResVolunteerInfo {
       datename: string;
       date: string;
     } | null;
+    // Date (YYYY-MM-DD) a SAP has been earned or assigned FOR — the assigned
+    // SAP's date if one exists (admin override), else the auto date when
+    // requirements are met, else null (earned-SAP box stays hidden).
+    earnedSapDate: string | null;
     totalCsp: number;
     requiredCsp: number;
     cspFulfilled: boolean;

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -9,6 +9,7 @@ import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
 import { isOwnerOrAdmin } from "@/lib/authz";
 import { buildRequiredDays, PRE_OPEN_DATENAMES } from "lib/sapStatus";
+import { autoTargetDay } from "lib/sap";
 
 // Role IDs for VIP-specific roles
 const ROLE_STAFF_ID = 2000006;
@@ -129,6 +130,23 @@ const volunteerInfo = async (
         dayCspMap[row.datename] = Number(row.day_csp);
       }
 
+      // 6b. earliest SAP-earning (CSP>0) shift date — drives the auto SAP date
+      // (day before it), the same "appropriate date" the super-admin page uses.
+      const [dbFirstCsp] = await pool.query<RowDataPacket[]>(
+        `SELECT MIN(d.\`date\`) AS first_date
+        FROM op_volunteer_shifts vs
+        JOIN op_shift_time_position stp ON vs.time_position_id=stp.time_position_id
+        JOIN op_shift_times st ON stp.shift_times_id=st.shift_times_id
+        JOIN op_dates d ON st.start_date_id=d.date_id
+        WHERE vs.shiftboard_id=? AND vs.remove_shift=false
+        AND stp.remove_time_position=false AND st.remove_shift_time=false
+        AND COALESCE(stp.sap_points,0) > 0`,
+        [shiftboardId]
+      );
+      const firstCspShiftDate: string | null = dbFirstCsp[0]?.first_date
+        ? String(dbFirstCsp[0].first_date)
+        : null;
+
       // 7. required trainings (derived from volunteer's shift positions)
       const [dbTrainingList] = await pool.query<RowDataPacket[]>(
         `SELECT DISTINCT t.training_id, t.training_name, t.url
@@ -217,6 +235,20 @@ const volunteerInfo = async (
           }
         : null;
 
+      // The date a SAP has been earned/assigned FOR. Precedence:
+      //   1. an assigned SAP's date (admin may have picked a different date on
+      //      the SAP page — that's the "override"), else
+      //   2. the auto date (day before the first SAP-earning shift) IF the
+      //      volunteer has met the SAP requirements (>=12 CSP + each required
+      //      day covered). Null otherwise -> the earned-SAP box stays hidden.
+      const sapRequirementsMet =
+        cspFulfilled && requiredDays.every((d) => d.fulfilled);
+      const earnedSapDate: string | null = sapFile
+        ? String(sapFile.date)
+        : sapRequirementsMet
+          ? autoTargetDay(firstCspShiftDate)
+          : null;
+
       // role-based thresholds
       const roleThresholds: IResVolunteerInfo["roleThresholds"] = dbRoleList
         .filter((r) => r.census_shift_points !== null)
@@ -299,6 +331,7 @@ const volunteerInfo = async (
           bypass,
           bypassReason,
           sapFile,
+          earnedSapDate,
           totalCsp,
           requiredCsp,
           cspFulfilled,


### PR DESCRIPTION
Per Mew: show the SAP status in its own always-visible box (not buried in completed items) once requirements are met or a SAP is assigned.

- **API** (`info`): adds `sapStatus.earnedSapDate` — the assigned SAP's date if one exists (admin override), else the auto date (day before first SAP-earning shift) when `>=12 CSP + each required day` is met, else null.
- **UI**: standalone box under the CSP total — "You have earned a SAP for <date>", or a Download button once assigned/issued. Old checklist item (hid once done) removed.

Placement note: currently rendered directly under the "current total CSP" box; can move strictly below the Welcome item if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)