### PR TITLE
SAP box: include datename with the date

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -465,6 +465,13 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
     welcomeComplete,
   } = data;
 
+  // e.g. "Aug 25 (PreTue)" — date plus its event datename, for the SAP box.
+  const sapDateLabel = sapStatus.earnedSapDate
+    ? `${formatDateDisplay(sapStatus.earnedSapDate)}${
+        sapStatus.earnedSapDatename ? ` (${sapStatus.earnedSapDatename})` : ""
+      }`
+    : "";
+
   const isAdmin = checkIsAdmin(accountType, roleListSession);
   const isPreOpen = arrivalDate
     ? PRE_OPEN_DATENAMES.includes(arrivalDate.datename)
@@ -1118,8 +1125,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                   <Stack spacing={1} alignItems="flex-start">
                     <span>
                       Your <strong>Setup Access Pass (SAP)</strong> for{" "}
-                      <strong>{formatDateDisplay(sapStatus.earnedSapDate)}</strong>{" "}
-                      is ready.
+                      <strong>{sapDateLabel}</strong> is ready.
                     </span>
                     <Button
                       href={`/api/volunteers/${shiftboardId}/sap/${sapStatus.sapFile.sapId}`}
@@ -1127,13 +1133,13 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
                       variant="contained"
                       size="small"
                     >
-                      Download SAP PDF
+                      Download your SAP for {sapDateLabel}
                     </Button>
                   </Stack>
                 ) : (
                   <span>
                     You have <strong>earned a SAP</strong> for{" "}
-                    <strong>{formatDateDisplay(sapStatus.earnedSapDate)}</strong>.
+                    <strong>{sapDateLabel}</strong>.
                   </span>
                 )}
               </Alert>

--- a/client/src/components/types/volunteer-info.ts
+++ b/client/src/components/types/volunteer-info.ts
@@ -47,6 +47,8 @@ export interface IResVolunteerInfo {
     // SAP's date if one exists (admin override), else the auto date when
     // requirements are met, else null (earned-SAP box stays hidden).
     earnedSapDate: string | null;
+    // datename for earnedSapDate (e.g. "PreTue"), shown alongside the date.
+    earnedSapDatename: string | null;
     totalCsp: number;
     requiredCsp: number;
     cspFulfilled: boolean;

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -248,6 +248,17 @@ const volunteerInfo = async (
         : sapRequirementsMet
           ? autoTargetDay(firstCspShiftDate)
           : null;
+      // datename that goes with earnedSapDate (e.g. "PreTue"), so the UI can
+      // show "Aug 25 (PreTue)". Assigned SAP carries its own; for the auto date
+      // look it up in the event calendar.
+      const dateToDatename = new Map<string, string>(
+        dbDateList.map((d) => [String(d.date), String(d.datename)])
+      );
+      const earnedSapDatename: string | null = sapFile
+        ? String(sapFile.datename)
+        : earnedSapDate
+          ? (dateToDatename.get(earnedSapDate) ?? null)
+          : null;
 
       // role-based thresholds
       const roleThresholds: IResVolunteerInfo["roleThresholds"] = dbRoleList
@@ -332,6 +343,7 @@ const volunteerInfo = async (
           bypassReason,
           sapFile,
           earnedSapDate,
+          earnedSapDatename,
           totalCsp,
           requiredCsp,
           cspFulfilled,


### PR DESCRIPTION
Adds `sapStatus.earnedSapDatename` and shows it with the date — box reads "...for **Aug 25 (PreTue)**" and the assigned state's button is "**Download your SAP for Aug 25 (PreTue)**".

🤖 Generated with [Claude Code](https://claude.com/claude-code)