### PR TITLE
Self-remove shifts for regular volunteers + #308 critical-drop warning

### DIFF
--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteers.tsx
@@ -87,6 +87,7 @@ interface IShiftVolunteersProps {
 interface IDialogCurrentState {
   dialogItem: number;
   shift: {
+    critical: boolean;
     positionName: string;
     timePositionId: number;
   };
@@ -123,6 +124,7 @@ export const ShiftVolunteers = ({
   const [dialogCurrent, setDialogCurrent] = useState<IDialogCurrentState>({
     dialogItem: 0,
     shift: {
+      critical: false,
       positionName: "",
       timePositionId: 0,
     },
@@ -182,6 +184,9 @@ export const ShiftVolunteers = ({
             if (dataShiftVolunteersItem) {
               const dataMutate = structuredClone(dataShiftVolunteersItem);
               dataMutate.volunteerList.push({
+                // socket payload has no critical flag; mutate() revalidates
+                // right after, which fills in the real value
+                critical: false,
                 isCheckedIn,
                 notes,
                 playaName,
@@ -395,6 +400,14 @@ export const ShiftVolunteers = ({
     isVolunteerAddAvailable = false;
     isCheckInAvailable = false;
   }
+  // Non-admins may remove THEMSELVES from a future/during shift — mirrors the
+  // account page (past shifts stay admin-only). Canceled shifts intentionally
+  // still allow self-removal (see the comment above). Admins keep the full
+  // remove-anyone menu.
+  const isSelfRemoveAvailable = (rowShiftboardId: number): boolean =>
+    isAuthenticated &&
+    rowShiftboardId === shiftboardId &&
+    checkInType !== SHIFT_PAST;
 
   // prepare datatable positions
   const columnListPositions = [
@@ -458,31 +471,38 @@ export const ShiftVolunteers = ({
     },
   ];
   if (isAdmin) {
-    columnListVolunteers.push(
-      {
-        name: "Admin review",
-        options: {
-          filter: false,
-          searchable: false,
-          setCellHeaderProps: setCellHeaderPropsCenter,
-          setCellProps: setCellPropsCenter,
-          sort: false,
-        },
+    columnListVolunteers.push({
+      name: "Admin review",
+      options: {
+        filter: false,
+        searchable: false,
+        setCellHeaderProps: setCellHeaderPropsCenter,
+        setCellProps: setCellPropsCenter,
+        sort: false,
       },
-      {
-        name: "Admin actions",
-        options: {
-          filter: false,
-          searchable: false,
-          setCellHeaderProps: setCellHeaderPropsCenter,
-          setCellProps: setCellPropsCenter,
-          sort: false,
-        },
-      }
-    );
+    });
+  }
+  // Actions column: admins always get it (remove anyone); a non-admin gets it
+  // only when their own removable row is on the roster. Row arrays below must
+  // stay in lockstep with the pushed columns — MUIDataTable maps cells to
+  // columns by index and silently drops extras.
+  const hasActionsColumn =
+    isAdmin || (isSignedUp && isSelfRemoveAvailable(shiftboardId));
+  if (hasActionsColumn) {
+    columnListVolunteers.push({
+      name: isAdmin ? "Admin actions" : "Actions",
+      options: {
+        filter: false,
+        searchable: false,
+        setCellHeaderProps: setCellHeaderPropsCenter,
+        setCellProps: setCellPropsCenter,
+        sort: false,
+      },
+    });
   }
   const dataTableVolunteers = dataShiftVolunteersItem.volunteerList.map(
     ({
+      critical,
       isCheckedIn,
       notes,
       playaName,
@@ -492,7 +512,10 @@ export const ShiftVolunteers = ({
       timePositionId,
       worldName,
     }: IResShiftVolunteerRowItem) => {
-      return [
+      // MUIDataTable maps cells to columns by index (extras are silently
+      // dropped), so this array must mirror the columnListVolunteers pushes:
+      // review cell only when admin, actions cell only when the column exists.
+      const row: React.ReactNode[] = [
         playaName,
         worldName,
         positionName,
@@ -520,78 +543,92 @@ export const ShiftVolunteers = ({
         ) : (
           ""
         ),
-        // if volunteer is admin AND check-in is open,
-        // then display volunteer shift review and volunteer menu
-        isAdmin && isCheckInAvailable && (
-          <IconButton
-            onClick={() => {
-              setDialogCurrent({
-                dialogItem: DialogList.Review,
-                shift: {
-                  positionName,
-                  timePositionId,
-                },
-                volunteer: {
-                  notes,
-                  playaName,
-                  rating,
-                  shiftboardId,
-                  worldName,
-                },
-              });
-              setIsDialogOpen(true);
-            }}
-          >
-            {rating ? (
-              <ChatIcon color="primary" />
-            ) : (
-              <ChatIcon color="disabled" />
-            )}
-          </IconButton>
-        ),
-        isAdmin && (
-          <MoreMenu
-            Icon={<MoreHorizIcon />}
-            key={`${shiftboardId}-menu`}
-            MenuList={
-              <MenuList>
-                <Link href={`/volunteers/${shiftboardId}/info`}>
-                  <MenuItem>
-                    <ListItemIcon>
-                      <ManageAccountsIcon />
-                    </ListItemIcon>
-                    <ListItemText>View account</ListItemText>
-                  </MenuItem>
-                </Link>
-                <MenuItem
-                  onClick={() => {
-                    setDialogCurrent({
-                      dialogItem: DialogList.Remove,
-                      shift: {
-                        positionName,
-                        timePositionId,
-                      },
-                      volunteer: {
-                        notes: "",
-                        playaName,
-                        rating: null,
-                        shiftboardId,
-                        worldName,
-                      },
-                    });
-                    setIsDialogOpen(true);
-                  }}
-                >
-                  <ListItemIcon>
-                    <PersonRemoveIcon />
-                  </ListItemIcon>
-                  <ListItemText>Remove volunteer</ListItemText>
-                </MenuItem>
-              </MenuList>
-            }
-          />
-        ),
       ];
+      if (isAdmin) {
+        // review cell appears once check-in is open
+        row.push(
+          isCheckInAvailable && (
+            <IconButton
+              onClick={() => {
+                setDialogCurrent({
+                  dialogItem: DialogList.Review,
+                  shift: {
+                    critical,
+                    positionName,
+                    timePositionId,
+                  },
+                  volunteer: {
+                    notes,
+                    playaName,
+                    rating,
+                    shiftboardId,
+                    worldName,
+                  },
+                });
+                setIsDialogOpen(true);
+              }}
+            >
+              {rating ? (
+                <ChatIcon color="primary" />
+              ) : (
+                <ChatIcon color="disabled" />
+              )}
+            </IconButton>
+          )
+        );
+      }
+      if (hasActionsColumn) {
+        row.push(
+          (isAdmin || isSelfRemoveAvailable(shiftboardId)) && (
+            <MoreMenu
+              Icon={<MoreHorizIcon />}
+              key={`${shiftboardId}-menu`}
+              MenuList={
+                <MenuList>
+                  {isAdmin && (
+                    <Link href={`/volunteers/${shiftboardId}/info`}>
+                      <MenuItem>
+                        <ListItemIcon>
+                          <ManageAccountsIcon />
+                        </ListItemIcon>
+                        <ListItemText>View account</ListItemText>
+                      </MenuItem>
+                    </Link>
+                  )}
+                  <MenuItem
+                    onClick={() => {
+                      setDialogCurrent({
+                        dialogItem: DialogList.Remove,
+                        shift: {
+                          critical,
+                          positionName,
+                          timePositionId,
+                        },
+                        volunteer: {
+                          notes: "",
+                          playaName,
+                          rating: null,
+                          shiftboardId,
+                          worldName,
+                        },
+                      });
+                      setIsDialogOpen(true);
+                    }}
+                  >
+                    <ListItemIcon>
+                      <PersonRemoveIcon />
+                    </ListItemIcon>
+                    <ListItemText>
+                      {isAdmin ? "Remove volunteer" : "Remove shift"}
+                    </ListItemText>
+                  </MenuItem>
+                </MenuList>
+              }
+            />
+          )
+        );
+      }
+      return row;
     }
   );
   const optionListCustomVolunteers = {
@@ -795,6 +832,7 @@ export const ShiftVolunteers = ({
                 setDialogCurrent({
                   dialogItem: DialogList.Add,
                   shift: {
+                    critical: false,
                     positionName: "",
                     timePositionId: 0,
                   },
@@ -819,6 +857,7 @@ export const ShiftVolunteers = ({
             <Stack spacing={1}>
               {dataShiftVolunteersItem.volunteerList.map(
                 ({
+                  critical,
                   isCheckedIn,
                   notes,
                   playaName,
@@ -890,6 +929,7 @@ export const ShiftVolunteers = ({
                               setDialogCurrent({
                                 dialogItem: DialogList.Review,
                                 shift: {
+                                  critical,
                                   positionName,
                                   timePositionId,
                                 },
@@ -911,24 +951,29 @@ export const ShiftVolunteers = ({
                             )}
                           </IconButton>
                         )}
-                        {isAdmin && (
+                        {(isAdmin || isSelfRemoveAvailable(shiftboardId)) && (
                           <MoreMenu
                             Icon={<MoreHorizIcon />}
                             MenuList={
                               <MenuList>
-                                <Link href={`/volunteers/${shiftboardId}/info`}>
-                                  <MenuItem>
-                                    <ListItemIcon>
-                                      <ManageAccountsIcon />
-                                    </ListItemIcon>
-                                    <ListItemText>View account</ListItemText>
-                                  </MenuItem>
-                                </Link>
+                                {isAdmin && (
+                                  <Link
+                                    href={`/volunteers/${shiftboardId}/info`}
+                                  >
+                                    <MenuItem>
+                                      <ListItemIcon>
+                                        <ManageAccountsIcon />
+                                      </ListItemIcon>
+                                      <ListItemText>View account</ListItemText>
+                                    </MenuItem>
+                                  </Link>
+                                )}
                                 <MenuItem
                                   onClick={() => {
                                     setDialogCurrent({
                                       dialogItem: DialogList.Remove,
                                       shift: {
+                                        critical,
                                         positionName,
                                         timePositionId,
                                       },
@@ -946,7 +991,11 @@ export const ShiftVolunteers = ({
                                   <ListItemIcon>
                                     <PersonRemoveIcon />
                                   </ListItemIcon>
-                                  <ListItemText>Remove volunteer</ListItemText>
+                                  <ListItemText>
+                                    {isAdmin
+                                      ? "Remove volunteer"
+                                      : "Remove shift"}
+                                  </ListItemText>
                                 </MenuItem>
                               </MenuList>
                             }

--- a/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogRemove.tsx
+++ b/client/src/app/shifts/[timeId]/volunteers/ShiftVolunteersDialogRemove.tsx
@@ -3,13 +3,17 @@ import {
   PersonRemove as PersonRemoveIcon,
 } from "@mui/icons-material";
 import {
+  Alert,
   Button,
+  Checkbox,
   CircularProgress,
   DialogActions,
   DialogContentText,
+  FormControlLabel,
   Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
+import { useEffect, useState } from "react";
 import { io } from "socket.io-client";
 import useSWRMutation from "swr/mutation";
 
@@ -22,6 +26,7 @@ interface IShiftVolunteersDialogRemoveProps {
   handleDialogClose: () => void;
   isDialogOpen: boolean;
   shift: {
+    critical: boolean;
     positionName: string;
     timeId: number;
     timePositionId: number;
@@ -37,9 +42,16 @@ const socket = io();
 export const ShiftVolunteersDialogRemove = ({
   handleDialogClose,
   isDialogOpen,
-  shift: { positionName, timeId, timePositionId },
+  shift: { critical, positionName, timeId, timePositionId },
   volunteer: { playaName, shiftboardId, worldName },
 }: IShiftVolunteersDialogRemoveProps) => {
+  // #308 warn-then-allow: dropping a critical position requires an explicit
+  // acknowledgment before the Remove button enables. Reset on every open.
+  const [isGapAcknowledged, setIsGapAcknowledged] = useState(false);
+  useEffect(() => {
+    if (isDialogOpen) setIsGapAcknowledged(false);
+  }, [isDialogOpen]);
+
   // fetching, mutation, and revalidation
   // ------------------------------------------------------------
   const { isMutating, trigger } = useSWRMutation(
@@ -112,6 +124,23 @@ export const ShiftVolunteersDialogRemove = ({
           for <strong>{positionName}</strong>?
         </Typography>
       </DialogContentText>
+      {critical && (
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          <strong>{positionName}</strong> is a critical position — removing this
+          volunteer leaves a gap that must be refilled. The Census volunteer
+          coordinators will be notified.
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isGapAcknowledged}
+                onChange={(event) => setIsGapAcknowledged(event.target.checked)}
+              />
+            }
+            label="I understand this leaves a critical position unfilled"
+            sx={{ display: "flex", mt: 1 }}
+          />
+        </Alert>
+      )}
       <DialogActions>
         <Button
           disabled={isMutating}
@@ -123,7 +152,7 @@ export const ShiftVolunteersDialogRemove = ({
           Cancel
         </Button>
         <Button
-          disabled={isMutating}
+          disabled={isMutating || (critical && !isGapAcknowledged)}
           onClick={handleVolunteerRemove}
           startIcon={
             isMutating ? <CircularProgress size="1rem" /> : <PersonRemoveIcon />

--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
@@ -71,6 +71,7 @@ interface IVolunteerShiftsProps {
 interface IState {
   dialogItem: number;
   shift: {
+    critical: boolean;
     date: string;
     dateName: string;
     endTime: string;
@@ -107,6 +108,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
   const [dialogCurrent, setDialogCurrent] = useState<IState>({
     dialogItem: 0,
     shift: {
+      critical: false,
       date: "",
       dateName: "",
       endTime: "",
@@ -372,6 +374,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
       department: { name: departmentName },
       shift: {
         canceled,
+        critical,
         date,
         dateName,
         endTime,
@@ -430,6 +433,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
                   setDialogCurrent({
                     dialogItem: DialogList.Remove,
                     shift: {
+                      critical,
                       date,
                       dateName,
                       endTime,
@@ -517,6 +521,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
               setDialogCurrent({
                 dialogItem: DialogList.Review,
                 shift: {
+                  critical,
                   date,
                   dateName,
                   endTime,
@@ -600,6 +605,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
               department: { name: departmentName },
               shift: {
                 canceled,
+                critical,
                 date,
                 dateName,
                 endTime,
@@ -712,6 +718,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
                             setDialogCurrent({
                               dialogItem: DialogList.Review,
                               shift: {
+                                critical,
                                 date,
                                 dateName,
                                 endTime,
@@ -754,6 +761,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
                                 setDialogCurrent({
                                   dialogItem: DialogList.Remove,
                                   shift: {
+                                    critical,
                                     date,
                                     dateName,
                                     endTime,

--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShiftsDialogRemove.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShiftsDialogRemove.tsx
@@ -15,6 +15,7 @@ import {
 import { useSnackbar } from "notistack";
 import { useEffect, useState } from "react";
 import { io } from "socket.io-client";
+import { useSWRConfig } from "swr";
 import useSWRMutation from "swr/mutation";
 
 import { DialogContainer } from "@/components/general/DialogContainer";
@@ -68,6 +69,7 @@ export const VolunteerShiftsDialogRemove = ({
     `/api/volunteers/${shiftboardId}/shifts`,
     fetcherTrigger
   );
+  const { mutate } = useSWRConfig();
 
   // other hooks
   // ------------------------------------------------------------
@@ -87,6 +89,9 @@ export const VolunteerShiftsDialogRemove = ({
         shiftboardId,
         timePositionId,
       });
+      // the open-shift list's slot counts include this signup — revalidate it
+      // so the agenda doesn't render the dropped shift with a stale count
+      mutate("/api/shifts");
 
       enqueueSnackbar(
         <SnackbarText>

--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShiftsDialogRemove.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShiftsDialogRemove.tsx
@@ -3,13 +3,17 @@ import {
   EventBusy as EventBusyIcon,
 } from "@mui/icons-material";
 import {
+  Alert,
   Button,
+  Checkbox,
   CircularProgress,
   DialogActions,
   DialogContentText,
+  FormControlLabel,
   Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
+import { useEffect, useState } from "react";
 import { io } from "socket.io-client";
 import useSWRMutation from "swr/mutation";
 
@@ -23,6 +27,7 @@ interface IVolunteerShiftsDialogRemoveProps {
   handleDialogClose: () => void;
   isDialogOpen: boolean;
   shift: {
+    critical: boolean;
     date: string;
     dateName: string;
     endTime: string;
@@ -39,9 +44,24 @@ const socket = io();
 export const VolunteerShiftsDialogRemove = ({
   handleDialogClose,
   isDialogOpen,
-  shift: { date, dateName, endTime, positionName, startTime, timePositionId },
+  shift: {
+    critical,
+    date,
+    dateName,
+    endTime,
+    positionName,
+    startTime,
+    timePositionId,
+  },
   volunteer: { shiftboardId },
 }: IVolunteerShiftsDialogRemoveProps) => {
+  // #308 warn-then-allow: dropping a critical position requires an explicit
+  // acknowledgment before the Remove button enables. Reset on every open.
+  const [isGapAcknowledged, setIsGapAcknowledged] = useState(false);
+  useEffect(() => {
+    if (isDialogOpen) setIsGapAcknowledged(false);
+  }, [isDialogOpen]);
+
   // fetching, mutation, and revalidation
   // ------------------------------------------------------------
   const { isMutating, trigger } = useSWRMutation(
@@ -112,6 +132,23 @@ export const VolunteerShiftsDialogRemove = ({
           <strong>{positionName}</strong>?
         </Typography>
       </DialogContentText>
+      {critical && (
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          <strong>{positionName}</strong> is a critical position — removing this
+          shift leaves a gap that must be refilled. The Census volunteer
+          coordinators will be notified.
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isGapAcknowledged}
+                onChange={(event) => setIsGapAcknowledged(event.target.checked)}
+              />
+            }
+            label="I understand this leaves a critical position unfilled"
+            sx={{ display: "flex", mt: 1 }}
+          />
+        </Alert>
+      )}
       <DialogActions>
         <Button
           disabled={isMutating}
@@ -123,7 +160,7 @@ export const VolunteerShiftsDialogRemove = ({
           Cancel
         </Button>
         <Button
-          disabled={isMutating}
+          disabled={isMutating || (critical && !isGapAcknowledged)}
           onClick={handleVolunteerRemove}
           startIcon={
             isMutating ? <CircularProgress size="1rem" /> : <EventBusyIcon />

--- a/client/src/app/volunteers/[shiftboardId]/schedule/Schedule.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/schedule/Schedule.tsx
@@ -3,6 +3,7 @@
 import {
   CalendarMonth as CalendarMonthIcon,
   Close as CloseIcon,
+  EventBusy as EventBusyIcon,
   FilterList as FilterListIcon,
 } from "@mui/icons-material";
 import {
@@ -29,6 +30,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 
+import { VolunteerShiftsDialogRemove } from "@/app/volunteers/[shiftboardId]/account/VolunteerShiftsDialogRemove";
 import { ErrorAlert } from "@/components/general/ErrorAlert";
 import { Loading } from "@/components/general/Loading";
 import { Hero } from "@/components/layout/Hero";
@@ -56,6 +58,8 @@ interface IAgendaItem {
   department: string;
   csp: string;
   canceled: boolean;
+  // set on "mine" rows only — drives the #308 critical-drop warning
+  critical?: boolean;
   state: "mine" | "open" | "full" | "conflict" | "ineligible";
   slots?: { filled: number; total: number };
   conflictWith?: string;
@@ -75,12 +79,8 @@ const FRIENDLY_ROLE: Record<string, string> = {
 const friendlyRole = (role: string) => FRIENDLY_ROLE[role] ?? role;
 
 // Strict time overlap (touching endpoints — back-to-back shifts — are fine).
-const overlaps = (
-  aStart: string,
-  aEnd: string,
-  bStart: string,
-  bEnd: string
-) => dayjs(aStart).isBefore(dayjs(bEnd)) && dayjs(bStart).isBefore(dayjs(aEnd));
+const overlaps = (aStart: string, aEnd: string, bStart: string, bEnd: string) =>
+  dayjs(aStart).isBefore(dayjs(bEnd)) && dayjs(bStart).isBefore(dayjs(aEnd));
 
 export const Schedule = ({ shiftboardId }: IScheduleProps) => {
   const theme = useTheme();
@@ -135,6 +135,7 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
         department: m.department.name,
         csp: cspLabel(s.csp, s.csp),
         canceled: s.canceled,
+        critical: s.critical,
         state: "mine",
       });
     }
@@ -147,12 +148,7 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
       const clash = mine.find(
         (m) =>
           !m.shift.canceled &&
-          overlaps(
-            o.startTime,
-            o.endTime,
-            m.shift.startTime,
-            m.shift.endTime
-          )
+          overlaps(o.startTime, o.endTime, m.shift.startTime, m.shift.endTime)
       );
       // role-gated: every position needs a role this volunteer lacks
       const requiredRoles = dataElig?.[o.id];
@@ -213,6 +209,11 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
   const [dates, setDates] = useState<string[]>([]);
   const [availability, setAvailability] = useState<string[]>([]); // "open" | "full"
   const [myShiftsOnly, setMyShiftsOnly] = useState(false);
+
+  // "mine" card whose Remove button was clicked; null = dialog closed.
+  const [removeDialogItem, setRemoveDialogItem] = useState<IAgendaItem | null>(
+    null
+  );
 
   // Reset every filter to its default (#470 design review, item 8).
   const removeAllFilters = () => {
@@ -373,8 +374,9 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
     />
   );
 
-  // One day-grouped section of browse-only cards. Whole card links to the
-  // shift detail page; no sign-up / remove actions here (#470).
+  // One day-grouped section of cards. Whole card links to the shift detail
+  // page. Sign-up still happens there (#470), but "mine" cards carry a Remove
+  // button (Mew 2026-07-29) — self-drops shouldn't need the extra hop.
   const renderDay = (day: {
     date: string;
     dateName: string;
@@ -529,7 +531,12 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
                 )}
 
                 {(item.canceled || item.state === "mine") && (
-                  <Box sx={{ mt: 1.5 }}>
+                  <Stack
+                    alignItems="center"
+                    direction="row"
+                    spacing={1}
+                    sx={{ mt: 1.5 }}
+                  >
                     {item.canceled ? (
                       <Chip
                         label="Canceled"
@@ -545,7 +552,28 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
                         variant="outlined"
                       />
                     )}
-                  </Box>
+                    {/* Self-remove, future/during only (past mirrors the
+                        account page and stays admin territory). Canceled
+                        shifts stay removable so volunteers can drop them. */}
+                    {item.state === "mine" &&
+                      item.timePositionId !== undefined &&
+                      dayjs(item.endTime).isAfter(dayjs()) && (
+                        <Button
+                          color="error"
+                          onClick={(event) => {
+                            // the whole card is a Link — don't navigate
+                            event.preventDefault();
+                            event.stopPropagation();
+                            setRemoveDialogItem(item);
+                          }}
+                          size="small"
+                          startIcon={<EventBusyIcon />}
+                          variant="outlined"
+                        >
+                          Remove
+                        </Button>
+                      )}
+                  </Stack>
                 )}
               </CardContent>
             </Card>
@@ -632,7 +660,9 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
                     selected.length === 0
                       ? "All"
                       : selected
-                          .map((v) => (v === "past" ? "Past" : "Present / Future"))
+                          .map((v) =>
+                            v === "past" ? "Past" : "Present / Future"
+                          )
                           .join(", ")
                   }
                 >
@@ -857,6 +887,26 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
               mineDays.map(renderDay)
             )}
           </>
+        )}
+
+        {/* remove dialog — its mutation key is this page's own
+            /api/volunteers/[id]/shifts SWR key, so the agenda revalidates
+            (card flips back to "open") without a reload */}
+        {removeDialogItem && (
+          <VolunteerShiftsDialogRemove
+            handleDialogClose={() => setRemoveDialogItem(null)}
+            isDialogOpen
+            shift={{
+              critical: removeDialogItem.critical ?? false,
+              date: removeDialogItem.date,
+              dateName: removeDialogItem.dateName,
+              endTime: removeDialogItem.endTime,
+              positionName: removeDialogItem.title,
+              startTime: removeDialogItem.startTime,
+              timePositionId: removeDialogItem.timePositionId ?? 0,
+            }}
+            volunteer={{ shiftboardId }}
+          />
         )}
       </Container>
     </>

--- a/client/src/components/api/shiftVolunteers.ts
+++ b/client/src/components/api/shiftVolunteers.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IReqReviewValues, IReqSwitchValues } from "@/components/types";
 import { UPDATE_TYPE_CHECK_IN, UPDATE_TYPE_REVIEW } from "@/constants";
-import { isOwnerOrAdmin } from "@/lib/authz";
+import { isAdmin, isOwnerOrAdmin } from "@/lib/authz";
 import { enqueueEmail } from "lib/mail";
 import {
   lookupActorDisplayName,
@@ -179,6 +179,29 @@ export const shiftVolunteerRemove = async (
   // are covered by the one check.
   if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
     return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
+  // Past shifts are admin-only to remove — same rule every UI enforces.
+  // Backstop it server-side so a direct API call can't erase an
+  // already-worked signup from fill reports and prior-year counts.
+  // 24h grace past end_time: skew between the server clock and playa-local
+  // shift times can never block a legitimate during/just-after self-drop.
+  if (!(await isAdmin(session.shiftboardId))) {
+    const [endRows] = await pool.query<RowDataPacket[]>(
+      `SELECT st.end_time
+      FROM op_shift_time_position AS stp
+      JOIN op_shift_times AS st
+      ON st.shift_times_id=stp.shift_times_id
+      WHERE stp.time_position_id=?`,
+      [timePositionId]
+    );
+    const endTime = endRows[0]?.end_time;
+    const endMs = endTime ? new Date(endTime).getTime() : NaN;
+    if (!Number.isNaN(endMs) && Date.now() - endMs > 24 * 60 * 60 * 1000) {
+      return res.status(403).json({
+        statusCode: 403,
+        message: "Past shifts can only be removed by an admin",
+      });
+    }
   }
 
   await pool.query<RowDataPacket[]>(

--- a/client/src/components/api/shiftVolunteers.ts
+++ b/client/src/components/api/shiftVolunteers.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { IReqReviewValues, IReqSwitchValues } from "@/components/types";
 import { UPDATE_TYPE_CHECK_IN, UPDATE_TYPE_REVIEW } from "@/constants";
+import { isOwnerOrAdmin } from "@/lib/authz";
 import { enqueueEmail } from "lib/mail";
 import {
   lookupActorDisplayName,
@@ -171,6 +172,14 @@ export const shiftVolunteerRemove = async (
   session: { shiftboardId: number }
 ) => {
   const { shiftboardId, timePositionId } = JSON.parse(req.body);
+
+  // Object-level authz: a volunteer may only remove THEMSELVES; admins can
+  // remove anyone. Guarded here (not per-route) so both mounts —
+  // /api/shifts/[timeId]/volunteers and /api/volunteers/[shiftboardId]/shifts —
+  // are covered by the one check.
+  if (!(await isOwnerOrAdmin(session, Number(shiftboardId)))) {
+    return res.status(403).json({ statusCode: 403, message: "Forbidden" });
+  }
 
   await pool.query<RowDataPacket[]>(
     `UPDATE op_volunteer_shifts

--- a/client/src/components/types/shifts/index.ts
+++ b/client/src/components/types/shifts/index.ts
@@ -50,6 +50,8 @@ export interface IResShiftPositionCountItem {
   timePositionId: number;
 }
 export interface IResShiftVolunteerRowItem {
+  // position is critical=1 — drives the #308 acknowledge-the-gap warning
+  critical: boolean;
   isCheckedIn: string;
   notes: string;
   playaName: string;

--- a/client/src/components/types/volunteers/index.ts
+++ b/client/src/components/types/volunteers/index.ts
@@ -55,6 +55,8 @@ export interface IResVolunteerShiftItem {
   };
   shift: {
     canceled: boolean;
+    // position is critical=1 — drives the #308 acknowledge-the-gap warning
+    critical: boolean;
     // csp = sap_points for this signup; positionId = op_position_type id.
     // Used by the add dialog to total a volunteer's scheduled CSP and count
     // how many of a given position they hold (signup-rule warnings, #436/#429).

--- a/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
+++ b/client/src/pages/api/shifts/[timeId]/volunteers/index.ts
@@ -80,6 +80,7 @@ const shiftVolunteers = async (
       const [dbShiftVolunteerList] = await pool.query<RowDataPacket[]>(
         `SELECT
           COALESCE(NULLIF(stp.position_alias, ''), pt.position) AS position,
+          pt.critical,
           stp.position_type_id,
           v.playa_name,
           v.world_name,
@@ -145,6 +146,7 @@ const shiftVolunteers = async (
       );
       const resShiftVolunteerList = dbShiftVolunteerList.map(
         ({
+          critical,
           noshow,
           notes,
           playa_name,
@@ -155,6 +157,7 @@ const shiftVolunteers = async (
           world_name,
         }) => {
           const resShiftVolunteerItem: IResShiftVolunteerRowItem = {
+            critical: Boolean(critical),
             isCheckedIn: noshow,
             notes: notes ?? "",
             playaName: playa_name,

--- a/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/shifts/index.ts
@@ -31,6 +31,7 @@ const volunteerShifts = async (
           d.date,
           d.datename,
           COALESCE(NULLIF(stp.position_alias, ''), pt.position) AS position,
+          pt.critical,
           stp.position_type_id,
           stp.sap_points,
           sc.department,
@@ -65,6 +66,7 @@ const volunteerShifts = async (
       const resVolunteerShiftList = dbVolunteerShiftList.map(
         ({
           canceled,
+          critical,
           date,
           datename,
           department,
@@ -87,6 +89,7 @@ const volunteerShifts = async (
             },
             shift: {
               canceled: Boolean(canceled),
+              critical: Boolean(critical),
               csp: Number(sap_points ?? 0),
               date: date,
               dateName: datename ?? "",


### PR DESCRIPTION
Closes #308.

Logged-in regular volunteers can now remove themselves from shifts they signed up for, from both places they actually look:

## What's in here

**`/shifts` (agenda)** — cards marked "✓ You're signed up" get a **Remove** button (future/during shifts only; past mirrors the account page and stays admin-only). The button opens the existing remove-confirmation dialog and the agenda updates in place — no reload, the card flips back to its open state.

**`/shifts/[timeId]/volunteers` (shift detail)** — non-admins now get an **Actions** menu on *their own* roster row with a single "Remove shift" item. Other volunteers' rows are untouched, and the admin view (Admin review / Admin actions columns) is unchanged.

**#308 critical-drop warning (warn-then-allow)** — both remove dialogs now show a warning when the position is `critical=1` and require an "I understand this leaves a critical position unfilled" checkbox before the Remove button enables. Not a hard block, per the standing decision. The CVC-list email (#313) still fires server-side. This also lights up on the account page's existing remove flow for free.

**Security fix** — `DELETE /api/shifts/[timeId]/volunteers` previously accepted any authenticated user removing *anyone* (only the UI hid it). `shiftVolunteerRemove` now enforces `isOwnerOrAdmin`, covering both DELETE mounts at once. The PATCH check-in path has the same gap — filed separately as a follow-up issue.

**Bug found while testing** — the volunteers DataTable row arrays always carried 6 cells while non-admins only had 4 columns; MUIDataTable maps cells by index and silently drops extras, so the new menu never rendered. Rows are now composed in lockstep with the pushed columns.

## Verification (local, prod-pull DB, headless Chromium)

- Regular user on `/shifts`: Remove on own cards, click doesn't navigate (card is a Link), dialog opens, confirm → card reverts to open, DB row gets `remove_shift=1`
- Critical position: Remove button disabled until the acknowledge checkbox is ticked; non-critical dialog unchanged
- `/shifts/61/volunteers` as regular user: menu only on own row; after remove, roster updates live and "Add this shift" re-enables
- Admin view on the same page: columns and menus identical to before
- Authz: cross-user DELETE with a valid session → **403**; unauthenticated → **401**; self → 200
- `tsc --noEmit` and `npm run build` clean
- e2e: specs 03/04/07/13 fail identically on unmodified `main` (pre-existing local-env issue), no new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)