### PR TITLE
fix(on-playa): pin mysql, drop nginx (app on :80), base-schema migration, capture dnsmasq

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,11 @@
-FROM mysql:9.4
+# MySQL version is pinned per-environment via build arg so each deployment
+# matches its own existing data-dir version (MySQL has no in-place downgrade):
+#   playa      = 9.4  (docker-compose-playa.yaml, ephemeral 9.4 data)
+#   cloud/test = 9.7  (docker-compose.yaml, persistent 9.7 volume)
+# Unpinned `latest` once jumped to 26.7 and crash-looped the on-playa DB after a
+# `docker system prune -fa` + rebuild, hence pinning.
+ARG MYSQL_VERSION=9.4
+FROM mysql:${MYSQL_VERSION}
 
 COPY scheduler_schema.sql /docker-entrypoint-initdb.d
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:9.4
 
 COPY scheduler_schema.sql /docker-entrypoint-initdb.d
 

--- a/dnsmasq/dnsmasq.conf
+++ b/dnsmasq/dnsmasq.conf
@@ -5,7 +5,17 @@ log-facility=/dev/stdout
 #address=/clients1.google.com/192.168.11.11
 #address=/clients3.google.com/192.168.11.11
 #address=/connectivitycheck.android.com/192.168.11.11
-address=/connectivitycheck.gstatic.com/142.251.46.227
+# Real IPs for the domains Android probes to decide "am I online?" plus FCM
+# push (mtalk), Play services, and NTP time sync — so tablets show connected
+# and keep time. Everything else (address=/#/) is redirected to the local
+# server. These are current-as-of-2026-07 Google IPs; refresh if tablets start
+# reporting "no internet".
+address=/connectivitycheck.gstatic.com/142.250.80.35
+address=/www.google.cn/142.250.189.195
+address=/mtalk.google.com/173.194.65.188
+address=/alt2-mtalk.google.com/192.178.220.188
+address=/play.googleapis.com/216.239.34.223
+address=/2.android.pool.ntp.org/5.161.111.190
 address=/#/192.168.11.11
 no-negcache
 no-resolv

--- a/docker-compose-playa.yaml
+++ b/docker-compose-playa.yaml
@@ -3,6 +3,9 @@ services:
     build:
       context: database
       dockerfile: Dockerfile
+      args:
+        # on-playa DB is 9.4 (ephemeral) — match it
+        MYSQL_VERSION: "9.4"
     container_name: census-database
     image: burning-man/census-database
     security_opt:

--- a/docker-compose-playa.yaml
+++ b/docker-compose-playa.yaml
@@ -26,18 +26,10 @@ services:
       - "192.168.11.11:53:53"
       - "192.168.11.11:53:53/udp"
     restart: always
-  httpd:
-    build:
-      context: httpd
-      dockerfile: Dockerfile
-    container_name: census-nginx
-    image: burning-man/census-nginx
-    security_opt:
-      - apparmor:unconfined
-    ports:
-      - "80:80"
-      - "443:443"
-    restart: always
+  # nginx (census-nginx) removed 2026-07: it only served a redirect-to-:3000
+  # landing page and an unused 443. The app now serves HTTP on port 80
+  # directly (see census.ports below). Restore from git history if a reverse
+  # proxy / TLS terminator is ever needed on-playa.
   census:
     build:
       context: client
@@ -49,5 +41,8 @@ services:
     security_opt:
       - apparmor:unconfined
     ports:
+      # 80 = the standard port tablets/browsers hit; 3000 kept so tablets
+      # still pointed at http://192.168.11.11:3000/ keep working.
+      - "80:3000"
       - "3000:3000"
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
     build:
       context: database
       dockerfile: Dockerfile
+      args:
+        # cloud/test has a persistent 9.7 data volume — match it (no downgrade)
+        MYSQL_VERSION: "9.7"
     container_name: census-database
     image: burning-man/census-database
     environment:

--- a/migrations/000_playa_base_columns.sql
+++ b/migrations/000_playa_base_columns.sql
@@ -1,0 +1,46 @@
+-- Migration: base-schema columns that the app assumes pre-exist but the
+-- OnPlayaData base schema (used to seed the on-playa DB) does not have.
+--
+-- Numbered 000 so it runs BEFORE 009, which does
+-- `ALTER TABLE op_volunteers ADD COLUMN arrival_auto_set ... AFTER arrival_date_id`
+-- and therefore requires arrival_date_id to already exist.
+--
+-- Discovered on the 2026-07-29 on-playa deploy: on a bare OnPlayaData base DB
+-- (zero app migrations applied), `st.canceled` and `arrival_date_id` are
+-- missing, so /api/shifts, shift-eligibility, backfill-notify, the mail worker,
+-- and migration 009 all fail. Cloud/prod already has these columns, so this
+-- migration is guarded (information_schema check) and is a no-op there.
+--
+-- MySQL 8 has no "ADD COLUMN IF NOT EXISTS"; use a guarded stored proc.
+-- Idempotent: safe to re-run.
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS _base_add_col $$
+CREATE PROCEDURE _base_add_col(IN tbl VARCHAR(64), IN col VARCHAR(64), IN ddl TEXT)
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables
+             WHERE table_schema = DATABASE() AND table_name = tbl)
+     AND NOT EXISTS (SELECT 1 FROM information_schema.columns
+                     WHERE table_schema = DATABASE() AND table_name = tbl AND column_name = col)
+  THEN
+    SET @sql = CONCAT('ALTER TABLE `', tbl, '` ADD COLUMN ', ddl);
+    PREPARE s FROM @sql; EXECUTE s; DEALLOCATE PREPARE s;
+  END IF;
+END $$
+
+DELIMITER ;
+
+-- op_shift_times.canceled — boolean "this shift-time was canceled" flag, read
+-- as `st.canceled = false` by /api/shifts, shift-eligibility, and
+-- backfill-notify. No other migration creates it.
+CALL _base_add_col('op_shift_times', 'canceled',
+  '`canceled` TINYINT(1) NOT NULL DEFAULT 0');
+
+-- op_volunteers.arrival_date_id — the volunteer's arrival day (FK-shaped to
+-- op_dates.date_id), written by the arrival-day form. Migration 009 adds
+-- arrival_auto_set AFTER it, so it must exist first.
+CALL _base_add_col('op_volunteers', 'arrival_date_id',
+  '`arrival_date_id` BIGINT DEFAULT NULL');
+
+DROP PROCEDURE IF EXISTS _base_add_col;


### PR DESCRIPTION
Folds the local fixes made on the on-playa box during the **2026-07-29 field deploy** into `main`, so `on_playa_code_update.sh` stops re-breaking. All four were live-verified on the box (app on :80 serving, DB stable on 9.4, migrations applied, mail sending).

## Changes

**1. `database/Dockerfile` — pin `mysql:9.4`**
The deploy script runs `docker system prune -fa`, wiping the cached image, so the rebuild re-pulled `mysql:latest` (now 26.7) onto a 9.4 data dir → `Invalid MySQL server upgrade` → `census-database` crash-loop. Data volume was intact; it just needed the matching engine.

**2. `docker-compose-playa.yaml` — drop nginx, app on port 80**
`census-nginx` only served a static redirect-to-`:3000` page plus an unused `:443`. Removed it; the app now publishes `80:3000` (and keeps `3000:3000` so tablets whose home page is `http://192.168.11.11:3000/` keep working). Frees 443. Decided against TLS: the app needs no secure context (no PWA/service-worker/camera; only the clipboard copy-link button), and self-signed on an offline LAN means a per-tablet CA install + an un-removable Android "monitored network" banner for marginal benefit.

**3. `migrations/000_playa_base_columns.sql` — base-schema columns**
`op_shift_times.canceled` and `op_volunteers.arrival_date_id` are referenced by the app (and required by migration 009's `... AFTER arrival_date_id`) but created by no migration — so on a bare OnPlayaData base DB (zero app migrations applied), `/api/shifts`, shift-eligibility, backfill-notify, the mail worker, and migration 009 all failed. Numbered `000` to run first; guarded via `information_schema` so it's a **no-op on cloud/prod** where the columns already exist.

**4. `dnsmasq/dnsmasq.conf` — capture live connectivity config**
The working connectivity fake-out (real IPs for Android connectivity-check + FCM push + NTP) was an uncommitted local mod on the box. Capturing it here so the box can reset to `main` without losing it and future pulls don't conflict.

## Not included
- `client/.env.production` (gitignored, holds DB creds + the Gmail SMTP block) stays box-local by design.

## After merge — one-time box reconciliation
The box has these as uncommitted local mods, which will block `git pull`. Once merged, on the box:
```
cd ~/CensusScheduler
git checkout -- database/Dockerfile docker-compose-playa.yaml dnsmasq/dnsmasq.conf
git pull   # takes main's versions, which now contain all the fixes
```
(`.env.production` is untracked, so it's untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)