### PR TITLE
fix(contact): always-reply (drop checkbox) + rename Technology -> App Help (#474)

### DIFF
--- a/client/src/app/contact/Contact.tsx
+++ b/client/src/app/contact/Contact.tsx
@@ -7,11 +7,9 @@ import {
   Card,
   CardActions,
   CardContent,
-  Checkbox,
   CircularProgress,
   Container,
   FormControl,
-  FormControlLabel,
   Grid,
   InputLabel,
   MenuItem,
@@ -215,24 +213,6 @@ export const Contact = () => {
                             ))}
                           </Select>
                         </FormControl>
-                      )}
-                    />
-                  </Grid>
-                  <Grid size={6}>
-                    <Controller
-                      control={control}
-                      name="isReplyWanted"
-                      render={({ field: { value, ...field } }) => (
-                        <FormControlLabel
-                          control={
-                            <Checkbox
-                              {...field}
-                              checked={value}
-                              color="secondary"
-                            />
-                          }
-                          label="Reply wanted after Burning Man"
-                        />
                       )}
                     />
                   </Grid>

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -13,7 +13,7 @@ export const CONTACT_RECIPIENTS: Record<string, string> = {
   "Volunteer Coordinator": "censusvolunteercoordinators@burningman.org",
   "Census Manager": "ann.norton@burningman.org, random@burningman.org",
   Data: "aaron.shev@burningman.org",
-  Technology: "mu@burningman.org, chipper@burningman.org, rqreyes@gmail.com",
+  "App Help": "mu@burningman.org, chipper@burningman.org, rqreyes@gmail.com",
 };
 export const CONTACT_RECIPIENT_LABELS = Object.keys(CONTACT_RECIPIENTS).sort();
 


### PR DESCRIPTION
Implements #474 (Mew approved to ship, 2026-08-02):
1. Drops the "Reply wanted after Burning Man" checkbox — every contact-form submission is now reply-wanted (kept `isReplyWanted` defaulting true so the API/logging is unchanged).
2. Renames the **Technology** recipient category to **App Help** for clarity. Same recipients (mu@ / chipper@ / rqreyes@), no routing change.

typecheck ✅ · lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)