### PR TITLE
feat(saps): per-person Notes column with save-as-you-type

### DIFF
--- a/client/src/app/saps/Saps.tsx
+++ b/client/src/app/saps/Saps.tsx
@@ -85,6 +85,10 @@ export const Saps = () => {
   // Rows the admin has unlocked for reassignment (received SAP burns on the
   // next assign, server-side).
   const [unlocked, setUnlocked] = useState<Record<string, boolean>>({});
+  // Per-row Notes: local draft (so typing isn't clobbered by SWR refetch) plus
+  // a per-row debounce timer so we save-as-you-type without a request/keystroke.
+  const [notesDraft, setNotesDraft] = useState<Record<string, string>>({});
+  const notesTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   if (peopleError) return <ErrorPage />;
   if (!peopleData) return <Loading />;
@@ -166,6 +170,24 @@ export const Saps = () => {
       enqueueSnackbar(await readError(res), { variant: "error" });
     }
     mutate(PEOPLE_URL);
+  };
+
+  // Per-person note, saved as you type (debounced). No SWR refetch on save so
+  // the field keeps focus/cursor; the local draft is the source of truth while
+  // editing.
+  const handleNotesChange = (p: ISapPerson, value: string) => {
+    const key = rowKey(p);
+    setNotesDraft((d) => ({ ...d, [key]: value }));
+    clearTimeout(notesTimers.current[key]);
+    notesTimers.current[key] = setTimeout(async () => {
+      const res = await fetch("/api/saps/notes", {
+        method: "POST",
+        body: JSON.stringify({ ...targetBody(p), notes: value }),
+      });
+      if (!res.ok) {
+        enqueueSnackbar(await readError(res), { variant: "error" });
+      }
+    }, 600);
   };
 
   // download (issue) — POST flips to received + streams the PDF -----------
@@ -302,6 +324,7 @@ export const Saps = () => {
                 <TableCell>SAP date</TableCell>
                 <TableCell align="center">Assign</TableCell>
                 <TableCell>Deliver</TableCell>
+                <TableCell>Notes</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -481,6 +504,17 @@ export const Saps = () => {
                           />
                         </Stack>
                       )}
+                    </TableCell>
+                    <TableCell>
+                      <TextField
+                        size="small"
+                        multiline
+                        maxRows={4}
+                        placeholder="Note / exception…"
+                        value={notesDraft[key] ?? p.notes ?? ""}
+                        onChange={(e) => handleNotesChange(p, e.target.value)}
+                        sx={{ minWidth: 200 }}
+                      />
                     </TableCell>
                   </TableRow>
                 );

--- a/client/src/components/types/sap.ts
+++ b/client/src/components/types/sap.ts
@@ -34,6 +34,7 @@ export interface ISapPerson {
   missingDetail: string[];
   totalCsp: number;
   dateOverride: string | null; // persisted SAP-date dropdown choice (null = Auto)
+  notes: string | null; // super-admin free-text note (exceptions), SAP page only
   assignment: ISapAssignment | null;
 }
 

--- a/client/src/pages/api/saps/notes/index.ts
+++ b/client/src/pages/api/saps/notes/index.ts
@@ -1,0 +1,53 @@
+import type { ResultSetHeader } from "mysql2";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSuperAdmin } from "@/lib/withSuperAdmin";
+import { pool } from "lib/database";
+
+interface NotesBody {
+  shiftboardId?: number;
+  email?: string;
+  notes?: string | null;
+}
+
+// POST /api/saps/notes — persist a super-admin's per-person note (exceptions,
+// context). Stored on the person: op_volunteers.sap_notes for real volunteers,
+// op_sap_offbook.notes for off-book entries. SAP page only.
+const sapNotes = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") {
+    return res
+      .status(405)
+      .json({ statusCode: 405, message: "Method not allowed" });
+  }
+
+  const body: NotesBody =
+    typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body ?? {});
+
+  // Empty string is a valid "cleared" note; only null/undefined normalizes.
+  const notes = body.notes == null ? null : String(body.notes);
+
+  let result: ResultSetHeader;
+  if (body.shiftboardId != null && !body.email) {
+    [result] = await pool.execute<ResultSetHeader>(
+      `UPDATE op_volunteers SET sap_notes=? WHERE shiftboard_id=?`,
+      [notes, body.shiftboardId],
+    );
+  } else if (body.email && body.shiftboardId == null) {
+    [result] = await pool.execute<ResultSetHeader>(
+      `UPDATE op_sap_offbook SET notes=? WHERE email=?`,
+      [notes, body.email.toLowerCase()],
+    );
+  } else {
+    return res.status(400).json({
+      statusCode: 400,
+      message: "Provide exactly one of shiftboardId or email",
+    });
+  }
+
+  if (result.affectedRows === 0) {
+    return res.status(404).json({ statusCode: 404, message: "Person not found" });
+  }
+  return res.status(200).json({ statusCode: 200, notes });
+};
+
+export default withSuperAdmin(sapNotes);

--- a/client/src/pages/api/saps/people/index.ts
+++ b/client/src/pages/api/saps/people/index.ts
@@ -57,13 +57,13 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
   ] = await Promise.all([
     pool.query<RowDataPacket[]>(
       `SELECT v.shiftboard_id, v.playa_name, v.world_name, v.email,
-              v.sap_date_override, d.datename AS arrival_datename
+              v.sap_date_override, v.sap_notes, d.datename AS arrival_datename
          FROM op_volunteers v
          LEFT JOIN op_dates d ON v.arrival_date_id = d.date_id
         WHERE v.delete_volunteer = false`,
     ),
     pool.query<RowDataPacket[]>(
-      `SELECT email, name, linked_shiftboard_id, sap_date_override
+      `SELECT email, name, linked_shiftboard_id, sap_date_override, notes
          FROM op_sap_offbook`,
     ),
     pool.query<RowDataPacket[]>(
@@ -246,6 +246,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       missingDetail: eligibility.missingDetail,
       totalCsp,
       dateOverride,
+      notes: v.sap_notes != null ? String(v.sap_notes) : null,
       assignment,
     };
   });
@@ -270,6 +271,7 @@ const sapsPeople = async (req: NextApiRequest, res: NextApiResponse) => {
       missingDetail: [],
       totalCsp: 0,
       dateOverride: o.sap_date_override ? String(o.sap_date_override) : null,
+      notes: o.notes != null ? String(o.notes) : null,
       assignment: assignByEmail.get(String(o.email).toLowerCase()) ?? null,
     }));
 

--- a/migrations/011_sap_notes.sql
+++ b/migrations/011_sap_notes.sql
@@ -1,0 +1,4 @@
+-- SAP page: per-person free-text notes so super-admins (Mew, Rescue) can
+-- record why they made an exception. Volunteers keep theirs on op_volunteers;
+-- off-book people reuse the existing op_sap_offbook.notes column.
+ALTER TABLE op_volunteers ADD COLUMN sap_notes TEXT NULL;


### PR DESCRIPTION
Adds a **per-person Notes** column to the SAP management page so super-admins (Mew, Rescue) can record why they made an exception, right where they manage SAPs.

## Behavior
- One text box per person in a new **Notes** column; **autosaves as you type** (debounced ~0.6s), no button.
- Multiline, keeps focus while typing (local draft, no SWR refetch mid-edit).
- Super-admin gated (whole SAP page already is). Nothing surfaced to volunteers.

## Storage
- `op_volunteers.sap_notes` for real volunteers.
- Existing `op_sap_offbook.notes` for off-book entries.
- New `POST /api/saps/notes` mirroring the existing `date-choice` persistence pattern.

## Migration
- **011_sap_notes.sql** adds `op_volunteers.sap_notes TEXT NULL` (off-book reuses its existing `notes` column).

Typecheck ✅ · lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)