### PR TITLE
feat(saps): name links + behavioral standards & trainings in SAP To-do

### DIFF
--- a/client/src/app/saps/Saps.tsx
+++ b/client/src/app/saps/Saps.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Chip,
   Container,
+  Link as MuiLink,
   MenuItem,
   Paper,
   Select,
@@ -26,6 +27,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import Link from "next/link";
 import { enqueueSnackbar } from "notistack";
 import { useRef, useState } from "react";
 import useSWR, { useSWRConfig } from "swr";
@@ -275,7 +277,16 @@ export const Saps = () => {
                         spacing={1}
                         alignItems="center"
                       >
-                        <span>{p.name}</span>
+                        {p.shiftboardId != null ? (
+                          <MuiLink
+                            component={Link}
+                            href={`/volunteers/${p.shiftboardId}/info`}
+                          >
+                            {p.name}
+                          </MuiLink>
+                        ) : (
+                          <span>{p.name}</span>
+                        )}
                         {p.kind === "offbook" && (
                           <Chip label="off-book" size="small" />
                         )}
@@ -288,11 +299,19 @@ export const Saps = () => {
                       {p.firstShiftDayname ?? p.firstShiftDate ?? "—"}
                     </TableCell>
                     <TableCell>
-                      {p.requiredDays.length === 0 ? (
-                        <Tooltip title="No arrival date set — nothing to require">
+                      {p.missing.length > 0 ? (
+                        <Tooltip title={`Missing: ${p.missing.join("; ")}`}>
+                          <span>Missing {p.missing.length} item(s)</span>
+                        </Tooltip>
+                      ) : p.kind === "offbook" ? (
+                        <Tooltip title="Off-book — no requirements tracked">
                           <span style={{ color: "#999" }}>—</span>
                         </Tooltip>
-                      ) : p.missing.length === 0 ? (
+                      ) : p.requiredDays.length === 0 ? (
+                        <Tooltip title="No arrival date set — no required days">
+                          <span style={{ color: "#999" }}>—</span>
+                        </Tooltip>
+                      ) : (
                         <Stack
                           direction="row"
                           spacing={0.5}
@@ -301,10 +320,6 @@ export const Saps = () => {
                           <CheckCircleIcon color="success" fontSize="small" />
                           <span>Complete</span>
                         </Stack>
-                      ) : (
-                        <Tooltip title={`Missing: ${p.missing.join("; ")}`}>
-                          <span>Missing {p.missing.length} day(s)</span>
-                        </Tooltip>
                       )}
                     </TableCell>
                     <TableCell>

--- a/client/src/pages/api/saps/people/index.ts
+++ b/client/src/pages/api/saps/people/index.ts
@@ -1,6 +1,7 @@
 import type { RowDataPacket } from "mysql2";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { ROLE_BEHAVIORAL_STANDARDS_ID } from "@/constants";
 import { withSuperAdmin } from "@/lib/withSuperAdmin";
 import { pool } from "lib/database";
 import { autoTargetDay, pickAutoSap } from "lib/sap";
@@ -40,6 +41,8 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
     [volRows],
     [offbookRows],
     [staffRows],
+    [bsRows],
+    [trainingRows],
     [totalCspRows],
     [dayCspRows],
     [firstShiftRows],
@@ -61,6 +64,28 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       `SELECT shiftboard_id FROM op_volunteer_roles
         WHERE role_id = ? AND remove_role = false`,
       [ROLE_STAFF_ID],
+    ),
+    pool.query<RowDataPacket[]>(
+      `SELECT shiftboard_id FROM op_volunteer_roles
+        WHERE role_id = ? AND remove_role = false`,
+      [ROLE_BEHAVIORAL_STANDARDS_ID],
+    ),
+    // Trainings required by each volunteer's signed-up positions, with
+    // completion = volunteer holds the training's role (same rule as the
+    // volunteer info endpoint).
+    pool.query<RowDataPacket[]>(
+      `SELECT DISTINCT vs.shiftboard_id, t.training_name,
+              (vr.shiftboard_id IS NOT NULL) AS completed
+         FROM op_volunteer_shifts vs
+         JOIN op_shift_time_position stp ON vs.time_position_id = stp.time_position_id
+         JOIN op_position_trainings pt ON stp.position_type_id = pt.position_type_id
+         JOIN op_trainings t ON pt.training_id = t.training_id
+         LEFT JOIN op_volunteer_roles vr
+                ON vr.shiftboard_id = vs.shiftboard_id
+               AND vr.role_id = t.role_id
+               AND vr.remove_role = false
+        WHERE vs.remove_shift = false AND stp.remove_time_position = false
+          AND pt.delete_position_training = false AND t.delete_training = false`,
     ),
     pool.query<RowDataPacket[]>(
       `SELECT vs.shiftboard_id, COALESCE(SUM(stp.sap_points), 0) AS total_csp
@@ -112,6 +137,15 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
   for (const d of dateRows) dateToDayname.set(String(d.date), d.datename);
 
   const staffSet = new Set<number>(staffRows.map((r) => r.shiftboard_id));
+  const bsSet = new Set<number>(bsRows.map((r) => r.shiftboard_id));
+
+  const missingTrainingsMap = new Map<number, string[]>();
+  for (const r of trainingRows) {
+    if (r.completed) continue;
+    const list = missingTrainingsMap.get(r.shiftboard_id) ?? [];
+    list.push(String(r.training_name));
+    missingTrainingsMap.set(r.shiftboard_id, list);
+  }
   const totalCspMap = new Map<number, number>();
   for (const r of totalCspRows)
     totalCspMap.set(r.shiftboard_id, Number(r.total_csp));
@@ -160,7 +194,12 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       v.arrival_datename ?? "",
       dayCspMap.get(v.shiftboard_id) ?? {},
     );
+    // SAP to-do criteria: required work days + signed behavioral standards +
+    // every training their positions require.
     const missing = requiredDays.filter((d) => !d.fulfilled).map((d) => d.label);
+    if (!bsSet.has(v.shiftboard_id)) missing.push("Sign Behavioral Standards");
+    for (const t of missingTrainingsMap.get(v.shiftboard_id) ?? [])
+      missing.push(`${t} training`);
     const totalCsp = totalCspMap.get(v.shiftboard_id) ?? 0;
     return {
       kind: "volunteer" as const,


### PR DESCRIPTION
Per Mew's request on the SAPs page:

1. **Names are links** to the volunteer's page (`/volunteers/{id}/info` — the page the rest of the app labels "View account"). Off-book rows stay plain text (no volunteer page to link).
2. **To-do criteria for the SAP line** now include, per person:
   - required work days (existing day-by-day logic),
   - **Sign Behavioral Standards** (role 1000012 not held),
   - **each uncompleted training** required by their signed-up positions (completion = volunteer holds the training's `op_trainings.role_id`, same rule as the volunteer info endpoint; both sets are queried set-based, no per-person queries).
3. Cell now reads "Missing N item(s)" (was "day(s)"); tooltip lists the items, e.g. `Missing: PreThur; Census Basics training; Sign Behavioral Standards`.

Verified on local prod build against a prod-pull DB: 42 people currently missing behavioral standards, 58 missing a training; screenshot checked. Display-only — assignment is not gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)