### PR TITLE
fix(test-db): blank_pii.sql — scrub PII beyond op_volunteers

### DIFF
--- a/blank_pii.sql
+++ b/blank_pii.sql
@@ -7,3 +7,18 @@ UPDATE op_volunteers SET
     phone = NULL,
     emergency_contact = NULL
 WHERE playa_name != "Admin";
+
+-- Additional PII sources beyond op_volunteers (found 2026-08-10): the schema grew
+-- more email columns. Without these, a snapshot refresh re-leaks real addresses
+-- even though op_volunteers is scrubbed.
+UPDATE op_messages    SET email          = NULL WHERE email          IS NOT NULL;
+UPDATE op_sap_offbook SET email          = NULL WHERE email          IS NOT NULL;
+UPDATE op_saps        SET assigned_email = NULL WHERE assigned_email IS NOT NULL;
+
+-- These two carry real emails as data/keys and aren't needed on a test box, so clear them:
+--   op_email_queue       -- real recipient addresses + message bodies (an outbound send queue)
+--   op_role_grant_roster -- email is part of the PRIMARY KEY (NOT NULL) so it can't be blanked
+--                           in place; it's only an email->role pre-provisioning map, which is
+--                           useless once volunteer emails are scrubbed.
+TRUNCATE TABLE op_email_queue;
+TRUNCATE TABLE op_role_grant_roster;


### PR DESCRIPTION
The test-server PII filter (`blank_pii.sql`) only scrubbed `op_volunteers`, but the schema has since grown more real-email columns. A snapshot refresh re-leaked real addresses even though op_volunteers was clean (caught during the 2026-08-10 test-server DB rebuild).

Adds:
- `op_messages.email`, `op_sap_offbook.email`, `op_saps.assigned_email` → NULL
- TRUNCATE `op_email_queue` (real recipient addresses + message bodies) and `op_role_grant_roster` (email is part of the NOT NULL primary key, so it can't be blanked in place; it's just an email→role pre-provisioning map)

Verified: after running this against a fresh prod snapshot, a full audit shows **0 real emails/phones** in any table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)