### PR TITLE
feat(saps): grey rule rework, persisted date choice, unlock+burn flow, ticket serials

### DIFF
--- a/client/lib/sapStatus.ts
+++ b/client/lib/sapStatus.ts
@@ -49,8 +49,9 @@ export interface RequiredDay {
 
 // Where a person stands on getting a SAP:
 // - external: getting a SAP from another group (role 2000007) — not ours to earn
-// - not_earning: no SAP-earning shift signed up (and not staff), so currently
-//   not on track to get one
+// - not_earning: not on track to get one by default — no CSP-earning shift
+//   before/on Open Sunday, or Staff. An explicit date (admin override or an
+//   actual assignment) lifts this back to missing/complete.
 // - missing: on track but requirements outstanding
 // - complete: all requirements met
 export type SapStanding = "external" | "not_earning" | "missing" | "complete";
@@ -62,7 +63,19 @@ export interface SapEligibilityInput {
   missingTrainings: string[]; // names of required-but-uncompleted trainings
   totalCsp: number;
   requiredDays: RequiredDay[];
-  hasEligibleShift: boolean; // has at least one CSP-earning shift
+  hasPreOpenShift: boolean; // has a CSP shift starting on/before Open Sunday
+  hasDateOverride: boolean; // admin picked a date or a SAP is assigned/issued
+}
+
+// A SAP is only relevant when the first CSP-earning shift starts on or before
+// Open Sunday — later shifts need no early entry. Dates are YYYY-MM-DD, so
+// string compare is safe. Unknown Open Sunday -> any CSP shift counts.
+export function isPreOpenShift(
+  firstCspShiftDate: string | null,
+  openSunDate: string | null,
+): boolean {
+  if (!firstCspShiftDate) return false;
+  return openSunDate === null || firstCspShiftDate <= openSunDate;
 }
 
 export interface SapEligibility {
@@ -110,7 +123,7 @@ export function evaluateSapEligibility(
 
   const standing: SapStanding = input.hasExternalSap
     ? "external"
-    : !input.hasEligibleShift && !input.isStaff
+    : (input.isStaff || !input.hasPreOpenShift) && !input.hasDateOverride
       ? "not_earning"
       : requirementsMet
         ? "complete"

--- a/client/src/app/saps/Saps.tsx
+++ b/client/src/app/saps/Saps.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Chip,
   Container,
+  IconButton,
   Link as MuiLink,
   MenuItem,
   Paper,
@@ -81,6 +82,9 @@ export const Saps = () => {
   const [uploading, setUploading] = useState(false);
   const [offbookEmail, setOffbookEmail] = useState("");
   const [offbookName, setOffbookName] = useState("");
+  // Rows the admin has unlocked for reassignment (received SAP burns on the
+  // next assign, server-side).
+  const [unlocked, setUnlocked] = useState<Record<string, boolean>>({});
 
   if (peopleError) return <ErrorPage />;
   if (!peopleData) return <Loading />;
@@ -121,7 +125,7 @@ export const Saps = () => {
     setRowBusy(key, true);
     try {
       if (checked) {
-        const date = dateChoice[key] ?? "auto";
+        const date = dateChoice[key] ?? p.dateOverride ?? "auto";
         const res = await fetch("/api/saps/assign", {
           method: "POST",
           body: JSON.stringify({ ...targetBody(p), date }),
@@ -140,10 +144,28 @@ export const Saps = () => {
           return;
         }
       }
+      setUnlocked((u) => ({ ...u, [key]: false }));
       refresh();
     } finally {
       setRowBusy(key, false);
     }
+  };
+
+  // Persist the SAP-date dropdown choice so it survives between sessions.
+  const handleDateChoice = async (p: ISapPerson, value: string) => {
+    const key = rowKey(p);
+    setDateChoice((d) => ({ ...d, [key]: value }));
+    const res = await fetch("/api/saps/date-choice", {
+      method: "POST",
+      body: JSON.stringify({
+        ...targetBody(p),
+        date: value === "auto" ? null : value,
+      }),
+    });
+    if (!res.ok) {
+      enqueueSnackbar(await readError(res), { variant: "error" });
+    }
+    mutate(PEOPLE_URL);
   };
 
   // download (issue) — POST flips to received + streams the PDF -----------
@@ -163,7 +185,7 @@ export const Saps = () => {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `SAP_${p.assignment.sapDate}.pdf`;
+      a.download = `SAP_${p.assignment.sapDate}_${p.assignment.ticketId ?? p.assignment.sapId}.pdf`;
       a.click();
       URL.revokeObjectURL(url);
       refresh();
@@ -204,6 +226,18 @@ export const Saps = () => {
     setOffbookEmail("");
     setOffbookName("");
     mutate(PEOPLE_URL);
+  };
+
+  // Unlock a delivered (locked) SAP row for reassignment. The old SAP stays
+  // valid until a new one is assigned; the assign endpoint then burns it.
+  const handleUnlock = (p: ISapPerson) => {
+    if (!p.assignment) return;
+    const ok = window.confirm(
+      `Unlock ${p.name}? Assigning a new SAP will permanently BURN their ` +
+        `delivered SAP (ticket ${p.assignment.ticketId ?? p.assignment.sapId}) — ` +
+        `burned SAPs can never be reassigned to anyone.`,
+    );
+    if (ok) setUnlocked((u) => ({ ...u, [rowKey(p)]: true }));
   };
 
   // render ----------------------------------------------------------------
@@ -267,14 +301,15 @@ export const Saps = () => {
                 const assignment = p.assignment;
                 const isReceived = assignment?.status === "received";
                 const isAssigned = assignment?.status === "assigned";
-                const choice = dateChoice[key] ?? "auto";
+                const choice = dateChoice[key] ?? p.dateOverride ?? "auto";
                 const rowBusy = busy[key] ?? false;
+                const isUnlocked = isReceived && (unlocked[key] ?? false);
                 // Row tint: grey = not currently getting one of our SAPs
                 // (external SAP or no eligible shift), light red = missing
                 // items, light green = all requirements complete.
                 const rowBg =
                   p.standing === "external" || p.standing === "not_earning"
-                    ? "#f5f5f5"
+                    ? "#e0e0e0"
                     : p.standing === "missing"
                       ? "#ffebee"
                       : p.standing === "complete"
@@ -345,24 +380,21 @@ export const Saps = () => {
                       )}
                     </TableCell>
                     <TableCell>
-                      {assignment ? (
+                      {assignment && !isUnlocked ? (
                         <span>{assignment.sapDate}</span>
                       ) : (
                         <Select
                           size="small"
                           value={choice}
                           disabled={rowBusy}
-                          onChange={(e) =>
-                            setDateChoice((d) => ({
-                              ...d,
-                              [key]: e.target.value,
-                            }))
-                          }
+                          onChange={(e) => handleDateChoice(p, e.target.value)}
                           sx={{ minWidth: 160 }}
                         >
                           <MenuItem value="auto">
                             {p.autoLabel}
-                            {p.autoSapDayname ? ` (${p.autoSapDayname})` : ""}
+                            {p.autoLabel !== "Staff" && p.autoSapDayname
+                              ? ` (${p.autoSapDayname})`
+                              : ""}
                           </MenuItem>
                           {availableDates.map((d) => (
                             <MenuItem key={d.date} value={d.date}>
@@ -373,14 +405,16 @@ export const Saps = () => {
                       )}
                     </TableCell>
                     <TableCell align="center">
-                      {isReceived ? (
-                        <Tooltip title="Issued — locked">
-                          <LockIcon color="disabled" fontSize="small" />
+                      {isReceived && !isUnlocked ? (
+                        <Tooltip title="Issued — locked. Click to unlock and reassign.">
+                          <IconButton size="small" onClick={() => handleUnlock(p)}>
+                            <LockIcon color="disabled" fontSize="small" />
+                          </IconButton>
                         </Tooltip>
                       ) : (
                         <input
                           type="checkbox"
-                          checked={Boolean(assignment)}
+                          checked={Boolean(assignment) && !isUnlocked}
                           disabled={rowBusy}
                           onChange={(e) =>
                             handleAssignToggle(p, e.target.checked)

--- a/client/src/app/saps/Saps.tsx
+++ b/client/src/app/saps/Saps.tsx
@@ -235,7 +235,8 @@ export const Saps = () => {
     const ok = window.confirm(
       `Unlock ${p.name}? Assigning a new SAP will permanently BURN their ` +
         `delivered SAP (ticket ${p.assignment.ticketId ?? p.assignment.sapId}) — ` +
-        `burned SAPs can never be reassigned to anyone.`,
+        `burned SAPs can never be reassigned to anyone. ` +
+        `(To re-send the same SAP, use Re-download / Email again instead.)`,
     );
     if (ok) setUnlocked((u) => ({ ...u, [rowKey(p)]: true }));
   };
@@ -401,6 +402,12 @@ export const Saps = () => {
                               {(d.dayname ?? d.date) + ` (${d.count})`}
                             </MenuItem>
                           ))}
+                          {choice !== "auto" &&
+                            !availableDates.some((d) => d.date === choice) && (
+                              <MenuItem value={choice} disabled>
+                                {choice} (none left)
+                              </MenuItem>
+                            )}
                         </Select>
                       )}
                     </TableCell>

--- a/client/src/components/types/sap.ts
+++ b/client/src/components/types/sap.ts
@@ -9,6 +9,7 @@ export interface ISapRequiredDay {
 export interface ISapAssignment {
   sapId: number;
   sapDate: string;
+  ticketId: string | null;
   status: "assigned" | "received";
   receivedVia: "download" | "email" | null;
 }
@@ -32,6 +33,7 @@ export interface ISapPerson {
   missingSummary: string[];
   missingDetail: string[];
   totalCsp: number;
+  dateOverride: string | null; // persisted SAP-date dropdown choice (null = Auto)
   assignment: ISapAssignment | null;
 }
 

--- a/client/src/pages/api/saps/[sapId]/email/index.ts
+++ b/client/src/pages/api/saps/[sapId]/email/index.ts
@@ -29,7 +29,7 @@ const emailSap = async (req: NextApiRequest, res: NextApiResponse) => {
   // Resolve recipient + validate BEFORE locking, so we never mark a SAP
   // received that we couldn't actually send.
   const [rows] = await pool.query<RowDataPacket[]>(
-    `SELECT s.filename, s.sap_date, s.status, s.assigned_email, v.email AS vol_email
+    `SELECT s.filename, s.sap_date, s.ticket_id, s.status, s.assigned_email, v.email AS vol_email
        FROM op_saps s
        LEFT JOIN op_volunteers v ON s.shiftboard_id = v.shiftboard_id
       WHERE s.sap_id = ?`,
@@ -79,13 +79,19 @@ const emailSap = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const { id } = await enqueueEmail({
     to,
-    subject: "Your Burning Man Setup Access Pass (SAP)",
+    subject: "Your Census Setup Access Pass (SAP)",
     bodyText:
       `Your Setup Access Pass is attached.\n\n` +
       `It is valid on or after ${row.sap_date}. Print it and present it ` +
       `together with your ticket or credential at the gate.\n\n` +
+      `Yes, the pass is addressed to Matthew Hewitt — that is expected ` +
+      `(all Census SAPs are issued under one name). Rest assured it will ` +
+      `work for you. If you have any issues at the Gate, contact Census.\n\n` +
       `A SAP is not a ticket and does not grant access on its own.`,
-    attachment: { filename: `SAP_${row.sap_date}.pdf`, content },
+    attachment: {
+      filename: `SAP_${row.sap_date}_${row.ticket_id ?? sapId}.pdf`,
+      content,
+    },
     category: "sap",
   });
 

--- a/client/src/pages/api/saps/[sapId]/file/index.ts
+++ b/client/src/pages/api/saps/[sapId]/file/index.ts
@@ -24,7 +24,7 @@ const file = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const [rows] = await pool.query<RowDataPacket[]>(
-    `SELECT filename, sap_date, status FROM op_saps WHERE sap_id=?`,
+    `SELECT filename, sap_date, ticket_id, status FROM op_saps WHERE sap_id=?`,
     [sapId],
   );
   const row = rows[0];
@@ -46,7 +46,7 @@ const file = async (req: NextApiRequest, res: NextApiResponse) => {
   res.setHeader("Content-Type", "application/pdf");
   res.setHeader(
     "Content-Disposition",
-    `attachment; filename="SAP_${row.sap_date}.pdf"`,
+    `attachment; filename="SAP_${row.sap_date}_${row.ticket_id ?? sapId}.pdf"`,
   );
   return res.send(buf);
 };

--- a/client/src/pages/api/saps/[sapId]/issue/index.ts
+++ b/client/src/pages/api/saps/[sapId]/issue/index.ts
@@ -41,7 +41,7 @@ const issue = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const [rows] = await pool.query<RowDataPacket[]>(
-    `SELECT filename, sap_date FROM op_saps WHERE sap_id=?`,
+    `SELECT filename, sap_date, ticket_id FROM op_saps WHERE sap_id=?`,
     [sapId],
   );
   const row = rows[0];
@@ -59,7 +59,7 @@ const issue = async (req: NextApiRequest, res: NextApiResponse) => {
   res.setHeader("Content-Type", "application/pdf");
   res.setHeader(
     "Content-Disposition",
-    `attachment; filename="SAP_${row.sap_date}.pdf"`,
+    `attachment; filename="SAP_${row.sap_date}_${row.ticket_id ?? sapId}.pdf"`,
   );
   return res.send(buf);
 };

--- a/client/src/pages/api/saps/date-choice/index.ts
+++ b/client/src/pages/api/saps/date-choice/index.ts
@@ -1,0 +1,57 @@
+import type { ResultSetHeader } from "mysql2";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSuperAdmin } from "@/lib/withSuperAdmin";
+import { pool } from "lib/database";
+
+interface DateChoiceBody {
+  shiftboardId?: number;
+  email?: string;
+  date?: string | null; // "YYYY-MM-DD" to pin, null/undefined to revert to Auto
+}
+
+// POST /api/saps/date-choice — persist the SAP-date dropdown choice so it
+// survives between sessions (it used to live only in client state). Stored on
+// the person, not a SAP: no pass is reserved until Assign.
+const dateChoice = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") {
+    return res
+      .status(405)
+      .json({ statusCode: 405, message: "Method not allowed" });
+  }
+
+  const body: DateChoiceBody =
+    typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body ?? {});
+
+  const date = body.date ?? null;
+  if (date !== null && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return res
+      .status(400)
+      .json({ statusCode: 400, message: "date must be YYYY-MM-DD or null" });
+  }
+
+  let result: ResultSetHeader;
+  if (body.shiftboardId != null && !body.email) {
+    [result] = await pool.execute<ResultSetHeader>(
+      `UPDATE op_volunteers SET sap_date_override=? WHERE shiftboard_id=?`,
+      [date, body.shiftboardId],
+    );
+  } else if (body.email && body.shiftboardId == null) {
+    [result] = await pool.execute<ResultSetHeader>(
+      `UPDATE op_sap_offbook SET sap_date_override=? WHERE email=?`,
+      [date, body.email.toLowerCase()],
+    );
+  } else {
+    return res.status(400).json({
+      statusCode: 400,
+      message: "Provide exactly one of shiftboardId or email",
+    });
+  }
+
+  if (result.affectedRows === 0) {
+    return res.status(404).json({ statusCode: 404, message: "Person not found" });
+  }
+  return res.status(200).json({ statusCode: 200, date });
+};
+
+export default withSuperAdmin(dateChoice);

--- a/client/src/pages/api/saps/people/index.ts
+++ b/client/src/pages/api/saps/people/index.ts
@@ -9,6 +9,7 @@ import { getCurrentBurnYear } from "lib/sapDb";
 import {
   buildRequiredDays,
   evaluateSapEligibility,
+  isPreOpenShift,
   ROLE_OTHER_SAP_ID,
   ROLE_STAFF_ID,
 } from "lib/sapStatus";
@@ -16,6 +17,7 @@ import {
 interface Assignment {
   sapId: number;
   sapDate: string;
+  ticketId: string | null;
   status: "assigned" | "received";
   receivedVia: "download" | "email" | null;
 }
@@ -55,13 +57,14 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
   ] = await Promise.all([
     pool.query<RowDataPacket[]>(
       `SELECT v.shiftboard_id, v.playa_name, v.world_name, v.email,
-              d.datename AS arrival_datename
+              v.sap_date_override, d.datename AS arrival_datename
          FROM op_volunteers v
          LEFT JOIN op_dates d ON v.arrival_date_id = d.date_id
         WHERE v.delete_volunteer = false`,
     ),
     pool.query<RowDataPacket[]>(
-      `SELECT email, name, linked_shiftboard_id FROM op_sap_offbook`,
+      `SELECT email, name, linked_shiftboard_id, sap_date_override
+         FROM op_sap_offbook`,
     ),
     pool.query<RowDataPacket[]>(
       `SELECT shiftboard_id FROM op_volunteer_roles
@@ -132,7 +135,8 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       [burnYear],
     ),
     pool.query<RowDataPacket[]>(
-      `SELECT sap_id, sap_date, status, received_via, shiftboard_id, assigned_email
+      `SELECT sap_id, sap_date, ticket_id, status, received_via, shiftboard_id,
+              assigned_email
          FROM op_saps
         WHERE burn_year = ? AND status IN ('assigned', 'received')`,
       [burnYear],
@@ -183,6 +187,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
     const a: Assignment = {
       sapId: r.sap_id,
       sapDate: String(r.sap_date),
+      ticketId: r.ticket_id ? String(r.ticket_id) : null,
       status: r.status,
       receivedVia: r.received_via,
     };
@@ -194,6 +199,9 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
   const dayname = (date: string | null) =>
     date ? (dateToDayname.get(date) ?? null) : null;
 
+  const openSunRow = dateRows.find((d) => d.datename === "OpenSun");
+  const openSunDate = openSunRow ? String(openSunRow.date) : null;
+
   const volunteers = volRows.map((v) => {
     const isStaff = staffSet.has(v.shiftboard_id);
     const firstShiftDate = firstShiftMap.get(v.shiftboard_id) ?? null;
@@ -204,6 +212,10 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       dayCspMap.get(v.shiftboard_id) ?? {},
     );
     const totalCsp = totalCspMap.get(v.shiftboard_id) ?? 0;
+    const assignment = assignByVol.get(v.shiftboard_id) ?? null;
+    const dateOverride = v.sap_date_override
+      ? String(v.sap_date_override)
+      : null;
     // Parity by design: the same shared function evaluates eligibility here
     // and on the volunteer info page.
     const eligibility = evaluateSapEligibility({
@@ -213,7 +225,8 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       missingTrainings: missingTrainingsMap.get(v.shiftboard_id) ?? [],
       totalCsp,
       requiredDays,
-      hasEligibleShift: firstShiftDate !== null,
+      hasPreOpenShift: isPreOpenShift(firstShiftDate, openSunDate),
+      hasDateOverride: assignment !== null || dateOverride !== null,
     });
     return {
       kind: "volunteer" as const,
@@ -232,7 +245,8 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       missingSummary: eligibility.missingSummary,
       missingDetail: eligibility.missingDetail,
       totalCsp,
-      assignment: assignByVol.get(v.shiftboard_id) ?? null,
+      dateOverride,
+      assignment,
     };
   });
 
@@ -255,6 +269,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       missingSummary: [],
       missingDetail: [],
       totalCsp: 0,
+      dateOverride: o.sap_date_override ? String(o.sap_date_override) : null,
       assignment: assignByEmail.get(String(o.email).toLowerCase()) ?? null,
     }));
 

--- a/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
+++ b/client/src/pages/api/volunteers/[shiftboardId]/info/index.ts
@@ -11,6 +11,7 @@ import { isOwnerOrAdmin } from "@/lib/authz";
 import {
   buildRequiredDays,
   evaluateSapEligibility,
+  isPreOpenShift,
   PRE_OPEN_DATENAMES,
   REQUIRED_CSP,
   ROLE_OTHER_SAP_ID,
@@ -299,6 +300,7 @@ const volunteerInfo = async (
       //      earned-SAP box stays hidden.
       // Parity by design: eligibility comes from the same shared function the
       // super-admin SAP page uses (BS + trainings + CSP + required days).
+      const openSunRow = dbDateList.find((d) => d.datename === "OpenSun");
       const sapRequirementsMet = evaluateSapEligibility({
         isStaff,
         hasExternalSap: hasOtherSap,
@@ -308,7 +310,11 @@ const volunteerInfo = async (
           .map((t) => t.trainingName),
         totalCsp,
         requiredDays,
-        hasEligibleShift: firstCspShiftDate !== null,
+        hasPreOpenShift: isPreOpenShift(
+          firstCspShiftDate,
+          openSunRow ? String(openSunRow.date) : null,
+        ),
+        hasDateOverride: hasSapFile,
       }).requirementsMet;
       const earnedSapDate: string | null = sapFile
         ? String(sapFile.date)

--- a/client/tests/unit/sapStatus.test.ts
+++ b/client/tests/unit/sapStatus.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { evaluateSapEligibility, REQUIRED_CSP } from "../../lib/sapStatus";
+import {
+  evaluateSapEligibility,
+  isPreOpenShift,
+  REQUIRED_CSP,
+} from "../../lib/sapStatus";
 
 const day = (label: string, fulfilled: boolean) => ({
   datenames: [label],
@@ -16,7 +20,8 @@ const base = {
   missingTrainings: [] as string[],
   totalCsp: REQUIRED_CSP,
   requiredDays: [day("PreThur", true)],
-  hasEligibleShift: true,
+  hasPreOpenShift: true,
+  hasDateOverride: false,
 };
 
 test("complete when everything is met", () => {
@@ -50,24 +55,42 @@ test("external SAP wins over everything else", () => {
     ...base,
     hasExternalSap: true,
     bsSigned: false,
-    hasEligibleShift: false,
+    hasPreOpenShift: false,
   });
   assert.equal(e.standing, "external");
 });
 
-test("no eligible shift -> not_earning, unless staff", () => {
+test("no pre-open shift or Staff -> not_earning, unless a date is set", () => {
   assert.equal(
-    evaluateSapEligibility({ ...base, hasEligibleShift: false, totalCsp: 0 })
+    evaluateSapEligibility({ ...base, hasPreOpenShift: false, totalCsp: 0 })
       .standing,
     "not_earning",
   );
   assert.equal(
+    evaluateSapEligibility({ ...base, isStaff: true }).standing,
+    "not_earning",
+  );
+  // An explicit date (override or assignment) lifts the grey back to normal.
+  assert.equal(
+    evaluateSapEligibility({ ...base, isStaff: true, hasDateOverride: true })
+      .standing,
+    "complete",
+  );
+  assert.equal(
     evaluateSapEligibility({
       ...base,
-      hasEligibleShift: false,
-      isStaff: true,
+      hasPreOpenShift: false,
+      hasDateOverride: true,
       totalCsp: 0,
     }).standing,
     "missing",
   );
+});
+
+test("isPreOpenShift compares against Open Sunday", () => {
+  assert.equal(isPreOpenShift(null, "2026-08-30"), false);
+  assert.equal(isPreOpenShift("2026-08-25", "2026-08-30"), true);
+  assert.equal(isPreOpenShift("2026-08-30", "2026-08-30"), true);
+  assert.equal(isPreOpenShift("2026-09-02", "2026-08-30"), false);
+  assert.equal(isPreOpenShift("2026-09-02", null), true);
 });

--- a/migrations/010_sap_date_override.sql
+++ b/migrations/010_sap_date_override.sql
@@ -1,0 +1,4 @@
+-- SAP page: persist the admin-chosen SAP date between sessions (dropdown
+-- choice used to live only in client state). NULL = Auto.
+ALTER TABLE op_volunteers ADD COLUMN sap_date_override DATE NULL;
+ALTER TABLE op_sap_offbook ADD COLUMN sap_date_override DATE NULL;


### PR DESCRIPTION
Per Mew's batch of SAP page requests:

1. **Grey rule** — rows are grey when the person has no CSP-earning shift starting on/before Open Sunday, **or** is Staff — unless someone sets a date (persisted override or an actual assignment), which lifts them back to red/green. External SAP stays grey with `External SAP` text.
2. **Staff dropdown** — the auto option reads just `Staff`, no dayname appended.
3. **Grey ≠ hover** — grey is now `#e0e0e0`; MUI's hover tint (~`#f5f5f5`) reads distinctly on all row colors.
4. **Date choice persists** — new `sap_date_override` column on `op_volunteers` / `op_sap_offbook` (**migration `010_sap_date_override.sql` — apply by hand before deploy**), saved via new `POST /api/saps/date-choice` whenever the dropdown changes. Assign uses it when no fresher choice is made.
5. **Unlock + burn** — clicking the lock on a delivered SAP asks `are you sure` (explains the burn), then re-opens the date dropdown + assign checkbox. Assigning a new SAP burns the old one via the existing assign-endpoint logic (`superseded_by_sap_id` chain); burned SAPs can never be reassigned.
6. **Ticket serial in filenames** — `SAP_<date>_<ticketId>.pdf` for download, re-download, and the email attachment.
7. **Email copy** — subject now includes “Census” (standing rule); body adds: addressed to Matthew Hewitt, works for you, contact Census if Gate issues.

Verified on local prod build + prod-pull DB (migration applied locally): date-choice round-trips and clears; staff without a date all grey; standings 57 grey / 20 red / 12 external / 4 green; screenshot checked. 34 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)