### PR TITLE
fix(nav): move Account to top of the left nav

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -209,6 +209,25 @@ export const Header = () => {
           <Box>
             {/* general nav */}
             <List>
+              {/* Account leads the nav — it's where we want volunteers to go
+                  (Chipper). Only shown when signed in (needs shiftboardId). */}
+              {isAuthenticated && (
+                <ListItem disablePadding>
+                  <Link
+                    href={`/volunteers/${shiftboardId}/info`}
+                    onClick={handleDrawerClose}
+                  >
+                    <ListItemButton
+                      selected={pathname === `/volunteers/${shiftboardId}/info`}
+                    >
+                      <ListItemIcon>
+                        <ManageAccountsIcon />
+                      </ListItemIcon>
+                      <ListItemText primary="Account" />
+                    </ListItemButton>
+                  </Link>
+                </ListItem>
+              )}
               {pageListDefault
                 .filter(({ path }) => {
                   // Off-playa /shifts requires auth (middleware redirects
@@ -324,23 +343,6 @@ export const Header = () => {
                   </ListSubheader>
                 }
               >
-                <ListItem disablePadding>
-                  <Link
-                    href={`/volunteers/${shiftboardId}/info`}
-                    onClick={handleDrawerClose}
-                  >
-                    <ListItemButton
-                      selected={
-                        pathname === `/volunteers/${shiftboardId}/info`
-                      }
-                    >
-                      <ListItemIcon>
-                        <ManageAccountsIcon />
-                      </ListItemIcon>
-                      <ListItemText>Account</ListItemText>
-                    </ListItemButton>
-                  </Link>
-                </ListItem>
                 <ListItem disablePadding>
                   <Link href="/sign-in">
                     <ListItemButton


### PR DESCRIPTION
Per Chipper (repeatedly requested). Account now leads the drawer nav when signed in (was tucked in the authenticated footer); footer keeps the name subheader + sign-out. typecheck ✅ lint ✅. 🤖 Generated with [Claude Code](https://claude.com/claude-code)