### PR TITLE
fix(saps): accept 2026 SAP header format

### DIFF
--- a/client/lib/sapPdf.ts
+++ b/client/lib/sapPdf.ts
@@ -10,7 +10,9 @@ import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 
 import { burnYear } from "./sap";
 
-const RE_DATE = /Setup Access Pass \(SAP\)\s*(\d{1,2})\/(\d{1,2})\s*&\s*Later/i;
+// 2025 header: "Setup Access Pass (SAP) 8/16 & Later"; 2026 dropped "(SAP)".
+const RE_DATE =
+  /Setup Access Pass\s*(?:\(SAP\)\s*)?(\d{1,2})\/(\d{1,2})\s*&\s*Later/i;
 const RE_YEAR = /Access\s*(\d{4})/i;
 const RE_TICKET = /Ticket ID\s*(\d+)/i;
 

--- a/client/tests/unit/sapPdf.test.ts
+++ b/client/tests/unit/sapPdf.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { PDFDocument, StandardFonts } from "pdf-lib";
+
+import { splitSapPdf } from "../../lib/sapPdf";
+
+// Build a one-page PDF whose text layer mimics a SAP batch page.
+async function makeBatch(pagesText: string[][]): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  for (const lines of pagesText) {
+    const page = doc.addPage();
+    lines.forEach((line, i) => {
+      page.drawText(line, { x: 40, y: 750 - i * 20, size: 10, font });
+    });
+  }
+  return Buffer.from(await doc.save());
+}
+
+// Body copy present on every real page — contains "Setup Access Pass (SAP)"
+// with no date after it, which must never satisfy the date regex.
+const BODY =
+  "This Setup Access Pass (SAP) is NOT A TICKET and on its own does not " +
+  "grant you access to Black Rock City before the event officially starts";
+
+test("parses 2026-format pages (no '(SAP)' in header)", async () => {
+  const buf = await makeBatch([
+    [
+      "Matthew Hewitt Face Value $0.00",
+      "Setup Access Pass 8/26 & Later",
+      "Black Rock City: Access 2026",
+      BODY,
+      "Ticket ID 473816590Confirmation Id39GG89B211922061",
+    ],
+  ]);
+  const { pages, unparseable } = await splitSapPdf(buf);
+  assert.equal(unparseable.length, 0);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].ticketId, "473816590");
+  assert.equal(pages[0].sapDate, "2026-08-26");
+});
+
+test("still parses 2025-format pages ('(SAP)' in header)", async () => {
+  const buf = await makeBatch([
+    [
+      "Setup Access Pass (SAP) 8/16 & Later",
+      "Black Rock City: Access 2025",
+      BODY,
+      "Ticket ID 123456789",
+    ],
+  ]);
+  const { pages, unparseable } = await splitSapPdf(buf);
+  assert.equal(unparseable.length, 0);
+  assert.equal(pages[0].sapDate, "2025-08-16");
+});
+
+test("quarantines pages missing fields instead of throwing", async () => {
+  const buf = await makeBatch([[BODY, "Black Rock City: Access 2026"]]);
+  const { pages, unparseable } = await splitSapPdf(buf);
+  assert.equal(pages.length, 0);
+  assert.equal(unparseable.length, 1);
+  assert.match(unparseable[0].reason, /date/);
+  assert.match(unparseable[0].reason, /ticket id/);
+});


### PR DESCRIPTION
## Problem
Uploading the 2026 SAP batch on the Send SAPs page reported **0 ingested, 110 unreadable page(s)**.

The 2026 batch PDFs changed the per-page header from:
- 2025: `Setup Access Pass (SAP) 8/16 & Later`
- 2026: `Setup Access Pass 8/26 & Later` (the `(SAP)` literal is gone)

`RE_DATE` in `client/lib/sapPdf.ts` required the `(SAP)` literal, so every page failed the date match and was quarantined.

## Fix
Make `(SAP)` optional in the date regex. Both 2025 and 2026 formats parse; the body copy on every page ("This Setup Access Pass (SAP) is NOT A TICKET…") cannot false-match because the regex still requires `M/D & Later` after it.

## Tests
New `tests/unit/sapPdf.test.ts` exercises the full `splitSapPdf` path with synthetic pdf-lib pages: 2026 format, 2025 format, and a missing-fields page (quarantined, not thrown). `npm run test:unit` green.

After deploy, re-uploading the same batch PDF is safe — ingest is idempotent on ticket_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)