### PR TITLE
fix(account): period after "Visit your Burner Profile"

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/info/VolunteerInfo.tsx
@@ -1066,6 +1066,7 @@ export const VolunteerInfo = ({ shiftboardId }: IVolunteerInfoProps) => {
               >
                 Visit your Burner Profile
               </a>
+              .
             </Typography>
           </CardContent>
         </Card>


### PR DESCRIPTION
Adds the missing period at the end of the last line of the account top card. Tiny copy fix requested by Chipper (Discord, 2026-08-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)