### PR TITLE
copy: "Reset all filters" label + "Data Nerds" contact option

### DIFF
--- a/client/src/app/volunteers/[shiftboardId]/schedule/Schedule.tsx
+++ b/client/src/app/volunteers/[shiftboardId]/schedule/Schedule.tsx
@@ -624,7 +624,7 @@ export const Schedule = ({ shiftboardId }: IScheduleProps) => {
               <Typography sx={{ fontWeight: 800 }}>Filters</Typography>
               <Stack direction="row" alignItems="center" spacing={0.5}>
                 <Button size="small" onClick={removeAllFilters}>
-                  Remove all filters
+                  Reset all filters
                 </Button>
                 <IconButton
                   aria-label="Close filters"

--- a/client/src/components/general/DataTable.tsx
+++ b/client/src/components/general/DataTable.tsx
@@ -86,11 +86,12 @@ export const DataTable = ({
     rowHover: false,
     rowsPerPage: 100,
     selectableRows: undefined,
-    // "Reset" clears every active filter (incl. the default ones), so label it
-    // for what it actually does (#143). mui-datatables deep-merges textLabels.
+    // Filter-clear control. On the Shifts list the Present/Future default
+    // persists through this, so "Reset all filters" is more accurate than
+    // "Remove" (Chipper, #624). mui-datatables deep-merges textLabels.
     textLabels: {
       filter: {
-        reset: "Remove all filters",
+        reset: "Reset all filters",
       },
     },
     viewColumns: false,

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -12,7 +12,7 @@ export const HELPER_TEXT_LOCATION =
 export const CONTACT_RECIPIENTS: Record<string, string> = {
   "Volunteer Coordinator": "censusvolunteercoordinators@burningman.org",
   "Census Manager": "ann.norton@burningman.org, random@burningman.org",
-  Data: "aaron.shev@burningman.org",
+  "Data Nerds": "aaron.shev@burningman.org",
   "App Help/Feedback": "mu@burningman.org, chipper@burningman.org, rqreyes@gmail.com",
 };
 export const CONTACT_RECIPIENT_LABELS = Object.keys(CONTACT_RECIPIENTS).sort();


### PR DESCRIPTION
Two copy-only fixes from Chipper's app walkthrough (2026-08-13).

### Changes
- **"Reset all filters"** — renames the shift filter control (both the Shifts-list mui-datatables reset and the personal Schedule page button). The Present/Future default persists through it, so "Reset" is accurate and "Remove" was misleading. Closes #624.
- **"Data Nerds"** — contact-form recipient option `Data` → `Data Nerds`, matching the Data Nerds Google Group. Same email routing (`aaron.shev@`). Addresses #299 (walkthrough item).

### Notes
- Copy-only; no logic/DB/schema changes. The `CONTACT_RECIPIENTS` key is both the dropdown label and the email-lookup key (only consumer is `CONTACT_RECIPIENTS[to]`), so renaming is consistent end-to-end.
- Not deployed — deploy is manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)