### PR TITLE
feat(saps): shared eligibility function (parity), category To-do summary, world names, row colors

### DIFF
--- a/client/lib/sapStatus.ts
+++ b/client/lib/sapStatus.ts
@@ -1,7 +1,8 @@
-// Shared SAP day-by-day requirements logic. Single source of truth for the
-// volunteer info endpoint (volunteer-facing "earn your SAP" page) and the
-// super-admin SAP page's people list. Pure helpers only — no DB — so both
-// callers feed it the day-CSP map they already query.
+// Shared SAP eligibility logic. Single source of truth for the volunteer info
+// endpoint (volunteer-facing "earn your SAP" page) and the super-admin SAP
+// page's people list — parity by design: both pages MUST evaluate eligibility
+// through evaluateSapEligibility below, never with their own rules. Pure
+// helpers only — no DB — so both callers feed it the data they already query.
 
 // SAP day-by-day requirements keyed by arrival datename. Each entry is either a
 // single datename, or an array meaning "any of these". EarlyThur/Fri/Man are
@@ -34,10 +35,88 @@ export const PRE_OPEN_DATENAMES = [
   "PreSat",
 ];
 
+// SAP-related role ids (op_roles), shared by both endpoints.
+export const ROLE_STAFF_ID = 2000006;
+export const ROLE_OTHER_SAP_ID = 2000007;
+
+export const REQUIRED_CSP = 12;
+
 export interface RequiredDay {
   datenames: string[];
   label: string;
   fulfilled: boolean;
+}
+
+// Where a person stands on getting a SAP:
+// - external: getting a SAP from another group (role 2000007) — not ours to earn
+// - not_earning: no SAP-earning shift signed up (and not staff), so currently
+//   not on track to get one
+// - missing: on track but requirements outstanding
+// - complete: all requirements met
+export type SapStanding = "external" | "not_earning" | "missing" | "complete";
+
+export interface SapEligibilityInput {
+  isStaff: boolean;
+  hasExternalSap: boolean;
+  bsSigned: boolean;
+  missingTrainings: string[]; // names of required-but-uncompleted trainings
+  totalCsp: number;
+  requiredDays: RequiredDay[];
+  hasEligibleShift: boolean; // has at least one CSP-earning shift
+}
+
+export interface SapEligibility {
+  standing: SapStanding;
+  requirementsMet: boolean;
+  missingSummary: string[]; // compact, e.g. ["BS", "2 trainings", "4 CSP", "1 day"]
+  missingDetail: string[]; // full labels for tooltips
+}
+
+// The one place SAP requirements are defined: signed Behavioral Standards,
+// every position-required training completed, >= REQUIRED_CSP points, and
+// each required work day covered.
+export function evaluateSapEligibility(
+  input: SapEligibilityInput,
+): SapEligibility {
+  const missingDays = input.requiredDays.filter((d) => !d.fulfilled);
+  const cspShort = Math.max(0, REQUIRED_CSP - input.totalCsp);
+
+  const missingSummary: string[] = [];
+  const missingDetail: string[] = [];
+  if (!input.bsSigned) {
+    missingSummary.push("BS");
+    missingDetail.push("Sign Behavioral Standards");
+  }
+  if (input.missingTrainings.length > 0) {
+    missingSummary.push(
+      `${input.missingTrainings.length} training${
+        input.missingTrainings.length > 1 ? "s" : ""
+      }`,
+    );
+    missingDetail.push(...input.missingTrainings.map((t) => `${t} training`));
+  }
+  if (cspShort > 0) {
+    missingSummary.push(`${cspShort} CSP`);
+    missingDetail.push(`CSP ${input.totalCsp}/${REQUIRED_CSP}`);
+  }
+  if (missingDays.length > 0) {
+    missingSummary.push(
+      `${missingDays.length} day${missingDays.length > 1 ? "s" : ""}`,
+    );
+    missingDetail.push(...missingDays.map((d) => d.label));
+  }
+
+  const requirementsMet = missingSummary.length === 0;
+
+  const standing: SapStanding = input.hasExternalSap
+    ? "external"
+    : !input.hasEligibleShift && !input.isStaff
+      ? "not_earning"
+      : requirementsMet
+        ? "complete"
+        : "missing";
+
+  return { standing, requirementsMet, missingSummary, missingDetail };
 }
 
 // Build the day-by-day requirement list for an arrival day. A day is fulfilled

--- a/client/src/app/saps/Saps.tsx
+++ b/client/src/app/saps/Saps.tsx
@@ -269,8 +269,19 @@ export const Saps = () => {
                 const isAssigned = assignment?.status === "assigned";
                 const choice = dateChoice[key] ?? "auto";
                 const rowBusy = busy[key] ?? false;
+                // Row tint: grey = not currently getting one of our SAPs
+                // (external SAP or no eligible shift), light red = missing
+                // items, light green = all requirements complete.
+                const rowBg =
+                  p.standing === "external" || p.standing === "not_earning"
+                    ? "#f5f5f5"
+                    : p.standing === "missing"
+                      ? "#ffebee"
+                      : p.standing === "complete"
+                        ? "#e8f5e9"
+                        : undefined;
                 return (
-                  <TableRow key={key} hover>
+                  <TableRow key={key} hover sx={{ bgcolor: rowBg }}>
                     <TableCell>
                       <Stack
                         direction="row"
@@ -287,6 +298,15 @@ export const Saps = () => {
                         ) : (
                           <span>{p.name}</span>
                         )}
+                        {p.worldName && p.worldName !== p.name && (
+                          <Typography
+                            component="span"
+                            variant="body2"
+                            color="text.secondary"
+                          >
+                            &quot;{p.worldName}&quot;
+                          </Typography>
+                        )}
                         {p.kind === "offbook" && (
                           <Chip label="off-book" size="small" />
                         )}
@@ -299,17 +319,19 @@ export const Saps = () => {
                       {p.firstShiftDayname ?? p.firstShiftDate ?? "—"}
                     </TableCell>
                     <TableCell>
-                      {p.missing.length > 0 ? (
-                        <Tooltip title={`Missing: ${p.missing.join("; ")}`}>
-                          <span>Missing {p.missing.length} item(s)</span>
+                      {p.standing === "external" ? (
+                        <Tooltip title="Getting a SAP from another group">
+                          <span>External SAP</span>
                         </Tooltip>
                       ) : p.kind === "offbook" ? (
                         <Tooltip title="Off-book — no requirements tracked">
                           <span style={{ color: "#999" }}>—</span>
                         </Tooltip>
-                      ) : p.requiredDays.length === 0 ? (
-                        <Tooltip title="No arrival date set — no required days">
-                          <span style={{ color: "#999" }}>—</span>
+                      ) : p.missingSummary.length > 0 ? (
+                        <Tooltip
+                          title={`Missing: ${p.missingDetail.join("; ")}`}
+                        >
+                          <span>Missing {p.missingSummary.join(", ")}</span>
                         </Tooltip>
                       ) : (
                         <Stack

--- a/client/src/components/types/sap.ts
+++ b/client/src/components/types/sap.ts
@@ -13,11 +13,14 @@ export interface ISapAssignment {
   receivedVia: "download" | "email" | null;
 }
 
+export type ISapStanding = "external" | "not_earning" | "missing" | "complete";
+
 export interface ISapPerson {
   kind: "volunteer" | "offbook";
   shiftboardId: number | null;
   email: string | null;
   name: string;
+  worldName: string | null;
   isStaff: boolean;
   autoLabel: string;
   firstShiftDate: string | null;
@@ -25,9 +28,10 @@ export interface ISapPerson {
   autoSapDate: string | null;
   autoSapDayname: string | null;
   requiredDays: ISapRequiredDay[];
-  missing: string[];
+  standing: ISapStanding | null; // null for off-book (no requirements tracked)
+  missingSummary: string[];
+  missingDetail: string[];
   totalCsp: number;
-  cspFulfilled: boolean;
   assignment: ISapAssignment | null;
 }
 

--- a/client/src/pages/api/saps/people/index.ts
+++ b/client/src/pages/api/saps/people/index.ts
@@ -6,10 +6,12 @@ import { withSuperAdmin } from "@/lib/withSuperAdmin";
 import { pool } from "lib/database";
 import { autoTargetDay, pickAutoSap } from "lib/sap";
 import { getCurrentBurnYear } from "lib/sapDb";
-import { buildRequiredDays } from "lib/sapStatus";
-
-const ROLE_STAFF_ID = 2000006;
-const REQUIRED_CSP = 12;
+import {
+  buildRequiredDays,
+  evaluateSapEligibility,
+  ROLE_OTHER_SAP_ID,
+  ROLE_STAFF_ID,
+} from "lib/sapStatus";
 
 interface Assignment {
   sapId: number;
@@ -41,6 +43,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
     [volRows],
     [offbookRows],
     [staffRows],
+    [otherSapRows],
     [bsRows],
     [trainingRows],
     [totalCspRows],
@@ -64,6 +67,11 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       `SELECT shiftboard_id FROM op_volunteer_roles
         WHERE role_id = ? AND remove_role = false`,
       [ROLE_STAFF_ID],
+    ),
+    pool.query<RowDataPacket[]>(
+      `SELECT shiftboard_id FROM op_volunteer_roles
+        WHERE role_id = ? AND remove_role = false`,
+      [ROLE_OTHER_SAP_ID],
     ),
     pool.query<RowDataPacket[]>(
       `SELECT shiftboard_id FROM op_volunteer_roles
@@ -137,6 +145,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
   for (const d of dateRows) dateToDayname.set(String(d.date), d.datename);
 
   const staffSet = new Set<number>(staffRows.map((r) => r.shiftboard_id));
+  const otherSapSet = new Set<number>(otherSapRows.map((r) => r.shiftboard_id));
   const bsSet = new Set<number>(bsRows.map((r) => r.shiftboard_id));
 
   const missingTrainingsMap = new Map<number, string[]>();
@@ -194,18 +203,24 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       v.arrival_datename ?? "",
       dayCspMap.get(v.shiftboard_id) ?? {},
     );
-    // SAP to-do criteria: required work days + signed behavioral standards +
-    // every training their positions require.
-    const missing = requiredDays.filter((d) => !d.fulfilled).map((d) => d.label);
-    if (!bsSet.has(v.shiftboard_id)) missing.push("Sign Behavioral Standards");
-    for (const t of missingTrainingsMap.get(v.shiftboard_id) ?? [])
-      missing.push(`${t} training`);
     const totalCsp = totalCspMap.get(v.shiftboard_id) ?? 0;
+    // Parity by design: the same shared function evaluates eligibility here
+    // and on the volunteer info page.
+    const eligibility = evaluateSapEligibility({
+      isStaff,
+      hasExternalSap: otherSapSet.has(v.shiftboard_id),
+      bsSigned: bsSet.has(v.shiftboard_id),
+      missingTrainings: missingTrainingsMap.get(v.shiftboard_id) ?? [],
+      totalCsp,
+      requiredDays,
+      hasEligibleShift: firstShiftDate !== null,
+    });
     return {
       kind: "volunteer" as const,
       shiftboardId: v.shiftboard_id,
       email: v.email ?? null,
       name: v.playa_name || v.world_name || `#${v.shiftboard_id}`,
+      worldName: v.world_name || null,
       isStaff,
       autoLabel: isStaff ? "Staff" : "Auto",
       firstShiftDate,
@@ -213,9 +228,10 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       autoSapDate,
       autoSapDayname: dayname(autoSapDate),
       requiredDays,
-      missing,
+      standing: eligibility.standing,
+      missingSummary: eligibility.missingSummary,
+      missingDetail: eligibility.missingDetail,
       totalCsp,
-      cspFulfilled: totalCsp >= REQUIRED_CSP,
       assignment: assignByVol.get(v.shiftboard_id) ?? null,
     };
   });
@@ -227,6 +243,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       shiftboardId: null,
       email: String(o.email),
       name: o.name || String(o.email),
+      worldName: null,
       isStaff: false,
       autoLabel: "Auto",
       firstShiftDate: null,
@@ -234,9 +251,10 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       autoSapDate: null,
       autoSapDayname: null,
       requiredDays: [],
-      missing: [],
+      standing: null,
+      missingSummary: [],
+      missingDetail: [],
       totalCsp: 0,
-      cspFulfilled: false,
       assignment: assignByEmail.get(String(o.email).toLowerCase()) ?? null,
     }));
 

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -8,12 +8,17 @@ import type {
 import { pool } from "lib/database";
 import { withAuth } from "@/lib/withAuth";
 import { isOwnerOrAdmin } from "@/lib/authz";
-import { buildRequiredDays, PRE_OPEN_DATENAMES } from "lib/sapStatus";
+import {
+  buildRequiredDays,
+  evaluateSapEligibility,
+  PRE_OPEN_DATENAMES,
+  REQUIRED_CSP,
+  ROLE_OTHER_SAP_ID,
+  ROLE_STAFF_ID,
+} from "lib/sapStatus";
 import { autoTargetDay } from "lib/sap";
 
 // Role IDs for VIP-specific roles
-const ROLE_STAFF_ID = 2000006;
-const ROLE_OTHER_SAP_ID = 2000007;
 const ROLE_BURNER_PROFILE_UPDATED_ID = 2000010;
 const ROLE_WELCOME_COMPLETE_ID = 174766;
 const ROLE_BEHAVIORAL_STANDARDS_ID = 1000012;
@@ -223,7 +228,7 @@ const volunteerInfo = async (
       const requiredDays: IResVolunteerInfo["sapStatus"]["requiredDays"] =
         buildRequiredDays(arrivalDatename, dayCspMap);
 
-      const requiredCsp = 12;
+      const requiredCsp = REQUIRED_CSP;
       const cspFulfilled = totalCsp >= requiredCsp;
 
       const sapFile = hasSapFile
@@ -234,31 +239,6 @@ const volunteerInfo = async (
             date: dbSapList[0].date,
           }
         : null;
-
-      // The date a SAP has been earned/assigned FOR. Precedence:
-      //   1. an assigned SAP's date (admin may have picked a different date on
-      //      the SAP page — that's the "override"), else
-      //   2. the auto date (day before the first SAP-earning shift) IF the
-      //      volunteer has met the SAP requirements (>=12 CSP + each required
-      //      day covered). Null otherwise -> the earned-SAP box stays hidden.
-      const sapRequirementsMet =
-        cspFulfilled && requiredDays.every((d) => d.fulfilled);
-      const earnedSapDate: string | null = sapFile
-        ? String(sapFile.date)
-        : sapRequirementsMet
-          ? autoTargetDay(firstCspShiftDate)
-          : null;
-      // datename that goes with earnedSapDate (e.g. "PreTue"), so the UI can
-      // show "Aug 25 (PreTue)". Assigned SAP carries its own; for the auto date
-      // look it up in the event calendar.
-      const dateToDatename = new Map<string, string>(
-        dbDateList.map((d) => [String(d.date), String(d.datename)])
-      );
-      const earnedSapDatename: string | null = sapFile
-        ? String(sapFile.datename)
-        : earnedSapDate
-          ? (dateToDatename.get(earnedSapDate) ?? null)
-          : null;
 
       // role-based thresholds
       const roleThresholds: IResVolunteerInfo["roleThresholds"] = dbRoleList
@@ -310,6 +290,42 @@ const volunteerInfo = async (
       const behavioralStandardsSigned = roleIdSet.has(
         ROLE_BEHAVIORAL_STANDARDS_ID
       );
+
+      // The date a SAP has been earned/assigned FOR. Precedence:
+      //   1. an assigned SAP's date (admin may have picked a different date on
+      //      the SAP page — that's the "override"), else
+      //   2. the auto date (day before the first SAP-earning shift) IF the
+      //      volunteer has met the SAP requirements. Null otherwise -> the
+      //      earned-SAP box stays hidden.
+      // Parity by design: eligibility comes from the same shared function the
+      // super-admin SAP page uses (BS + trainings + CSP + required days).
+      const sapRequirementsMet = evaluateSapEligibility({
+        isStaff,
+        hasExternalSap: hasOtherSap,
+        bsSigned: behavioralStandardsSigned,
+        missingTrainings: trainings
+          .filter((t) => !t.completed)
+          .map((t) => t.trainingName),
+        totalCsp,
+        requiredDays,
+        hasEligibleShift: firstCspShiftDate !== null,
+      }).requirementsMet;
+      const earnedSapDate: string | null = sapFile
+        ? String(sapFile.date)
+        : sapRequirementsMet
+          ? autoTargetDay(firstCspShiftDate)
+          : null;
+      // datename that goes with earnedSapDate (e.g. "PreTue"), so the UI can
+      // show "Aug 25 (PreTue)". Assigned SAP carries its own; for the auto date
+      // look it up in the event calendar.
+      const dateToDatename = new Map<string, string>(
+        dbDateList.map((d) => [String(d.date), String(d.datename)])
+      );
+      const earnedSapDatename: string | null = sapFile
+        ? String(sapFile.datename)
+        : earnedSapDate
+          ? (dateToDatename.get(earnedSapDate) ?? null)
+          : null;
       // Strict (add_role=true AND remove_role=false) so the checkbox state
        // matches the queue's send-time filter in client/lib/mail/queue.ts
       // exactly. The bulk role-list query above is intentionally looser to

--- a/client/tests/unit/sapStatus.test.ts
+++ b/client/tests/unit/sapStatus.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { evaluateSapEligibility, REQUIRED_CSP } from "../../lib/sapStatus";
+
+const day = (label: string, fulfilled: boolean) => ({
+  datenames: [label],
+  label,
+  fulfilled,
+});
+
+const base = {
+  isStaff: false,
+  hasExternalSap: false,
+  bsSigned: true,
+  missingTrainings: [] as string[],
+  totalCsp: REQUIRED_CSP,
+  requiredDays: [day("PreThur", true)],
+  hasEligibleShift: true,
+};
+
+test("complete when everything is met", () => {
+  const e = evaluateSapEligibility(base);
+  assert.equal(e.standing, "complete");
+  assert.equal(e.requirementsMet, true);
+  assert.deepEqual(e.missingSummary, []);
+});
+
+test("summary lists BS, trainings, CSP shortfall, days — in that order", () => {
+  const e = evaluateSapEligibility({
+    ...base,
+    bsSigned: false,
+    missingTrainings: ["Census Basics", "Random Sampling"],
+    totalCsp: 8,
+    requiredDays: [day("PreThur", false), day("PreFri", true)],
+  });
+  assert.equal(e.standing, "missing");
+  assert.deepEqual(e.missingSummary, ["BS", "2 trainings", "4 CSP", "1 day"]);
+  assert.deepEqual(e.missingDetail, [
+    "Sign Behavioral Standards",
+    "Census Basics training",
+    "Random Sampling training",
+    "CSP 8/12",
+    "PreThur",
+  ]);
+});
+
+test("external SAP wins over everything else", () => {
+  const e = evaluateSapEligibility({
+    ...base,
+    hasExternalSap: true,
+    bsSigned: false,
+    hasEligibleShift: false,
+  });
+  assert.equal(e.standing, "external");
+});
+
+test("no eligible shift -> not_earning, unless staff", () => {
+  assert.equal(
+    evaluateSapEligibility({ ...base, hasEligibleShift: false, totalCsp: 0 })
+      .standing,
+    "not_earning",
+  );
+  assert.equal(
+    evaluateSapEligibility({
+      ...base,
+      hasEligibleShift: false,
+      isStaff: true,
+      totalCsp: 0,
+    }).standing,
+    "missing",
+  );
+});


### PR DESCRIPTION
Per Mew's requests on the SAPs page:

1. **Parity by design** — new `evaluateSapEligibility()` in `lib/sapStatus.ts` is the single source of truth for SAP eligibility (BS + trainings + CSP + required days). Both the volunteer info endpoint and the SAP page endpoint call it; neither carries its own rules anymore. Staff/other-SAP role ids and `REQUIRED_CSP` moved there too.
2. **To-do summary by category** — `Missing BS, 2 trainings, 4 CSP, 1 day` (that order), full detail in the tooltip (`Sign Behavioral Standards; Census Basics training; CSP 8/12; PreThur`).
3. **World name in quotes** next to the playa name (skipped when it would duplicate the display name).
4. **External SAP** — role 2000007 holders show `External SAP` in To-do.
5. **Row colors** — grey `#f5f5f5` = not currently getting one of ours (external SAP, or no SAP-earning shift and not staff); light red `#ffebee` = missing items; light green `#e8f5e9` = complete.

**Behavior change to be aware of:** the volunteer-facing earned-SAP box (info page) now requires BS signed + trainings complete in addition to CSP + days — that's the point of parity, but it means some volunteers who previously saw the earned box will see it disappear until they sign/complete.

Verified on local prod build against prod-pull DB: standings distribute 55 missing / 22 not-earning / 12 external / 4 complete; screenshot checked. Unit tests for the shared function in `tests/unit/sapStatus.test.ts` (33 unit tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)