### PR TITLE
ui(account): rename 'Shifts' section heading to 'My Shifts'

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/account/VolunteerShifts.tsx
@@ -243,7 +243,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     return (
       <>
         <Typography component="h2" sx={{ mb: 1 }} variant="h4">
-          Shifts
+          My Shifts
         </Typography>
         <ErrorAlert />
       </>
@@ -252,7 +252,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
     return (
       <>
         <Typography component="h2" sx={{ mb: 1 }} variant="h4">
-          Shifts
+          My Shifts
         </Typography>
         <Loading />
       </>
@@ -585,7 +585,7 @@ export const VolunteerShifts = ({ shiftboardId }: IVolunteerShiftsProps) => {
         sx={{ mb: 2 }}
       >
         <Typography component="h2" variant="h4">
-          Shifts
+          My Shifts
         </Typography>
         <Button
           onClick={() => {


### PR DESCRIPTION
Renames the volunteer's shift-list heading on the Account page from **Shifts** to **My Shifts** (normal, loading, and error states) so it's clearly *their* shifts, distinct from the site-wide Shifts page.

Copy change only — no logic touched. Requested by Chipper 2026-08-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)