### PR TITLE
feat(saps): red 'SAPs have been uploaded' note next to the upload button

### DIFF
--- a/client/src/app/saps/Saps.tsx
+++ b/client/src/app/saps/Saps.tsx
@@ -259,7 +259,10 @@ export const Saps = () => {
         </Typography>
 
         {/* upload */}
-        <Box component="section" sx={{ mb: 4 }}>
+        <Box
+          component="section"
+          sx={{ mb: 4, display: "flex", alignItems: "center", gap: 2 }}
+        >
           <input
             ref={fileInputRef}
             type="file"
@@ -278,6 +281,11 @@ export const Saps = () => {
           >
             {uploading ? "Uploading…" : "Upload SAP batch PDF"}
           </Button>
+          {(poolData?.saps.length ?? 0) > 0 && (
+            <Typography component="span" sx={{ color: "error.main" }}>
+              The {burnYear} SAPs have been uploaded
+            </Typography>
+          )}
         </Box>
 
         {/* people */}


### PR DESCRIPTION
Shows `The {year} SAPs have been uploaded` in red next to the upload button whenever the pool has any SAPs for the current burn year. Verified on local prod build (DOM check: text renders, MUI error red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)